### PR TITLE
Mosaic ZK Migration: land M8 compressed verify on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,9 +271,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -282,13 +293,34 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-poly 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
  "zeroize",
 ]
@@ -299,10 +331,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
@@ -314,6 +346,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +373,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -337,16 +399,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -355,8 +445,21 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.4.2",
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -373,10 +476,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -761,10 +885,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "equivalent"
@@ -966,6 +1122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,8 +1219,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
 dependencies = [
- "ark-bn254",
- "ark-ff",
+ "ark-bn254 0.4.0",
+ "ark-ff 0.4.2",
  "num-bigint",
  "thiserror 1.0.69",
 ]
@@ -1104,8 +1269,8 @@ dependencies = [
 
 [[package]]
 name = "mosaic-core"
-version = "0.8.5-msm-helper-coverage"
-source = "git+https://github.com/wienerlabs/mosaic?tag=v0.8.5-msm-helper-coverage#b77a3f23d5988755fb549fc712ad60eb292f887f"
+version = "0.9.15-onchain-compressed-verify"
+source = "git+https://github.com/wienerlabs/mosaic?rev=3265eb13008e563b655285c0858a0b876f4cf9ee#3265eb13008e563b655285c0858a0b876f4cf9ee"
 dependencies = [
  "arrayvec",
  "borsh 1.6.1",
@@ -1119,14 +1284,27 @@ dependencies = [
 
 [[package]]
 name = "mosaic-groth16"
-version = "0.8.5-msm-helper-coverage"
-source = "git+https://github.com/wienerlabs/mosaic?tag=v0.8.5-msm-helper-coverage#b77a3f23d5988755fb549fc712ad60eb292f887f"
+version = "0.9.15-onchain-compressed-verify"
+source = "git+https://github.com/wienerlabs/mosaic?rev=3265eb13008e563b655285c0858a0b876f4cf9ee#3265eb13008e563b655285c0858a0b876f4cf9ee"
 dependencies = [
  "arrayvec",
  "borsh 1.6.1",
  "mosaic-core",
+ "mosaic-zk-primitives",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "mosaic-zk-primitives"
+version = "0.9.15-onchain-compressed-verify"
+source = "git+https://github.com/wienerlabs/mosaic?rev=3265eb13008e563b655285c0858a0b876f4cf9ee#3265eb13008e563b655285c0858a0b876f4cf9ee"
+dependencies = [
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "mosaic-core",
 ]
 
 [[package]]
@@ -1648,10 +1826,10 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4420f125118732833f36facf96a27e7b78314b2d642ba07fa9ffdacd8d79e243"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
+ "ark-bn254 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
  "bytemuck",
  "solana-define-syscall",
  "thiserror 2.0.18",
@@ -1993,7 +2171,7 @@ version = "2.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbac4eb90016eeb1d37fa36e592d3a64421510c49666f81020736611c319faff"
 dependencies = [
- "ark-bn254",
+ "ark-bn254 0.4.0",
  "light-poseidon",
  "solana-define-syscall",
  "thiserror 2.0.18",

--- a/programs/etornie-zk-verifier/Cargo.toml
+++ b/programs/etornie-zk-verifier/Cargo.toml
@@ -20,9 +20,9 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-lang = { version = "0.31.1", features = ["init-if-needed"] }
 
 # Wiener Labs Mosaic — proof-system-agnostic Solana verifier (epic M0).
-# Pinned to the latest published tag on wienerlabs/mosaic. The README
-# references a future `v0.9.x-onchain-compressed-verify` release; that tag
-# does not exist yet, so we pin against the latest shipped tag and bump
-# together with the epic once mosaic ships its next release.
-mosaic-core    = { git = "https://github.com/wienerlabs/mosaic", tag = "v0.8.5-msm-helper-coverage", features = ["solana"] }
-mosaic-groth16 = { git = "https://github.com/wienerlabs/mosaic", tag = "v0.8.5-msm-helper-coverage", features = ["solana"] }
+# Pinned to a specific main commit rather than a tag: the latest published
+# tag (v0.8.5) predates the proof-compression API that `verify_proof_compressed`
+# (M8) needs. `3265eb13` is mosaic main with that API. Bump to a real tag once
+# mosaic ships a compression-capable release.
+mosaic-core    = { git = "https://github.com/wienerlabs/mosaic", rev = "3265eb13008e563b655285c0858a0b876f4cf9ee", features = ["solana"] }
+mosaic-groth16 = { git = "https://github.com/wienerlabs/mosaic", rev = "3265eb13008e563b655285c0858a0b876f4cf9ee", features = ["solana"] }

--- a/programs/etornie-zk-verifier/src/lib.rs
+++ b/programs/etornie-zk-verifier/src/lib.rs
@@ -7,6 +7,7 @@ use anchor_lang::solana_program::hash::hashv;
 use mosaic_core::error::OnChainError as MosaicError;
 use mosaic_core::syscall::solana::SolanaSyscallBackend;
 use mosaic_groth16::batch::batch_verify;
+use mosaic_groth16::Groth16Proof;
 use mosaic_groth16::Groth16Verifier as MosaicGroth16Verifier;
 
 pub mod groth16_vk;
@@ -230,6 +231,57 @@ pub mod etornie_zk_verifier {
         Ok(())
     }
 
+    /// Same as `verify_proof` but accepts a 128-byte compressed proof
+    /// (`A_compressed(32) || B_compressed(64) || C_compressed(32)`), decompressed
+    /// on-chain via mosaic's alt_bn128 compression syscall. ~50% smaller proof
+    /// payload — useful for mobile wallets with tight transaction envelopes.
+    ///
+    /// Shares the ProofRecord PDA `(PROOF_RECORD_SEED, user, journal_digest)`
+    /// with `verify_proof`, so a given proof cannot be replayed across the
+    /// compressed and uncompressed paths.
+    pub fn verify_proof_compressed(
+        ctx: Context<VerifyProofCompressed>,
+        compressed_proof: [u8; 128],
+        public_inputs: [[u8; 32]; PUBLIC_INPUT_COUNT],
+        journal_digest: [u8; 32],
+    ) -> Result<()> {
+        // 1. Journal digest integrity (identical to verify_proof).
+        let mut concat = [0u8; 32 * PUBLIC_INPUT_COUNT];
+        for (i, input) in public_inputs.iter().enumerate() {
+            concat[i * 32..(i + 1) * 32].copy_from_slice(input);
+        }
+        let computed = hashv(&[&concat]).to_bytes();
+        require!(computed == journal_digest, ZkError::MismatchedDigest);
+
+        // 2. Replay protection (shared PDA with verify_proof).
+        let record = &mut ctx.accounts.proof_record;
+        require!(!record.is_initialized, ZkError::ReplayedProof);
+
+        // 3. Decompress 128 -> 256 bytes, then verify via mosaic.
+        let backend = SolanaSyscallBackend::new();
+        let proof_bytes = Groth16Proof::decompress_to_canonical_bytes(&backend, &compressed_proof)
+            .map_err(map_mosaic_error)?;
+        let verifier = MosaicGroth16Verifier::<_, false>::new(&backend);
+        verifier
+            .verify(&vk_canonical(&VERIFYINGKEY), &proof_bytes, &concat)
+            .map_err(map_mosaic_error)?;
+
+        // 4. Persist the record (same layout as verify_proof).
+        record.operator = ctx.accounts.user.key();
+        record.journal_digest = journal_digest;
+        record.verified_at = Clock::get()?.unix_timestamp;
+        record.bump = ctx.bumps.proof_record;
+        record.is_initialized = true;
+
+        msg!(
+            "zk-verifier: compressed proof recorded (user={}, verified_at={})",
+            record.operator,
+            record.verified_at
+        );
+
+        Ok(())
+    }
+
     /// Verifies a Groth16 proof that the caller knows a secret `s` such that
     /// `Poseidon(s, fh_hi, fh_lo) == commitment`, without revealing `s` or the
     /// underlying file. Records the ownership claim in a per-(user, file_hash)
@@ -438,6 +490,30 @@ pub struct VerifyProofBatch<'info> {
         bump,
     )]
     pub batch_record: Account<'info, BatchProofRecord>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(
+    _compressed_proof: [u8; 128],
+    _public_inputs: [[u8; 32]; PUBLIC_INPUT_COUNT],
+    journal_digest: [u8; 32],
+)]
+pub struct VerifyProofCompressed<'info> {
+    #[account(mut)]
+    pub fee_payer: Signer<'info>,
+
+    pub user: Signer<'info>,
+
+    #[account(
+        init_if_needed,
+        payer = fee_payer,
+        space = 8 + ProofRecord::INIT_SPACE,
+        seeds = [PROOF_RECORD_SEED, user.key().as_ref(), journal_digest.as_ref()],
+        bump,
+    )]
+    pub proof_record: Account<'info, ProofRecord>,
 
     pub system_program: Program<'info, System>,
 }


