### PR TITLE
M5: Rebudget compute units 300k -> 180k for mosaic

### DIFF
--- a/dashboard/src/lib/zk/submitFileOwnership.ts
+++ b/dashboard/src/lib/zk/submitFileOwnership.ts
@@ -190,7 +190,7 @@ export async function proveDocumentOwnershipOnChain(
   });
 
   const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-    units: opts.computeUnitLimit ?? 300_000,
+    units: opts.computeUnitLimit ?? 180_000,
   });
 
   const msg = new TransactionMessage({

--- a/dashboard/src/lib/zk/verifyProof.ts
+++ b/dashboard/src/lib/zk/verifyProof.ts
@@ -118,7 +118,7 @@ export async function submitProofOnChain(
   });
 
   const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-    units: opts.computeUnitLimit ?? 300_000,
+    units: opts.computeUnitLimit ?? 180_000,
   });
 
   const msg = new TransactionMessage({

--- a/programs/etornie-zk-verifier/README.md
+++ b/programs/etornie-zk-verifier/README.md
@@ -1,0 +1,56 @@
+# etornie-zk-verifier
+
+On-chain Groth16 verifier for Etornie's three circuits, running on
+[Wiener Labs Mosaic](https://github.com/wienerlabs/mosaic) (`mosaic-groth16`).
+
+| Instruction | Circuit | Public inputs | Record PDA |
+|---|---|---|---|
+| `verify_proof` | `hello_world` | 1 | `(proof, user, journal_digest)` |
+| `verify_file_ownership_proof` | `file_ownership` | 3 `[fh_hi, fh_lo, commitment]` | `(file-ownership, user, file_hash)` |
+| `verify_compliance_proof` | `compliance` (x402) | 3 `[qh_hi, qh_lo, commitment]` | `(compliance, user, query_hash)` |
+
+All three route through `mosaic_groth16::Groth16Verifier` with the
+`SolanaSyscallBackend` and big-endian field elements (`<_, false>`).
+
+## Compute-unit budget
+
+Clients prepend `ComputeBudgetInstruction::set_compute_unit_limit(180_000)`
+(down from `300_000` under the previous `groth16-solana` verifier).
+
+| Cost component | Approx CU | Source |
+|---|---|---|
+| BN254 Groth16 single verify | ~83,500 | mosaic-groth16 published baseline |
+| PDA `init_if_needed` + rent | ~15,000 | Anchor account init |
+| sha256 journal digest + input checks | ~5,000 | per circuit |
+| Anchor dispatch + account writes | ~15,000 | framework overhead |
+| **Estimated total** | **~120,000** | |
+| **Requested limit (1.5x margin)** | **180,000** | conservative |
+
+> These are conservative estimates anchored on mosaic's published 83,574 CU
+> single-verify figure. The exact per-instruction CU is calibrated by the
+> on-chain benchmark in CI (#48) and the SBF integration tests (M9), and the
+> `180_000` limit should be tightened once those land.
+
+### Why mosaic is cheaper
+
+`mosaic-groth16` negates `A` internally and batches all four pairings into a
+single `sol_alt_bn128_group_op(Pairing, …)` call (768 B input), versus the
+multi-call path in `groth16-solana`. The linear combination
+`L = IC[0] + Σ pi[i]·IC[i+1]` is the only per-input cost (~3,300 CU each).
+
+## Client compute-budget call sites
+
+The `180_000` limit is set in:
+
+- `tests/zk_verifier.ts`, `tests/file_ownership.ts`, `tests/compliance.ts`
+- `services/api/app/solana/client.py`
+- `dashboard/src/lib/zk/verifyProof.ts`, `dashboard/src/lib/zk/submitFileOwnership.ts`
+
+All are overridable per call (the frontend helpers accept `opts.computeUnitLimit`).
+
+## Migration status
+
+Part of the [Mosaic ZK Migration epic (#15)](https://github.com/wienerlabs/etornie-solana/issues/15).
+The legacy `groth16-solana` dependency is retained only for its
+`Groth16Verifyingkey` struct (the auto-generated VK modules type against it)
+and is removed in M13 once M7 bakes canonical VK bytes at build time.

--- a/programs/etornie-zk-verifier/src/lib.rs
+++ b/programs/etornie-zk-verifier/src/lib.rs
@@ -62,8 +62,11 @@ pub mod etornie_zk_verifier {
     /// then records the result in a PDA keyed on (operator, journal_digest)
     /// so the same proof cannot be submitted twice under the same operator.
     ///
-    /// The client is expected to prepend a `ComputeBudgetInstruction::set_compute_unit_limit(300_000)`
-    /// - the pairing + PDA init typically consumes ~180k CU, well above Anchor's 200k default.
+    /// The client is expected to prepend a `ComputeBudgetInstruction::set_compute_unit_limit(180_000)`.
+    /// On mosaic-groth16 a single BN254 verify is ~83.5k CU; with PDA init and
+    /// Anchor overhead the instruction lands well under 180k (down from the 300k
+    /// requested under groth16-solana). Exact figure is calibrated by the
+    /// on-chain benchmark in CI (#48) and the SBF integration tests (M9).
     pub fn verify_proof(
         ctx: Context<VerifyProof>,
         proof_a: [u8; 64],
@@ -135,7 +138,7 @@ pub mod etornie_zk_verifier {
     /// field elements could map unrelated files to the same PDA.
     ///
     /// Same CU budget expectation as `verify_proof`: client should prepend
-    /// `ComputeBudgetInstruction::set_compute_unit_limit(300_000)`.
+    /// `ComputeBudgetInstruction::set_compute_unit_limit(180_000)`.
     pub fn verify_file_ownership_proof(
         ctx: Context<VerifyFileOwnership>,
         proof_a: [u8; 64],
@@ -209,7 +212,7 @@ pub mod etornie_zk_verifier {
     /// elements could map unrelated queries to the same PDA.
     ///
     /// Same CU budget expectation as `verify_proof`: client should prepend
-    /// `ComputeBudgetInstruction::set_compute_unit_limit(300_000)`.
+    /// `ComputeBudgetInstruction::set_compute_unit_limit(180_000)`.
     pub fn verify_compliance_proof(
         ctx: Context<VerifyCompliance>,
         proof_a: [u8; 64],

--- a/services/api/app/solana/client.py
+++ b/services/api/app/solana/client.py
@@ -1269,7 +1269,7 @@ async def submit_compliance_proof_tx(
         ],
         data=ix_data,
     )
-    compute_ix = set_compute_unit_limit(300_000)
+    compute_ix = set_compute_unit_limit(180_000)
 
     async with AsyncClient(settings.solana_cluster_url) as rpc:
         latest = await rpc.get_latest_blockhash()

--- a/tests/compliance.ts
+++ b/tests/compliance.ts
@@ -138,7 +138,7 @@ describe('compliance verifier on devnet (sponsored flow)', function () {
   }): Promise<{ signature: string; pda: PublicKey }> {
     const [pda] = derivePda(params.user.publicKey, params.queryHash);
     const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-      units: 300_000,
+      units: 180_000,
     });
 
     // user is an UncheckedAccount - only funder (operator) signs. The ZK

--- a/tests/file_ownership.ts
+++ b/tests/file_ownership.ts
@@ -145,7 +145,7 @@ describe('file_ownership verifier on devnet (sponsored flow)', function () {
   }): Promise<{ signature: string; pda: PublicKey }> {
     const [pda] = derivePda(params.user.publicKey, params.fileHash);
     const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-      units: 300_000,
+      units: 180_000,
     });
 
     const signature = await program.methods

--- a/tests/zk_verifier.ts
+++ b/tests/zk_verifier.ts
@@ -89,7 +89,7 @@ describe('etornie-zk-verifier on devnet (sponsored flow)', function () {
     const { user, proofA, proofB, proofC, publicInputs, journalDigest } = params;
     const [pda] = derivePda(user.publicKey, journalDigest);
 
-    const computeIx = ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 });
+    const computeIx = ComputeBudgetProgram.setComputeUnitLimit({ units: 180_000 });
 
     const signature = await program.methods
       .verifyProof(


### PR DESCRIPTION
## Summary

mosaic-groth16's single verify is **~83.5k CU** vs **~180k** under groth16-solana, so the `300_000` compute-unit limit clients requested is now over-provisioned. This PR drops it to a conservative **180_000**.

## Budget

| Component | ~CU |
|---|---|
| BN254 Groth16 single verify (mosaic) | 83,500 |
| PDA init_if_needed + rent | 15,000 |
| sha256 digest + input checks | 5,000 |
| Anchor dispatch + writes | 15,000 |
| **Estimated total** | **~120,000** |
| **Requested limit (margin)** | **180,000** |

## Call sites updated

- `tests/{zk_verifier,file_ownership,compliance}.ts`
- `services/api/app/solana/client.py`
- `dashboard/src/lib/zk/{verifyProof,submitFileOwnership}.ts`
- 3 `lib.rs` instruction doc comments

Mocha `this.timeout(300_000)` values are unrelated and untouched (verified by grep).

## Honest caveat

These are **estimates** anchored on mosaic's published 83,574 CU figure. This environment has no `solana` / `cargo build-sbf`, so exact per-instruction CU is **not measured here**. The new `programs/etornie-zk-verifier/README.md` documents the budget and flags that `180_000` should be tightened once the on-chain benchmark (#48) and SBF integration tests (#10 M9) produce real numbers.

## Refs

- Epic #15, resolves part of #6
- Builds on #78 (M4)