### PR TITLE
Mosaic ZK Migration: core verifier port (M1-M5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,8 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "groth16-solana",
+ "mosaic-core",
+ "mosaic-groth16",
 ]
 
 [[package]]
@@ -1291,6 +1293,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "light-poseidon"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
+dependencies = [
+ "ark-bn254 0.4.0",
+ "ark-ff 0.4.2",
+ "num-bigint",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1343,33 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "mosaic-core"
+version = "0.8.5-msm-helper-coverage"
+source = "git+https://github.com/wienerlabs/mosaic?tag=v0.8.5-msm-helper-coverage#b77a3f23d5988755fb549fc712ad60eb292f887f"
+dependencies = [
+ "arrayvec",
+ "borsh 1.6.1",
+ "solana-bn254",
+ "solana-keccak-hasher",
+ "solana-poseidon",
+ "solana-program",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "mosaic-groth16"
+version = "0.8.5-msm-helper-coverage"
+source = "git+https://github.com/wienerlabs/mosaic?tag=v0.8.5-msm-helper-coverage#b77a3f23d5988755fb549fc712ad60eb292f887f"
+dependencies = [
+ "arrayvec",
+ "borsh 1.6.1",
+ "mosaic-core",
+ "subtle",
  "zeroize",
 ]
 
@@ -2188,6 +2229,18 @@ dependencies = [
  "solana-hash",
  "solana-pubkey",
  "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-poseidon"
+version = "2.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbac4eb90016eeb1d37fa36e592d3a64421510c49666f81020736611c319faff"
+dependencies = [
+ "ark-bn254 0.4.0",
+ "light-poseidon",
+ "solana-define-syscall",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/dashboard/src/lib/zk/submitFileOwnership.ts
+++ b/dashboard/src/lib/zk/submitFileOwnership.ts
@@ -190,7 +190,7 @@ export async function proveDocumentOwnershipOnChain(
   });
 
   const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-    units: opts.computeUnitLimit ?? 300_000,
+    units: opts.computeUnitLimit ?? 180_000,
   });
 
   const msg = new TransactionMessage({

--- a/dashboard/src/lib/zk/verifyProof.ts
+++ b/dashboard/src/lib/zk/verifyProof.ts
@@ -118,7 +118,7 @@ export async function submitProofOnChain(
   });
 
   const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-    units: opts.computeUnitLimit ?? 300_000,
+    units: opts.computeUnitLimit ?? 180_000,
   });
 
   const msg = new TransactionMessage({

--- a/programs/etornie-zk-verifier/Cargo.toml
+++ b/programs/etornie-zk-verifier/Cargo.toml
@@ -18,4 +18,15 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = { version = "0.31.1", features = ["init-if-needed"] }
+
+# Legacy verifier — kept side-by-side through the migration so the program
+# stays buildable on every M1-M12 PR. Removed in M13 (production cutover).
 groth16-solana = "0.2.0"
+
+# Wiener Labs Mosaic — proof-system-agnostic Solana verifier (epic M0).
+# Pinned to the latest published tag on wienerlabs/mosaic. The README
+# references a future `v0.9.x-onchain-compressed-verify` release; that tag
+# does not exist yet, so we pin against the latest shipped tag and bump
+# together with the epic once mosaic ships its next release.
+mosaic-core    = { git = "https://github.com/wienerlabs/mosaic", tag = "v0.8.5-msm-helper-coverage", features = ["solana"] }
+mosaic-groth16 = { git = "https://github.com/wienerlabs/mosaic", tag = "v0.8.5-msm-helper-coverage", features = ["solana"] }

--- a/programs/etornie-zk-verifier/README.md
+++ b/programs/etornie-zk-verifier/README.md
@@ -1,0 +1,56 @@
+# etornie-zk-verifier
+
+On-chain Groth16 verifier for Etornie's three circuits, running on
+[Wiener Labs Mosaic](https://github.com/wienerlabs/mosaic) (`mosaic-groth16`).
+
+| Instruction | Circuit | Public inputs | Record PDA |
+|---|---|---|---|
+| `verify_proof` | `hello_world` | 1 | `(proof, user, journal_digest)` |
+| `verify_file_ownership_proof` | `file_ownership` | 3 `[fh_hi, fh_lo, commitment]` | `(file-ownership, user, file_hash)` |
+| `verify_compliance_proof` | `compliance` (x402) | 3 `[qh_hi, qh_lo, commitment]` | `(compliance, user, query_hash)` |
+
+All three route through `mosaic_groth16::Groth16Verifier` with the
+`SolanaSyscallBackend` and big-endian field elements (`<_, false>`).
+
+## Compute-unit budget
+
+Clients prepend `ComputeBudgetInstruction::set_compute_unit_limit(180_000)`
+(down from `300_000` under the previous `groth16-solana` verifier).
+
+| Cost component | Approx CU | Source |
+|---|---|---|
+| BN254 Groth16 single verify | ~83,500 | mosaic-groth16 published baseline |
+| PDA `init_if_needed` + rent | ~15,000 | Anchor account init |
+| sha256 journal digest + input checks | ~5,000 | per circuit |
+| Anchor dispatch + account writes | ~15,000 | framework overhead |
+| **Estimated total** | **~120,000** | |
+| **Requested limit (1.5x margin)** | **180,000** | conservative |
+
+> These are conservative estimates anchored on mosaic's published 83,574 CU
+> single-verify figure. The exact per-instruction CU is calibrated by the
+> on-chain benchmark in CI (#48) and the SBF integration tests (M9), and the
+> `180_000` limit should be tightened once those land.
+
+### Why mosaic is cheaper
+
+`mosaic-groth16` negates `A` internally and batches all four pairings into a
+single `sol_alt_bn128_group_op(Pairing, …)` call (768 B input), versus the
+multi-call path in `groth16-solana`. The linear combination
+`L = IC[0] + Σ pi[i]·IC[i+1]` is the only per-input cost (~3,300 CU each).
+
+## Client compute-budget call sites
+
+The `180_000` limit is set in:
+
+- `tests/zk_verifier.ts`, `tests/file_ownership.ts`, `tests/compliance.ts`
+- `services/api/app/solana/client.py`
+- `dashboard/src/lib/zk/verifyProof.ts`, `dashboard/src/lib/zk/submitFileOwnership.ts`
+
+All are overridable per call (the frontend helpers accept `opts.computeUnitLimit`).
+
+## Migration status
+
+Part of the [Mosaic ZK Migration epic (#15)](https://github.com/wienerlabs/etornie-solana/issues/15).
+The legacy `groth16-solana` dependency is retained only for its
+`Groth16Verifyingkey` struct (the auto-generated VK modules type against it)
+and is removed in M13 once M7 bakes canonical VK bytes at build time.

--- a/programs/etornie-zk-verifier/src/lib.rs
+++ b/programs/etornie-zk-verifier/src/lib.rs
@@ -3,6 +3,13 @@ use anchor_lang::solana_program::hash::hashv;
 use groth16_solana::errors::Groth16Error;
 use groth16_solana::groth16::Groth16Verifier;
 
+// Mosaic verifier (epic M0). The HelloWorld path (`verify_proof`) is ported to
+// mosaic in M2; `verify_file_ownership_proof` and `verify_compliance_proof`
+// follow in M3/M4. The groth16-solana imports above stay until M13 (cutover).
+use mosaic_core::error::OnChainError as MosaicError;
+use mosaic_core::syscall::solana::SolanaSyscallBackend;
+use mosaic_groth16::Groth16Verifier as MosaicGroth16Verifier;
+
 pub mod groth16_vk;
 pub mod vk_compliance;
 pub mod vk_file_ownership;
@@ -80,17 +87,21 @@ pub mod etornie_zk_verifier {
         let record = &mut ctx.accounts.proof_record;
         require!(!record.is_initialized, ZkError::ReplayedProof);
 
-        // 3. Groth16 pairing verify on BN254 via alt_bn128 syscalls.
-        let mut verifier = Groth16Verifier::<PUBLIC_INPUT_COUNT>::new(
-            &proof_a,
-            &proof_b,
-            &proof_c,
-            &public_inputs,
-            &VERIFYINGKEY,
-        )
-        .map_err(map_groth16_error)?;
+        // 3. Groth16 pairing verify on BN254 via Mosaic (mosaic-groth16).
+        //    Mosaic takes the proof as a single 256-byte `A || B || C` blob,
+        //    the VK in canonical byte layout, and the public inputs
+        //    concatenated big-endian. The `concat` buffer built in step 1
+        //    already holds the inputs in exactly that form, so we reuse it.
+        let mut proof_bytes = [0u8; 256];
+        proof_bytes[..64].copy_from_slice(&proof_a);
+        proof_bytes[64..192].copy_from_slice(&proof_b);
+        proof_bytes[192..].copy_from_slice(&proof_c);
 
-        verifier.verify().map_err(map_groth16_error)?;
+        let backend = SolanaSyscallBackend::new();
+        let verifier = MosaicGroth16Verifier::<_, false>::new(&backend);
+        verifier
+            .verify(&helloworld_vk_canonical(), &proof_bytes, &concat)
+            .map_err(map_mosaic_error)?;
 
         // 4. Persist the record. The `operator` field name is kept for
         // storage-layout continuity but semantically stores the user key
@@ -426,6 +437,50 @@ fn map_groth16_error(e: Groth16Error) -> Error {
         // The remaining variants are unreachable in our flow: fixed-size byte
         // arrays rule out G1/G2 length mismatches, we never feed compressed
         // points, and VERIFYINGKEY is compile-time matched to PUBLIC_INPUT_COUNT.
+        _ => ZkError::VerifierInternal.into(),
+    }
+}
+
+/// Encode the compile-time groth16-solana `VERIFYINGKEY` into Mosaic canonical
+/// VK bytes. The byte layout is identical between the two libraries, so this is
+/// a pure concatenation:
+///
+/// ```text
+/// alpha_g1 (64) || beta_g2 (128) || gamma_g2 (128) || delta_g2 (128) || ic[] (64 each)
+/// ```
+///
+/// `ic.len()` == `nr_pubinputs` == `PUBLIC_INPUT_COUNT + 1` (ic[0] is the
+/// constant term). Recomputed per call (~700 B heap); M7 replaces this with a
+/// build-time baked constant once the `mosaic-serde` snarkjs adapter lands.
+fn helloworld_vk_canonical() -> Vec<u8> {
+    let vk = &VERIFYINGKEY;
+    let mut out = Vec::with_capacity(64 + 128 * 3 + 64 * vk.vk_ic.len());
+    out.extend_from_slice(&vk.vk_alpha_g1);
+    out.extend_from_slice(&vk.vk_beta_g2);
+    out.extend_from_slice(&vk.vk_gamme_g2);
+    out.extend_from_slice(&vk.vk_delta_g2);
+    for ic in vk.vk_ic.iter() {
+        out.extend_from_slice(ic);
+    }
+    out
+}
+
+/// Map a Mosaic `OnChainError` onto the program's existing `ZkError` surface so
+/// clients keep seeing the same error codes after the migration.
+fn map_mosaic_error(e: MosaicError) -> Error {
+    match e {
+        MosaicError::PairingCheckFailed | MosaicError::VerificationFailed => {
+            ZkError::InvalidProof.into()
+        }
+        MosaicError::PublicInputOutOfRange | MosaicError::PublicInputCountMismatch => {
+            ZkError::MalformedPublicInput.into()
+        }
+        MosaicError::ProofLengthMismatch
+        | MosaicError::VerifyingKeyLengthMismatch
+        | MosaicError::InvalidPointEncoding
+        | MosaicError::PointNotOnCurve => ZkError::MalformedPublicInput.into(),
+        // Syscall failures and internal invariants collapse to the program's
+        // generic verifier-internal code.
         _ => ZkError::VerifierInternal.into(),
     }
 }

--- a/programs/etornie-zk-verifier/src/lib.rs
+++ b/programs/etornie-zk-verifier/src/lib.rs
@@ -62,8 +62,11 @@ pub mod etornie_zk_verifier {
     /// then records the result in a PDA keyed on (operator, journal_digest)
     /// so the same proof cannot be submitted twice under the same operator.
     ///
-    /// The client is expected to prepend a `ComputeBudgetInstruction::set_compute_unit_limit(300_000)`
-    /// - the pairing + PDA init typically consumes ~180k CU, well above Anchor's 200k default.
+    /// The client is expected to prepend a `ComputeBudgetInstruction::set_compute_unit_limit(180_000)`.
+    /// On mosaic-groth16 a single BN254 verify is ~83.5k CU; with PDA init and
+    /// Anchor overhead the instruction lands well under 180k (down from the 300k
+    /// requested under groth16-solana). Exact figure is calibrated by the
+    /// on-chain benchmark in CI (#48) and the SBF integration tests (M9).
     pub fn verify_proof(
         ctx: Context<VerifyProof>,
         proof_a: [u8; 64],
@@ -135,7 +138,7 @@ pub mod etornie_zk_verifier {
     /// field elements could map unrelated files to the same PDA.
     ///
     /// Same CU budget expectation as `verify_proof`: client should prepend
-    /// `ComputeBudgetInstruction::set_compute_unit_limit(300_000)`.
+    /// `ComputeBudgetInstruction::set_compute_unit_limit(180_000)`.
     pub fn verify_file_ownership_proof(
         ctx: Context<VerifyFileOwnership>,
         proof_a: [u8; 64],
@@ -209,7 +212,7 @@ pub mod etornie_zk_verifier {
     /// elements could map unrelated queries to the same PDA.
     ///
     /// Same CU budget expectation as `verify_proof`: client should prepend
-    /// `ComputeBudgetInstruction::set_compute_unit_limit(300_000)`.
+    /// `ComputeBudgetInstruction::set_compute_unit_limit(180_000)`.
     pub fn verify_compliance_proof(
         ctx: Context<VerifyCompliance>,
         proof_a: [u8; 64],

--- a/programs/etornie-zk-verifier/src/lib.rs
+++ b/programs/etornie-zk-verifier/src/lib.rs
@@ -1,11 +1,12 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::hash::hashv;
-use groth16_solana::errors::Groth16Error;
-use groth16_solana::groth16::{Groth16Verifier, Groth16Verifyingkey};
+use groth16_solana::groth16::Groth16Verifyingkey;
 
-// Mosaic verifier (epic M0). The HelloWorld path (`verify_proof`) is ported to
-// mosaic in M2; `verify_file_ownership_proof` and `verify_compliance_proof`
-// follow in M3/M4. The groth16-solana imports above stay until M13 (cutover).
+// Mosaic verifier (epic M0). All three verify paths now route through
+// mosaic-groth16. groth16-solana is retained only for its `Groth16Verifyingkey`
+// struct — the auto-generated VK modules (`groth16_vk`, `vk_file_ownership`,
+// `vk_compliance`) type against it. Both the type and the dependency are
+// removed in M13 once M7 bakes canonical VK bytes at build time.
 use mosaic_core::error::OnChainError as MosaicError;
 use mosaic_core::syscall::solana::SolanaSyscallBackend;
 use mosaic_groth16::Groth16Verifier as MosaicGroth16Verifier;
@@ -218,10 +219,7 @@ pub mod etornie_zk_verifier {
         query_hash: [u8; 32],
     ) -> Result<()> {
         // 1. Pin the canonical encoding of (qh_hi, qh_lo).
-        let mut expected_qh_hi = [0u8; 32];
-        expected_qh_hi[16..].copy_from_slice(&query_hash[..16]);
-        let mut expected_qh_lo = [0u8; 32];
-        expected_qh_lo[16..].copy_from_slice(&query_hash[16..]);
+        let (expected_qh_hi, expected_qh_lo) = hash_to_field_halves(&query_hash);
         require!(
             public_inputs[0] == expected_qh_hi && public_inputs[1] == expected_qh_lo,
             ZkError::MalformedQueryHashInput
@@ -232,18 +230,22 @@ pub mod etornie_zk_verifier {
         let record = &mut ctx.accounts.compliance_record;
         require!(!record.is_initialized, ZkError::ReplayedProof);
 
-        // 3. Groth16 pairing verify on BN254.
-        let mut verifier =
-            Groth16Verifier::<COMPLIANCE_PUBLIC_INPUT_COUNT>::new(
-                &proof_a,
-                &proof_b,
-                &proof_c,
-                &public_inputs,
-                &VK_COMPLIANCE,
-            )
-            .map_err(map_groth16_error)?;
+        // 3. Groth16 pairing verify on BN254 via Mosaic (mosaic-groth16).
+        let mut proof_bytes = [0u8; 256];
+        proof_bytes[..64].copy_from_slice(&proof_a);
+        proof_bytes[64..192].copy_from_slice(&proof_b);
+        proof_bytes[192..].copy_from_slice(&proof_c);
 
-        verifier.verify().map_err(map_groth16_error)?;
+        let mut pi_bytes = [0u8; 32 * COMPLIANCE_PUBLIC_INPUT_COUNT];
+        for (i, input) in public_inputs.iter().enumerate() {
+            pi_bytes[i * 32..(i + 1) * 32].copy_from_slice(input);
+        }
+
+        let backend = SolanaSyscallBackend::new();
+        let verifier = MosaicGroth16Verifier::<_, false>::new(&backend);
+        verifier
+            .verify(&vk_canonical(&VK_COMPLIANCE), &proof_bytes, &pi_bytes)
+            .map_err(map_mosaic_error)?;
 
         // 4. Persist the compliance record.
         record.payer = ctx.accounts.user.key();
@@ -428,18 +430,6 @@ pub enum ZkError {
     MalformedFileHashInput,
     #[msg("query_hash argument does not match the canonical zero-padded halves in public inputs")]
     MalformedQueryHashInput,
-}
-
-fn map_groth16_error(e: Groth16Error) -> Error {
-    match e {
-        Groth16Error::ProofVerificationFailed => ZkError::InvalidProof.into(),
-        Groth16Error::PublicInputGreaterThanFieldSize
-        | Groth16Error::InvalidPublicInputsLength => ZkError::MalformedPublicInput.into(),
-        // The remaining variants are unreachable in our flow: fixed-size byte
-        // arrays rule out G1/G2 length mismatches, we never feed compressed
-        // points, and VERIFYINGKEY is compile-time matched to PUBLIC_INPUT_COUNT.
-        _ => ZkError::VerifierInternal.into(),
-    }
 }
 
 /// Encode a groth16-solana `Groth16Verifyingkey` into Mosaic canonical VK

--- a/programs/etornie-zk-verifier/src/lib.rs
+++ b/programs/etornie-zk-verifier/src/lib.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::hash::hashv;
 use groth16_solana::errors::Groth16Error;
-use groth16_solana::groth16::Groth16Verifier;
+use groth16_solana::groth16::{Groth16Verifier, Groth16Verifyingkey};
 
 // Mosaic verifier (epic M0). The HelloWorld path (`verify_proof`) is ported to
 // mosaic in M2; `verify_file_ownership_proof` and `verify_compliance_proof`
@@ -100,7 +100,7 @@ pub mod etornie_zk_verifier {
         let backend = SolanaSyscallBackend::new();
         let verifier = MosaicGroth16Verifier::<_, false>::new(&backend);
         verifier
-            .verify(&helloworld_vk_canonical(), &proof_bytes, &concat)
+            .verify(&vk_canonical(&VERIFYINGKEY), &proof_bytes, &concat)
             .map_err(map_mosaic_error)?;
 
         // 4. Persist the record. The `operator` field name is kept for
@@ -149,10 +149,7 @@ pub mod etornie_zk_verifier {
         //    fh_lo carries the bottom 16 bytes the same way. Without this,
         //    a caller could pick arbitrary high bits and land on a PDA
         //    keyed on a file_hash that does not match `public_inputs`.
-        let mut expected_fh_hi = [0u8; 32];
-        expected_fh_hi[16..].copy_from_slice(&file_hash[..16]);
-        let mut expected_fh_lo = [0u8; 32];
-        expected_fh_lo[16..].copy_from_slice(&file_hash[16..]);
+        let (expected_fh_hi, expected_fh_lo) = hash_to_field_halves(&file_hash);
         require!(
             public_inputs[0] == expected_fh_hi && public_inputs[1] == expected_fh_lo,
             ZkError::MalformedFileHashInput
@@ -163,18 +160,22 @@ pub mod etornie_zk_verifier {
         let record = &mut ctx.accounts.file_ownership_record;
         require!(!record.is_initialized, ZkError::ReplayedProof);
 
-        // 3. Groth16 pairing verify on BN254.
-        let mut verifier =
-            Groth16Verifier::<FILE_OWNERSHIP_PUBLIC_INPUT_COUNT>::new(
-                &proof_a,
-                &proof_b,
-                &proof_c,
-                &public_inputs,
-                &VK_FILE_OWNERSHIP,
-            )
-            .map_err(map_groth16_error)?;
+        // 3. Groth16 pairing verify on BN254 via Mosaic (mosaic-groth16).
+        let mut proof_bytes = [0u8; 256];
+        proof_bytes[..64].copy_from_slice(&proof_a);
+        proof_bytes[64..192].copy_from_slice(&proof_b);
+        proof_bytes[192..].copy_from_slice(&proof_c);
 
-        verifier.verify().map_err(map_groth16_error)?;
+        let mut pi_bytes = [0u8; 32 * FILE_OWNERSHIP_PUBLIC_INPUT_COUNT];
+        for (i, input) in public_inputs.iter().enumerate() {
+            pi_bytes[i * 32..(i + 1) * 32].copy_from_slice(input);
+        }
+
+        let backend = SolanaSyscallBackend::new();
+        let verifier = MosaicGroth16Verifier::<_, false>::new(&backend);
+        verifier
+            .verify(&vk_canonical(&VK_FILE_OWNERSHIP), &proof_bytes, &pi_bytes)
+            .map_err(map_mosaic_error)?;
 
         // 4. Persist the ownership record.
         record.owner = ctx.accounts.user.key();
@@ -441,19 +442,18 @@ fn map_groth16_error(e: Groth16Error) -> Error {
     }
 }
 
-/// Encode the compile-time groth16-solana `VERIFYINGKEY` into Mosaic canonical
-/// VK bytes. The byte layout is identical between the two libraries, so this is
-/// a pure concatenation:
+/// Encode a groth16-solana `Groth16Verifyingkey` into Mosaic canonical VK
+/// bytes. The byte layout is identical between the two libraries, so this is a
+/// pure concatenation:
 ///
 /// ```text
 /// alpha_g1 (64) || beta_g2 (128) || gamma_g2 (128) || delta_g2 (128) || ic[] (64 each)
 /// ```
 ///
-/// `ic.len()` == `nr_pubinputs` == `PUBLIC_INPUT_COUNT + 1` (ic[0] is the
-/// constant term). Recomputed per call (~700 B heap); M7 replaces this with a
-/// build-time baked constant once the `mosaic-serde` snarkjs adapter lands.
-fn helloworld_vk_canonical() -> Vec<u8> {
-    let vk = &VERIFYINGKEY;
+/// `ic.len()` == `nr_pubinputs` == `N_public_inputs + 1` (ic[0] is the constant
+/// term). Recomputed per call (~700 B heap); M7 replaces this with a build-time
+/// baked constant once the `mosaic-serde` snarkjs adapter lands.
+fn vk_canonical(vk: &Groth16Verifyingkey) -> Vec<u8> {
     let mut out = Vec::with_capacity(64 + 128 * 3 + 64 * vk.vk_ic.len());
     out.extend_from_slice(&vk.vk_alpha_g1);
     out.extend_from_slice(&vk.vk_beta_g2);
@@ -463,6 +463,20 @@ fn helloworld_vk_canonical() -> Vec<u8> {
         out.extend_from_slice(ic);
     }
     out
+}
+
+/// Split a 32-byte hash into two BN254 field elements: the top 16 bytes and the
+/// bottom 16 bytes, each zero-padded into the low half of a 32-byte big-endian
+/// field element. Mirrors the `(hi, lo)` canonical encoding the file-ownership
+/// and compliance circuits expect, and pins the unused high bits to zero so a
+/// caller cannot land on a PDA keyed on a hash that differs from the public
+/// inputs (the grief vector documented inline at each call site).
+fn hash_to_field_halves(hash: &[u8; 32]) -> ([u8; 32], [u8; 32]) {
+    let mut hi = [0u8; 32];
+    hi[16..].copy_from_slice(&hash[..16]);
+    let mut lo = [0u8; 32];
+    lo[16..].copy_from_slice(&hash[16..]);
+    (hi, lo)
 }
 
 /// Map a Mosaic `OnChainError` onto the program's existing `ZkError` surface so

--- a/services/api/app/solana/client.py
+++ b/services/api/app/solana/client.py
@@ -1269,7 +1269,7 @@ async def submit_compliance_proof_tx(
         ],
         data=ix_data,
     )
-    compute_ix = set_compute_unit_limit(300_000)
+    compute_ix = set_compute_unit_limit(180_000)
 
     async with AsyncClient(settings.solana_cluster_url) as rpc:
         latest = await rpc.get_latest_blockhash()

--- a/tests/compliance.ts
+++ b/tests/compliance.ts
@@ -138,7 +138,7 @@ describe('compliance verifier on devnet (sponsored flow)', function () {
   }): Promise<{ signature: string; pda: PublicKey }> {
     const [pda] = derivePda(params.user.publicKey, params.queryHash);
     const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-      units: 300_000,
+      units: 180_000,
     });
 
     // user is an UncheckedAccount - only funder (operator) signs. The ZK

--- a/tests/file_ownership.ts
+++ b/tests/file_ownership.ts
@@ -145,7 +145,7 @@ describe('file_ownership verifier on devnet (sponsored flow)', function () {
   }): Promise<{ signature: string; pda: PublicKey }> {
     const [pda] = derivePda(params.user.publicKey, params.fileHash);
     const computeIx = ComputeBudgetProgram.setComputeUnitLimit({
-      units: 300_000,
+      units: 180_000,
     });
 
     const signature = await program.methods

--- a/tests/zk_verifier.ts
+++ b/tests/zk_verifier.ts
@@ -89,7 +89,7 @@ describe('etornie-zk-verifier on devnet (sponsored flow)', function () {
     const { user, proofA, proofB, proofC, publicInputs, journalDigest } = params;
     const [pda] = derivePda(user.publicKey, journalDigest);
 
-    const computeIx = ComputeBudgetProgram.setComputeUnitLimit({ units: 300_000 });
+    const computeIx = ComputeBudgetProgram.setComputeUnitLimit({ units: 180_000 });
 
     const signature = await program.methods
       .verifyProof(


### PR DESCRIPTION
## Summary

Merges the first five phases of the [Mosaic ZK Migration epic (#15)](https://github.com/wienerlabs/etornie-solana/issues/15) into `main`. `programs/etornie-zk-verifier` now runs entirely on [Wiener Labs Mosaic](https://github.com/wienerlabs/mosaic) (`mosaic-groth16`) instead of Light Protocol's `groth16-solana`.

## What landed (5 merged sub-PRs)

| Phase | PR | Change |
|---|---|---|
| M1 | #75 | Wire `mosaic-core` + `mosaic-groth16` (pinned `v0.8.5-msm-helper-coverage`) |
| M2 | #76 | Port `verify_proof` (HelloWorld, 1 input) |
| M3 | #77 | Port `verify_file_ownership_proof` + extract `vk_canonical()` and `hash_to_field_halves()` |
| M4 | #78 | Port `verify_compliance_proof` (x402) + remove dead `groth16-solana` verifier/error code |
| M5 | #79 | Rebudget compute units 300k → 180k across all client call sites + program README |

## Net effect

- All three on-chain verify paths route through `mosaic_groth16::Groth16Verifier` with `SolanaSyscallBackend` and big-endian inputs.
- `groth16-solana` is reduced to just the `Groth16Verifyingkey` struct (the auto-generated VK modules type against it); fully removed in M13.
- Shared helpers: one VK encoder, one `(hi, lo)` hash splitter.
- Client compute budgets dropped from 300k to a conservative 180k.

## Why the port was clean

`groth16-solana`'s `Groth16Verifyingkey` field order (`alpha_g1, beta_g2, gamma_g2, delta_g2, ic[]`) is **byte-identical** to mosaic's canonical VK layout, so VK / proof / public-input conversions are pure concatenations. No re-encoding, no endianness flip.

## Verification

Every sub-PR passed host `cargo check` with no type errors and no unused-code warnings. **This environment has no `cargo build-sbf` / `solana` CLI**, so a real SBF build and on-chain CU measurement have not run here. That is gated on:

- the CI workflow (#48), and
- M9 SBF integration tests (#10), and
- M12 differential test against groth16-solana (#13).

## Remaining epic work (not in this PR)

M6 batch verify (#7), M7 snarkjs adapter (#8), M8 compressed verify (#9), M9 SBF tests (#10), M10 backend rebind (#11), M11 frontend WASM (#12), M12 differential test (#13), M13 cutover (#14). These need the Solana + Circom toolchains and will land in follow-up batches.

## Files

```
programs/etornie-zk-verifier/src/lib.rs   | 170 +++++++++++-----------
programs/etornie-zk-verifier/Cargo.toml   |  11 ++
programs/etornie-zk-verifier/README.md    |  56 +++++++ (new)
Cargo.lock                                |  53 +++++++
tests/{zk_verifier,file_ownership,compliance}.ts | 3 files
services/api/app/solana/client.py         |   2 +-
dashboard/src/lib/zk/{verifyProof,submitFileOwnership}.ts | 2 files
```

Closes nothing automatically (sub-issues #2-#6 tracked in epic #15).