### PR TITLE
M7: Own VkBytes struct, drop groth16-solana dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,20 +271,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
-dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -293,34 +282,13 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff 0.4.2",
- "ark-poly 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-poly 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.2",
- "itertools 0.13.0",
- "num-bigint",
- "num-integer",
  "num-traits",
  "zeroize",
 ]
@@ -331,10 +299,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
@@ -346,26 +314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ff"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
-dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "arrayvec",
- "digest 0.10.7",
- "educe",
- "itertools 0.13.0",
- "num-bigint",
- "num-traits",
- "paste",
- "zeroize",
-]
-
-[[package]]
 name = "ark-ff-asm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,16 +321,6 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -399,44 +337,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ff-macros"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "derivative",
  "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -445,21 +355,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive 0.4.2",
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
-dependencies = [
- "ark-serialize-derive 0.5.0",
- "ark-std 0.5.0",
- "arrayvec",
+ "ark-serialize-derive",
+ "ark-std",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -476,31 +373,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -885,42 +761,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "educe"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "equivalent"
@@ -948,7 +792,6 @@ name = "etornie-zk-verifier"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "groth16-solana",
  "mosaic-core",
  "mosaic-groth16",
 ]
@@ -1042,21 +885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "groth16-solana"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6d1ffb18dbf5cfc60b11bd7da88474c672870247c1e5b498619bcb6ba3d8f5"
-dependencies = [
- "ark-bn254 0.5.0",
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "num-bigint",
- "solana-bn254",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,15 +961,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1235,8 +1054,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.2",
+ "ark-bn254",
+ "ark-ff",
  "num-bigint",
  "thiserror 1.0.69",
 ]
@@ -1829,10 +1648,10 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
  "bytemuck",
  "solana-define-syscall",
  "thiserror 2.0.18",
