### PR TITLE
M6: Add verify_proof_batch via mosaic batch verifier

### DIFF
--- a/programs/etornie-zk-verifier/README.md
+++ b/programs/etornie-zk-verifier/README.md
@@ -6,11 +6,26 @@ On-chain Groth16 verifier for Etornie's three circuits, running on
 | Instruction | Circuit | Public inputs | Record PDA |
 |---|---|---|---|
 | `verify_proof` | `hello_world` | 1 | `(proof, user, journal_digest)` |
+| `verify_proof_batch` | `hello_world` × N | 1 each | `(batch, user, batch_digest)` |
 | `verify_file_ownership_proof` | `file_ownership` | 3 `[fh_hi, fh_lo, commitment]` | `(file-ownership, user, file_hash)` |
 | `verify_compliance_proof` | `compliance` (x402) | 3 `[qh_hi, qh_lo, commitment]` | `(compliance, user, query_hash)` |
 
-All three route through `mosaic_groth16::Groth16Verifier` with the
-`SolanaSyscallBackend` and big-endian field elements (`<_, false>`).
+The single-proof paths route through `mosaic_groth16::Groth16Verifier`; the
+batch path uses `mosaic_groth16::batch::batch_verify` (Bowe-Gabizon). All use
+the `SolanaSyscallBackend` and big-endian field elements (`<_, false>`).
+
+### Batch verification
+
+`verify_proof_batch` verifies `N` proofs (`2..=MAX_BATCH`, MAX_BATCH = 4)
+sharing the hello_world VK in a **single BN254 pairing**. mosaic's batch
+verifier costs ~52k CU/proof versus ~83k single, a ~38% saving. A single
+`BatchProofRecord` PDA keyed on `(user, batch_digest)` covers the whole batch.
+
+The batch size is bounded by the 1232-byte Solana transaction limit: each
+`BatchEntry` is 288 bytes (256 proof + one 32-byte public input), so 4 entries
+plus the seed and accounts fit one tx. Larger batches would need address
+lookup tables or chunking. `batch_digest = sha256(concat(per-entry journal
+digests))` and is recomputed on-chain so the PDA seed cannot be spoofed.
 
 ## Compute-unit budget
 

--- a/programs/etornie-zk-verifier/src/lib.rs
+++ b/programs/etornie-zk-verifier/src/lib.rs
@@ -9,6 +9,7 @@ use groth16_solana::groth16::Groth16Verifyingkey;
 // removed in M13 once M7 bakes canonical VK bytes at build time.
 use mosaic_core::error::OnChainError as MosaicError;
 use mosaic_core::syscall::solana::SolanaSyscallBackend;
+use mosaic_groth16::batch::batch_verify;
 use mosaic_groth16::Groth16Verifier as MosaicGroth16Verifier;
 
 pub mod groth16_vk;
@@ -38,6 +39,17 @@ pub const COMPLIANCE_PUBLIC_INPUT_COUNT: usize = 3;
 
 /// Seed prefix for the ProofRecord PDA.
 pub const PROOF_RECORD_SEED: &[u8] = b"proof";
+
+/// Seed prefix for the BatchProofRecord PDA. PDA key =
+/// (BATCH_RECORD_SEED, user, batch_digest) so a given batch is recorded once
+/// per submitter.
+pub const BATCH_RECORD_SEED: &[u8] = b"batch";
+
+/// Maximum proofs in a single `verify_proof_batch` call. Bounded by the
+/// 1232-byte Solana transaction: each entry is 288 bytes (256 proof + 32-byte
+/// single public input), so up to 4 entries plus the batch_digest seed and
+/// accounts fit one tx. Larger batches need address lookup tables or chunking.
+pub const MAX_BATCH: usize = 4;
 
 /// Seed prefix for the FileOwnershipRecord PDA. PDA key =
 /// (FILE_OWNERSHIP_SEED, user, file_hash) so multiple users can register
