### PR TITLE
M1: Cargo wiring for mosaic-core + mosaic-groth16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,8 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "groth16-solana",
+ "mosaic-core",
+ "mosaic-groth16",
 ]
 
 [[package]]
@@ -1291,6 +1293,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-poseidon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
+dependencies = [
+ "ark-bn254 0.4.0",
+ "ark-ff 0.4.2",
+ "num-bigint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1343,33 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "mosaic-core"
+version = "0.8.5-msm-helper-coverage"
+source = "git+https://github.com/wienerlabs/mosaic?tag=v0.8.5-msm-helper-coverage#b77a3f23d5988755fb549fc712ad60eb292f887f"
+dependencies = [
+ "arrayvec",
+ "borsh 1.6.1",
+ "solana-bn254",
+ "solana-keccak-hasher",
+ "solana-poseidon",
+ "solana-program",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "mosaic-groth16"
+version = "0.8.5-msm-helper-coverage"
+source = "git+https://github.com/wienerlabs/mosaic?tag=v0.8.5-msm-helper-coverage#b77a3f23d5988755fb549fc712ad60eb292f887f"
+dependencies = [
+ "arrayvec",
+ "borsh 1.6.1",
+ "mosaic-core",
+ "subtle",
  "zeroize",
 ]
 
@@ -2188,6 +2229,18 @@ dependencies = [
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-poseidon"
+version = "2.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbac4eb90016eeb1d37fa36e592d3a64421510c49666f81020736611c319faff"
+dependencies = [
+ "ark-bn254 0.4.0",
+ "light-poseidon",
+ "solana-define-syscall",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/programs/etornie-zk-verifier/Cargo.toml
+++ b/programs/etornie-zk-verifier/Cargo.toml
@@ -18,4 +18,15 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = { version = "0.31.1", features = ["init-if-needed"] }
+
+# Legacy verifier — kept side-by-side through the migration so the program
+# stays buildable on every M1-M12 PR. Removed in M13 (production cutover).
 groth16-solana = "0.2.0"
+
+# Wiener Labs Mosaic — proof-system-agnostic Solana verifier (epic M0).
+# Pinned to the latest published tag on wienerlabs/mosaic. The README
+# references a future `v0.9.x-onchain-compressed-verify` release; that tag
+# does not exist yet, so we pin against the latest shipped tag and bump
+# together with the epic once mosaic ships its next release.
+mosaic-core    = { git = "https://github.com/wienerlabs/mosaic", tag = "v0.8.5-msm-helper-coverage", features = ["solana"] }
+mosaic-groth16 = { git = "https://github.com/wienerlabs/mosaic", tag = "v0.8.5-msm-helper-coverage", features = ["solana"] }


### PR DESCRIPTION
## Summary

First step of the Mosaic ZK Migration epic (#15). Adds the Wiener Labs Mosaic verifier crates to `programs/etornie-zk-verifier` as **side-by-side** dependencies of the existing `groth16-solana` lib.

## Why side-by-side (deviation from issue body)

The original M1 acceptance criteria stated `groth16-solana` would be removed in this PR. Removing it now would break `cargo build-sbf` until M2 lands (since `lib.rs` still imports `groth16_solana::*`). Keeping both keeps every PR in the M1-M12 series green and lets M13 drop the legacy crate atomically. Acceptance criteria in #2 will be updated to reflect this.

## Pin selection

The epic body references `v0.9.15-onchain-compressed-verify`. That tag does not exist on `wienerlabs/mosaic` yet. Latest published tag is `v0.8.5-msm-helper-coverage` (resolved commit `b77a3f23`). Pinning there for now; bump together with the next mosaic release.

## Changes

- `programs/etornie-zk-verifier/Cargo.toml` adds `mosaic-core` and `mosaic-groth16` with `features = ["solana"]`.
- `Cargo.lock` records the resolved versions:
  - `mosaic-core v0.8.5-msm-helper-coverage (b77a3f23)`
  - `mosaic-groth16 v0.8.5-msm-helper-coverage (b77a3f23)`
  - transitively pulls `light-poseidon v0.2.0`, `solana-poseidon v2.3.13`

## Verification

```
$ cargo fetch --manifest-path programs/etornie-zk-verifier/Cargo.toml
    Updating git repository `https://github.com/wienerlabs/mosaic`
    Updating crates.io index
     Locking 4 packages to latest compatible versions
```

Local `cargo build-sbf` not run in this environment; CI workflow (#48) will gate that once it ships.

## What this unblocks

- #3 M2 HelloWorld pilot port
- #8 M7 snarkjs adapter (can land in parallel)

## Out of scope

- Removing `groth16-solana` (M13)
- Any `lib.rs` changes (M2-M4)
- Compute budget tuning (M5)

## Refs

- Epic: #15
- Resolves part of #2 (M1)
- Mosaic repo: https://github.com/wienerlabs/mosaic