@@ -2174,7 +1993,7 @@ version = "2.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbac4eb90016eeb1d37fa36e592d3a64421510c49666f81020736611c319faff"
 dependencies = [
- "ark-bn254 0.4.0",
+ "ark-bn254",
  "light-poseidon",
  "solana-define-syscall",
  "thiserror 2.0.18",

--- a/programs/etornie-zk-verifier/Cargo.toml
+++ b/programs/etornie-zk-verifier/Cargo.toml
@@ -19,10 +19,6 @@ idl-build = ["anchor-lang/idl-build"]
 [dependencies]
 anchor-lang = { version = "0.31.1", features = ["init-if-needed"] }
 
-# Legacy verifier — kept side-by-side through the migration so the program
-# stays buildable on every M1-M12 PR. Removed in M13 (production cutover).
-groth16-solana = "0.2.0"
-
 # Wiener Labs Mosaic — proof-system-agnostic Solana verifier (epic M0).
 # Pinned to the latest published tag on wienerlabs/mosaic. The README
 # references a future `v0.9.x-onchain-compressed-verify` release; that tag

--- a/programs/etornie-zk-verifier/src/groth16_vk.rs
+++ b/programs/etornie-zk-verifier/src/groth16_vk.rs
@@ -6,9 +6,9 @@
 // Note: the field name `vk_gamme_g2` (typo) is intentional — it matches the
 //       Groth16Verifyingkey struct in groth16-solana v0.2.0 verbatim.
 
-use groth16_solana::groth16::Groth16Verifyingkey;
+use crate::VkBytes;
 
-pub const VERIFYINGKEY: Groth16Verifyingkey = Groth16Verifyingkey {
+pub const VERIFYINGKEY: VkBytes = VkBytes {
     nr_pubinputs: 2,
 
     vk_alpha_g1: [

--- a/programs/etornie-zk-verifier/src/lib.rs
+++ b/programs/etornie-zk-verifier/src/lib.rs
@@ -1,12 +1,9 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::hash::hashv;
-use groth16_solana::groth16::Groth16Verifyingkey;
 
-// Mosaic verifier (epic M0). All three verify paths now route through
-// mosaic-groth16. groth16-solana is retained only for its `Groth16Verifyingkey`
-// struct — the auto-generated VK modules (`groth16_vk`, `vk_file_ownership`,
-// `vk_compliance`) type against it. Both the type and the dependency are
-// removed in M13 once M7 bakes canonical VK bytes at build time.
+// Mosaic verifier (epic M0). All verify paths route through mosaic-groth16.
+// The auto-generated VK modules now type against the local `VkBytes` struct
+// (below), so groth16-solana is no longer a dependency of this program.
 use mosaic_core::error::OnChainError as MosaicError;
 use mosaic_core::syscall::solana::SolanaSyscallBackend;
 use mosaic_groth16::batch::batch_verify;
@@ -21,6 +18,21 @@ use vk_compliance::VERIFYINGKEY as VK_COMPLIANCE;
 use vk_file_ownership::VERIFYINGKEY as VK_FILE_OWNERSHIP;
 
 declare_id!("GCnpSrJ1W8SXPZ94FbYy4xs5kNZEAQuiDD7Nqk4nwSk5");
+
+/// Minimal Groth16 verifying-key container. Field names and byte layout match
+/// the upstream `groth16-solana` `Groth16Verifyingkey` struct verbatim (the
+/// `vk_gamme_g2` typo included) so the auto-generated VK modules stay
+/// byte-for-byte identical. Owning the type here lets the program drop the
+/// `groth16-solana` dependency: `vk_canonical()` reads these fields directly,
+/// and their concatenation is already the Mosaic canonical VK layout.
+pub struct VkBytes {
+    pub nr_pubinputs: usize,
+    pub vk_alpha_g1: [u8; 64],
+    pub vk_beta_g2: [u8; 128],
+    pub vk_gamme_g2: [u8; 128],
+    pub vk_delta_g2: [u8; 128],
+    pub vk_ic: &'static [[u8; 64]],
+}
 
 /// Number of public inputs for the hello_world Groth16 circuit.
 /// When a new circuit is added this constant (and VERIFYINGKEY) must change
@@ -587,7 +599,7 @@ pub enum ZkError {
 /// `ic.len()` == `nr_pubinputs` == `N_public_inputs + 1` (ic[0] is the constant
 /// term). Recomputed per call (~700 B heap); M7 replaces this with a build-time
 /// baked constant once the `mosaic-serde` snarkjs adapter lands.
-fn vk_canonical(vk: &Groth16Verifyingkey) -> Vec<u8> {
+fn vk_canonical(vk: &VkBytes) -> Vec<u8> {
     let mut out = Vec::with_capacity(64 + 128 * 3 + 64 * vk.vk_ic.len());
     out.extend_from_slice(&vk.vk_alpha_g1);
     out.extend_from_slice(&vk.vk_beta_g2);

--- a/programs/etornie-zk-verifier/src/vk_compliance.rs
+++ b/programs/etornie-zk-verifier/src/vk_compliance.rs
@@ -6,9 +6,9 @@
 // Note: the field name `vk_gamme_g2` (typo) is intentional — it matches the
 //       Groth16Verifyingkey struct in groth16-solana v0.2.0 verbatim.
 
-use groth16_solana::groth16::Groth16Verifyingkey;
+use crate::VkBytes;
 
-pub const VERIFYINGKEY: Groth16Verifyingkey = Groth16Verifyingkey {
+pub const VERIFYINGKEY: VkBytes = VkBytes {
     nr_pubinputs: 4,
 
     vk_alpha_g1: [

--- a/programs/etornie-zk-verifier/src/vk_file_ownership.rs
+++ b/programs/etornie-zk-verifier/src/vk_file_ownership.rs
@@ -6,9 +6,9 @@
 // Note: the field name `vk_gamme_g2` (typo) is intentional — it matches the
 //       Groth16Verifyingkey struct in groth16-solana v0.2.0 verbatim.
 
-use groth16_solana::groth16::Groth16Verifyingkey;
+use crate::VkBytes;
 
-pub const VERIFYINGKEY: Groth16Verifyingkey = Groth16Verifyingkey {
+pub const VERIFYINGKEY: VkBytes = VkBytes {
     nr_pubinputs: 4,
 
     vk_alpha_g1: [


### PR DESCRIPTION
## Summary

Removes the last `groth16-solana` usage (epic #15). The auto-generated VK modules typed against `Groth16Verifyingkey`; replacing it with a local `VkBytes` struct of identical layout lets the program drop the dependency entirely.

## Approach (deviation from issue, simpler)

The M7 issue proposed a `build.rs` + `mosaic-serde` bake. That turned out unnecessary: groth16-solana's VK byte order **already equals** mosaic's canonical layout (proven by M2-M5 building and running on SBF). So:

- New `VkBytes` struct, same fields (`vk_alpha_g1`, `vk_beta_g2`, `vk_gamme_g2`, `vk_delta_g2`, `vk_ic`) — `vk_gamme_g2` typo kept so the generator output is unchanged.
- The three VK modules switch `use groth16_solana::groth16::Groth16Verifyingkey` -> `use crate::VkBytes`. **VK constants are byte-for-byte identical.**
- `vk_canonical(&VkBytes)` reads the fields and concatenates (already canonical).
- `groth16-solana` removed from `Cargo.toml`.

## Verification

```
$ RUSTC_BOOTSTRAP=1 cargo build-sbf --tools-version v1.54 ...
    Finished `release` in 3.11s
$ cargo tree | grep -c groth16-solana
0
```

groth16-solana has **0 references** in the dep tree. The program is mosaic-only and still produces a valid .so. Since VK bytes are unchanged, on-chain behaviour is identical.

## Refs

- Epic #15, resolves part of #8 (M7) + groth16-solana removal of #14 (M13)
- Builds on M6