@@ -120,6 +132,86 @@ pub mod etornie_zk_verifier {
             "zk-verifier: proof recorded (user={}, fee_payer={}, verified_at={})",
             record.operator,
             ctx.accounts.fee_payer.key(),
+            record.verified_at
+        );
+
+        Ok(())
+    }
+
+    /// Batched HelloWorld verification: verify `N` proofs (`2..=MAX_BATCH`)
+    /// sharing the hello_world VK in a single BN254 pairing via mosaic's
+    /// Bowe-Gabizon batch verifier (~52k CU/proof vs ~83k single). One
+    /// `BatchProofRecord` PDA keyed on `(user, batch_digest)` gives the whole
+    /// batch replay protection.
+    ///
+    /// `batch_digest` MUST equal `sha256(concat(per-entry journal digests))`,
+    /// where each journal digest is `sha256(concat(entry.public_inputs))`. The
+    /// handler recomputes and checks it so the PDA seed cannot be spoofed.
+    ///
+    /// The client should prepend a larger compute budget than the single-proof
+    /// path (a batch of 4 is roughly 400k CU). See the program README.
+    pub fn verify_proof_batch(
+        ctx: Context<VerifyProofBatch>,
+        batch_digest: [u8; 32],
+        entries: Vec<BatchEntry>,
+    ) -> Result<()> {
+        let n = entries.len();
+        require!((2..=MAX_BATCH).contains(&n), ZkError::InvalidBatchSize);
+
+        // 1. Recompute the batch digest from the entries' public inputs and pin
+        //    it to the client-supplied value used as the PDA seed.
+        let mut digest_concat = Vec::with_capacity(n * 32);
+        for entry in entries.iter() {
+            let mut pi_concat = [0u8; 32 * PUBLIC_INPUT_COUNT];
+            for (i, input) in entry.public_inputs.iter().enumerate() {
+                pi_concat[i * 32..(i + 1) * 32].copy_from_slice(input);
+            }
+            let jd = hashv(&[&pi_concat]).to_bytes();
+            digest_concat.extend_from_slice(&jd);
+        }
+        let computed = hashv(&[&digest_concat]).to_bytes();
+        require!(computed == batch_digest, ZkError::MismatchedDigest);
+
+        // 2. Replay protection at the batch level.
+        let record = &mut ctx.accounts.batch_record;
+        require!(!record.is_initialized, ZkError::ReplayedProof);
+
+        // 3. Pack proofs + public inputs into the slice-of-slices mosaic wants.
+        let mut proof_blobs: Vec<[u8; 256]> = Vec::with_capacity(n);
+        let mut pi_blobs: Vec<[u8; 32 * PUBLIC_INPUT_COUNT]> = Vec::with_capacity(n);
+        for entry in entries.iter() {
+            let mut pb = [0u8; 256];
+            pb[..64].copy_from_slice(&entry.proof_a);
+            pb[64..192].copy_from_slice(&entry.proof_b);
+            pb[192..].copy_from_slice(&entry.proof_c);
+            proof_blobs.push(pb);
+
+            let mut pi = [0u8; 32 * PUBLIC_INPUT_COUNT];
+            for (i, input) in entry.public_inputs.iter().enumerate() {
+                pi[i * 32..(i + 1) * 32].copy_from_slice(input);
+            }
+            pi_blobs.push(pi);
+        }
+        let proof_refs: Vec<&[u8]> = proof_blobs.iter().map(|b| b.as_slice()).collect();
+        let pi_refs: Vec<&[u8]> = pi_blobs.iter().map(|b| b.as_slice()).collect();
+
+        // 4. Single batched pairing check over all N proofs.
+        let backend = SolanaSyscallBackend::new();
+        batch_verify::<_, false>(&backend, &vk_canonical(&VERIFYINGKEY), &proof_refs, &pi_refs)
+            .map_err(map_mosaic_error)?;
+
+        // 5. Persist the batch record.
+        record.submitter = ctx.accounts.user.key();
+        record.batch_digest = batch_digest;
+        record.count = n as u8;
+        record.verified_at = Clock::get()?.unix_timestamp;
+        record.bump = ctx.bumps.batch_record;
+        record.is_initialized = true;
+
+        msg!(
+            "zk-verifier: batch recorded (user={}, count={}, verified_at={})",
+            record.submitter,
+            record.count,
             record.verified_at
         );
 
@@ -305,6 +397,39 @@ pub struct VerifyProof<'info> {
     pub system_program: Program<'info, System>,
 }
 