### PR DESCRIPTION
## Summary
- Lands the final migration phase, M8 (#9), onto main. The #85 cutover merged M6-M13 but M8 (PR #86) merged into `mosaic-migration` afterward, so this brings main up to the full integration branch.
- Adds `verify_proof_compressed` (wire tag `0x03`): accepts a 128-byte compressed Groth16 proof (32+64+32) and decompresses to canonical 256 bytes on-chain via `Groth16Proof::decompress_to_canonical_bytes`.
- Bumps the mosaic pin from tag `v0.8.5` to main rev `3265eb13`, which is the first revision carrying the proof-compression API.

## Delta over main
Only three files, all isolated to the zk-verifier program:
- `programs/etornie-zk-verifier/Cargo.toml` (pin bump)
- `programs/etornie-zk-verifier/src/lib.rs` (+76 lines: the new instruction)
- `Cargo.lock` (resolved against the new rev)

No change to existing instruction ABIs; `verify_proof`, `verify_proof_batch`, `verify_file_ownership_proof`, and `verify_compliance_proof` are untouched.

## Test plan
- [x] Host-backend parity crate (`tests/zk-parity/`) green: mosaic accepts every snarkjs-verified proof, rejects tampered.
- [x] SBF build succeeds with `RUSTC_BOOTSTRAP=1 cargo build-sbf --tools-version v1.54`.
- [ ] Wire the SBF parity test into CI (tracked in #48).

Closes the implementation work for epic #15.