+/// A single proof in a `verify_proof_batch` call. `journal_digest` is omitted
+/// (recomputed on-chain from `public_inputs`) to keep the entry small so more
+/// fit under the transaction size limit.
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct BatchEntry {
+    pub proof_a: [u8; 64],
+    pub proof_b: [u8; 128],
+    pub proof_c: [u8; 64],
+    pub public_inputs: [[u8; 32]; PUBLIC_INPUT_COUNT],
+}
+
+#[derive(Accounts)]
+#[instruction(batch_digest: [u8; 32])]
+pub struct VerifyProofBatch<'info> {
+    /// Covers the tx fee and the PDA rent.
+    #[account(mut)]
+    pub fee_payer: Signer<'info>,
+
+    /// Logical owner of the batch - PDA is keyed to this pubkey.
+    pub user: Signer<'info>,
+
+    #[account(
+        init,
+        payer = fee_payer,
+        space = 8 + BatchProofRecord::INIT_SPACE,
+        seeds = [BATCH_RECORD_SEED, user.key().as_ref(), batch_digest.as_ref()],
+        bump,
+    )]
+    pub batch_record: Account<'info, BatchProofRecord>,
+
+    pub system_program: Program<'info, System>,
+}
+
 #[derive(Accounts)]
 #[instruction(
     _proof_a: [u8; 64],
@@ -387,6 +512,20 @@ pub struct ProofRecord {
 
 #[account]
 #[derive(InitSpace)]
+pub struct BatchProofRecord {
+    /// Submitter (the `user` signer the PDA is keyed on).
+    pub submitter: Pubkey,
+    /// sha256(concat(per-entry journal digests)) — also the PDA seed.
+    pub batch_digest: [u8; 32],
+    /// Number of proofs verified in the batch (2..=MAX_BATCH).
+    pub count: u8,
+    pub verified_at: i64,
+    pub bump: u8,
+    pub is_initialized: bool,
+}
+
+#[account]
+#[derive(InitSpace)]
 pub struct FileOwnershipRecord {
     /// Claim owner (pubkey of the signer that submitted the proof).
     pub owner: Pubkey,
@@ -433,6 +572,8 @@ pub enum ZkError {
     MalformedFileHashInput,
     #[msg("query_hash argument does not match the canonical zero-padded halves in public inputs")]
     MalformedQueryHashInput,
+    #[msg("Batch size must be between 2 and MAX_BATCH proofs")]
+    InvalidBatchSize,
 }
 
 /// Encode a groth16-solana `Groth16Verifyingkey` into Mosaic canonical VK


### PR DESCRIPTION
## Summary

Adds `verify_proof_batch` (epic #15): verify **N proofs in a single BN254 pairing** via `mosaic_groth16::batch::batch_verify` (Bowe-Gabizon). ~52k CU/proof vs ~83k single = ~38% saving.

## Design decisions

| Concern | Decision |
|---|---|
| Batch size | `2..=MAX_BATCH` where `MAX_BATCH = 4` |
| Why 4 | Solana 1232-byte tx limit; each `BatchEntry` is 288 B (256 proof + one 32-B input). 4 entries + seed + accounts fit one tx. Larger needs ALTs/chunking. |
| Replay | one `BatchProofRecord` PDA keyed on `(user, batch_digest)` |
| Seed integrity | `batch_digest = sha256(concat(per-entry journal digests))`, recomputed + pinned on-chain (same pattern as `verify_proof`) |
| Entry size | `journal_digest` omitted from `BatchEntry` (derived on-chain) to fit more proofs |

## Verification

**Real SBF build** (not just host check):

```
$ RUSTC_BOOTSTRAP=1 cargo build-sbf --tools-version v1.54 \
    --manifest-path programs/etornie-zk-verifier/Cargo.toml
   Compiling etornie-zk-verifier v0.1.0
    Finished `release` profile [optimized] in 1.83s
-> target/deploy/etornie_zk_verifier.so  (306 KB, was 262 KB)
```

The mosaic batch path compiles to the on-chain binary. (Full anchor test with a real localnet proof is M9, #10.)

## Scope

- In: `verify_proof_batch` for the hello_world circuit.
- Out: batch for file_ownership / compliance (different input counts; future). On-chain CU measurement (M9).

## Refs

- Epic #15, resolves part of #7
- Builds on the M1-M5 core (now on main)