### PR TITLE
feat(compliance): GDPR Article 20 data export endpoint (#60)

### DIFF
--- a/dashboard/src/app/dashboard/profile/page.tsx
+++ b/dashboard/src/app/dashboard/profile/page.tsx
@@ -117,6 +117,12 @@ export default function ProfilePage() {
   const [avatarBusy, setAvatarBusy] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  // GDPR Article 20 data export
+  const [dataExporting, setDataExporting] = useState(false);
+  const [dataExportMessage, setDataExportMessage] = useState<string | null>(
+    null
+  );
+
   const refreshAvatar = useCallback(async (user: MeUser) => {
     if (!user.has_avatar) {
       setAvatarUrl((prev) => {
@@ -231,6 +237,35 @@ export default function ProfilePage() {
       setAvatarBusy(false);
     }
   }, [avatarBusy, refreshAvatar]);
+
+  const handleDataExport = useCallback(
+    async (fmt: "json" | "pdf" | "docx" | "xlsx") => {
+      if (!me || dataExporting) return;
+      setDataExporting(true);
+      setDataExportMessage(null);
+      try {
+        const res = await api.get("/users/me/export", {
+          params: { format: fmt },
+          responseType: "blob",
+        });
+        const blob = res.data as Blob;
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `etornie-data-export-${me.id}.${fmt}`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+        setDataExportMessage("Your data export downloaded.");
+      } catch (err) {
+        setDataExportMessage(extractErrorMessage(err, "Data export failed."));
+      } finally {
+        setDataExporting(false);
+      }
+    },
+    [me, dataExporting]
+  );
 
   const handleExport = useCallback(
     async (caseId: string, fmt: "pdf" | "docx" | "xlsx") => {
@@ -516,6 +551,48 @@ export default function ProfilePage() {
           {notifMessage && (
             <p className="mt-2 text-xs text-[color:var(--color-muted)]">
               {notifMessage}
+            </p>
+          )}
+        </div>
+
+        {/* Data export block (GDPR Article 20 — right to data portability) */}
+        <div className="mt-5 border-t border-[color:var(--color-stone)] pt-5">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-wider text-[color:var(--color-muted)]">
+                Your data
+              </p>
+              <p className="mt-1 text-xs text-[color:var(--color-muted)]">
+                Download a complete, machine-readable copy of all personal
+                data we hold about you — profile, cases, documents, chat
+                history, payments, and notifications — as a single JSON file.
+                This is your GDPR Article 20 right to data portability.
+              </p>
+            </div>
+            <div className="flex shrink-0 flex-wrap gap-2">
+              {(
+                [
+                  ["json", "JSON"],
+                  ["pdf", "PDF"],
+                  ["docx", "Word"],
+                  ["xlsx", "Excel"],
+                ] as const
+              ).map(([fmt, label]) => (
+                <button
+                  key={fmt}
+                  type="button"
+                  onClick={() => handleDataExport(fmt)}
+                  disabled={dataExporting}
+                  className="rounded-md border border-[color:var(--color-stone)] bg-white px-3 py-2 text-sm font-semibold text-[color:var(--color-ink)] hover:bg-[color:var(--color-sand)] disabled:opacity-50"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+          {dataExportMessage && (
+            <p className="mt-2 text-xs text-[color:var(--color-muted)]">
+              {dataExportMessage}
             </p>
           )}
         </div>

--- a/services/api/app/compliance/data_export.py
+++ b/services/api/app/compliance/data_export.py
@@ -1,0 +1,263 @@
+"""GDPR Article 20 data-portability export.
+
+Collects every row of personal data tied to a single user across all
+domain tables and returns one JSON-serialisable dict. The whole module
+is a pure read path: it issues only ``SELECT``s on the caller's session
+and never mutates anything.
+
+Rows are serialised by introspecting each model's mapped columns rather
+than by hand-listing fields, so the export tracks the schema as it
+evolves. Two classes of column are always withheld:
+
+* credential columns (``hashed_password``) — never portability data and
+  a security risk to hand back, and
+* deferred / large-binary columns (e.g. ``users.avatar_data``) — left
+  unloaded so the serialiser never triggers a lazy IO inside the async
+  session, and excluded because raw blobs are not Article-20 data.
+
+The set of tables and the column each is linked to the subject through
+is declared explicitly below; that mapping is schema knowledge, not a
+hardcoded value, and is the one place to extend when a new
+user-scoped table is added.
+"""
+from __future__ import annotations
+
+import base64
+import uuid
+from datetime import date, datetime, time, timezone
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import inspect as sa_inspect, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import ColumnElement
+
+from app.agent.models import (
+    AgentMessage,
+    AgentSession,
+    AgentUpload,
+    CaseDraft,
+    FilingAttempt,
+    PaymentIntent,
+)
+from app.audit.models import AuditLog
+from app.braid.models import BraidCalibrationEvent
+from app.cases.models import Case, CaseEvent, CaseNote
+from app.documents.models import Document
+from app.etorniegpt.models import ChatMessage
+from app.in_app_notifications.models import InAppNotification
+from app.notifications.models import Notification
+from app.organizations.models import OrganizationInvite, OrganizationMembership
+from app.proposals.models import Proposal
+from app.users.models import User
+
+EXPORT_FORMAT = "etornie-gdpr-data-export"
+EXPORT_VERSION = "1"
+GDPR_BASIS = (
+    "Regulation (EU) 2016/679 (GDPR) Article 20 — right to data portability"
+)
+
+# Column names never exported regardless of which table they live on:
+# credentials and other secrets that are not portability data.
+_SENSITIVE_COLUMNS = frozenset({"hashed_password"})
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Convert a single column value into a JSON-serialisable form."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return base64.b64encode(bytes(value)).decode("ascii")
+    if isinstance(value, (list, tuple, set)):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _to_jsonable(v) for k, v in value.items()}
+    return str(value)
+
+
+def _serialize(row: Any) -> dict[str, Any]:
+    """Serialise one ORM row using only its already-loaded columns.
+
+    Deferred columns stay unloaded (so no lazy IO fires inside the async
+    session) and known credential columns are dropped outright.
+    """
+    state = sa_inspect(row)
+    unloaded = state.unloaded
+    out: dict[str, Any] = {}
+    for attr in state.mapper.column_attrs:
+        key = attr.key
+        if key in _SENSITIVE_COLUMNS or key in unloaded:
+            continue
+        out[key] = _to_jsonable(getattr(row, key))
+    return out
+
+
+async def _rows(db: AsyncSession, stmt) -> list[Any]:
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def _serialized_rows(db: AsyncSession, stmt) -> list[dict[str, Any]]:
+    return [_serialize(row) for row in await _rows(db, stmt)]
+
+
+def _in(column: ColumnElement, ids: list[uuid.UUID]):
+    """``column IN ids`` with an explicit empty guard.
+
+    SQLAlchemy emits a warning (and some backends choke) on an empty
+    ``IN ()``; callers skip the query entirely when ``ids`` is empty, so
+    this is only ever called with a non-empty list.
+    """
+    return column.in_(ids)
+
+
+async def build_user_export(db: AsyncSession, user: User) -> dict[str, Any]:
+    """Assemble the full personal-data export for ``user``.
+
+    Returns a dict ready to be ``json.dumps``-ed. Every collection is a
+    list of row dicts; empty lists are kept so the shape is stable and a
+    consumer can tell "no rows" from "table not exported".
+    """
+    uid = user.id
+
+    # --- tables linked directly to the subject ---------------------------
+    memberships = await _serialized_rows(
+        db,
+        select(OrganizationMembership).where(
+            OrganizationMembership.user_id == uid
+        ),
+    )
+    invites = await _serialized_rows(
+        db,
+        select(OrganizationInvite).where(
+            (OrganizationInvite.invited_by_user_id == uid)
+            | (OrganizationInvite.accepted_by_user_id == uid)
+        ),
+    )
+    chat_messages = await _serialized_rows(
+        db, select(ChatMessage).where(ChatMessage.user_id == uid)
+    )
+    case_notes = await _serialized_rows(
+        db, select(CaseNote).where(CaseNote.author_id == uid)
+    )
+    documents = await _serialized_rows(
+        db, select(Document).where(Document.uploaded_by == uid)
+    )
+    in_app_notifications = await _serialized_rows(
+        db,
+        select(InAppNotification).where(
+            InAppNotification.recipient_id == uid
+        ),
+    )
+    audit_logs = await _serialized_rows(
+        db, select(AuditLog).where(AuditLog.actor_id == uid)
+    )
+    notifications = await _serialized_rows(
+        db, select(Notification).where(Notification.created_by == uid)
+    )
+    proposals = await _serialized_rows(
+        db, select(Proposal).where(Proposal.created_by == uid)
+    )
+    braid_feedback = await _serialized_rows(
+        db,
+        select(BraidCalibrationEvent).where(
+            BraidCalibrationEvent.feedback_user_id == uid
+        ),
+    )
+    agent_uploads = await _serialized_rows(
+        db, select(AgentUpload).where(AgentUpload.user_id == uid)
+    )
+
+    # Parents fetched as ORM rows so we can both serialise them and read
+    # their ids for the child queries below.
+    cases = await _rows(db, select(Case).where(Case.client_id == uid))
+    sessions = await _rows(
+        db, select(AgentSession).where(AgentSession.user_id == uid)
+    )
+    drafts = await _rows(db, select(CaseDraft).where(CaseDraft.user_id == uid))
+
+    case_ids = [c.id for c in cases]
+    session_ids = [s.id for s in sessions]
+    draft_ids = [d.id for d in drafts]
+
+    # --- child tables reached through a parent the subject owns ----------
+    agent_messages = (
+        await _serialized_rows(
+            db,
+            select(AgentMessage).where(
+                _in(AgentMessage.session_id, session_ids)
+            ),
+        )
+        if session_ids
+        else []
+    )
+    filing_attempts = (
+        await _serialized_rows(
+            db,
+            select(FilingAttempt).where(
+                _in(FilingAttempt.case_draft_id, draft_ids)
+            ),
+        )
+        if draft_ids
+        else []
+    )
+    payment_intents = (
+        await _serialized_rows(
+            db,
+            select(PaymentIntent).where(
+                _in(PaymentIntent.case_draft_id, draft_ids)
+            ),
+        )
+        if draft_ids
+        else []
+    )
+    case_events = (
+        await _serialized_rows(
+            db, select(CaseEvent).where(_in(CaseEvent.case_id, case_ids))
+        )
+        if case_ids
+        else []
+    )
+
+    return {
+        "export_format": EXPORT_FORMAT,
+        "export_version": EXPORT_VERSION,
+        "gdpr_basis": GDPR_BASIS,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "subject": {
+            "user_id": str(uid),
+            "email": user.email,
+            "full_name": user.full_name,
+            "wallet_address": user.wallet_address,
+            "public_handle": user.public_handle,
+        },
+        "data": {
+            "profile": _serialize(user),
+            "organization_memberships": memberships,
+            "organization_invites": invites,
+            "cases": [_serialize(c) for c in cases],
+            "case_events": case_events,
+            "case_notes": case_notes,
+            "documents": documents,
+            "agent_sessions": [_serialize(s) for s in sessions],
+            "agent_messages": agent_messages,
+            "case_drafts": [_serialize(d) for d in drafts],
+            "filing_attempts": filing_attempts,
+            "payment_intents": payment_intents,
+            "agent_uploads": agent_uploads,
+            "etorniegpt_chat_messages": chat_messages,
+            "in_app_notifications": in_app_notifications,
+            "notifications": notifications,
+            "proposals": proposals,
+            "audit_logs": audit_logs,
+            "braid_feedback_events": braid_feedback,
+        },
+    }

--- a/services/api/app/compliance/data_export_render.py
+++ b/services/api/app/compliance/data_export_render.py
@@ -1,0 +1,390 @@
+"""Render a GDPR data export (the dict from :mod:`data_export`) to a
+branded PDF, Word (DOCX), or Excel (XLSX) document.
+
+JSON stays the canonical, machine-readable Article-20 format; these
+renderers are the human-readable companions a user can hand to counsel
+or an accountant. They consume the very same ``build_user_export`` dict,
+so the three formats can never drift from the JSON.
+
+The export is a nested structure — a metadata header, a ``profile``
+key/value object, and a list of row-objects per domain table — so the
+renderers are generic: every section is drawn from the dict's shape
+rather than from hand-listed fields, which keeps them correct as new
+tables are added to the export.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+from typing import Any, Iterator
+from xml.sax.saxutils import escape as _xml_escape
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.utils import get_column_letter
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import mm
+from reportlab.platypus import (
+    Image as PdfImage,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+LOGO_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "assets", "etornie-logo.png")
+)
+ETORNIE_ACCENT_HEX = "2520FE"
+_ETORNIE_ACCENT = colors.HexColor(f"#{ETORNIE_ACCENT_HEX}")
+
+# Section keys whose Title-cased form would read wrong.
+_SECTION_LABELS = {
+    "etorniegpt_chat_messages": "EtornieGPT Chat Messages",
+    "in_app_notifications": "In-App Notifications",
+    "braid_feedback_events": "BRAID Feedback Events",
+}
+
+_NULL = "—"
+
+
+def _label(key: str) -> str:
+    return _SECTION_LABELS.get(key, key.replace("_", " ").title())
+
+
+def _cell(value: Any) -> str:
+    """Render one value as a flat string cell."""
+    if value is None:
+        return _NULL
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    # lists / dicts (e.g. JSONB columns) round-trip as compact JSON.
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _meta_rows(export: dict[str, Any]) -> list[tuple[str, str]]:
+    subject = export["subject"]
+    return [
+        ("Export format", _cell(export["export_format"])),
+        ("Export version", _cell(export["export_version"])),
+        ("GDPR basis", _cell(export["gdpr_basis"])),
+        ("Generated at", _cell(export["generated_at"])),
+        ("User ID", _cell(subject.get("user_id"))),
+        ("Email", _cell(subject.get("email"))),
+        ("Full name", _cell(subject.get("full_name"))),
+        ("Wallet address", _cell(subject.get("wallet_address"))),
+        ("Public handle", _cell(subject.get("public_handle"))),
+    ]
+
+
+def _profile_rows(profile: dict[str, Any]) -> list[tuple[str, str]]:
+    return [(_label(k), _cell(v)) for k, v in profile.items()]
+
+
+def _collection_sections(
+    export: dict[str, Any],
+) -> Iterator[tuple[str, list[dict[str, Any]]]]:
+    """Yield ``(label, rows)`` for every list-valued data section."""
+    for key, value in export["data"].items():
+        if isinstance(value, list):
+            yield _label(key), value
+
+
+def _union_keys(rows: list[dict[str, Any]]) -> list[str]:
+    """Column order = first-seen order across every row."""
+    keys: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for key in row:
+            if key not in seen:
+                seen.add(key)
+                keys.append(key)
+    return keys
+
+
+def _counts(export: dict[str, Any]) -> list[tuple[str, str]]:
+    return [
+        (_label(key), str(len(value)))
+        for key, value in export["data"].items()
+        if isinstance(value, list)
+    ]
+
+
+def _has_logo() -> bool:
+    return os.path.isfile(LOGO_PATH)
+
+
+# ---------------------------------------------------------------------------
+# PDF
+# ---------------------------------------------------------------------------
+
+
+def render_pdf(export: dict[str, Any]) -> bytes:
+    """Render the export as an A4 PDF — one key/value block per record."""
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        leftMargin=18 * mm,
+        rightMargin=18 * mm,
+        topMargin=18 * mm,
+        bottomMargin=18 * mm,
+        title="Etornie Personal Data Export",
+        author="Etornie",
+    )
+    styles = getSampleStyleSheet()
+    title_style = ParagraphStyle(
+        "Title_", parent=styles["Title"], fontSize=18, leading=22,
+        textColor=_ETORNIE_ACCENT, spaceAfter=4,
+    )
+    subtitle_style = ParagraphStyle(
+        "Subtitle_", parent=styles["Normal"], fontSize=9,
+        textColor=colors.grey, spaceAfter=12,
+    )
+    section_style = ParagraphStyle(
+        "Section_", parent=styles["Heading2"], fontSize=12,
+        textColor=_ETORNIE_ACCENT, spaceBefore=12, spaceAfter=6,
+    )
+    item_style = ParagraphStyle(
+        "Item_", parent=styles["Heading3"], fontSize=9,
+        textColor=colors.grey, spaceBefore=8, spaceAfter=2,
+    )
+    body = styles["BodyText"]
+
+    def kv_table(rows: list[tuple[str, str]]) -> Table:
+        # reportlab Paragraph parses a mini-HTML grammar, so any '<', '>'
+        # or '&' in the real data (chat text, JSON values, URLs) must be
+        # XML-escaped or the build raises a parse error.
+        data = [
+            [
+                Paragraph(f"<b>{_xml_escape(k)}</b>", body),
+                Paragraph(_xml_escape(v), body),
+            ]
+            for k, v in rows
+        ]
+        table = Table(data, colWidths=[55 * mm, None])
+        table.setStyle(
+            TableStyle(
+                [
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("ROWBACKGROUNDS", (0, 0), (-1, -1),
+                     [colors.whitesmoke, colors.white]),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                    ("TOPPADDING", (0, 0), (-1, -1), 3),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                    ("LINEBELOW", (0, 0), (-1, -1), 0.25, colors.lightgrey),
+                ]
+            )
+        )
+        return table
+
+    story: list[Any] = []
+    if _has_logo():
+        story.append(PdfImage(LOGO_PATH, width=22 * mm, height=22 * mm))
+        story.append(Spacer(1, 4))
+    story.append(Paragraph("Personal Data Export", title_style))
+    story.append(
+        Paragraph(
+            _xml_escape(
+                f"Generated {export['generated_at']} · {export['gdpr_basis']}"
+            ),
+            subtitle_style,
+        )
+    )
+
+    story.append(Paragraph("Export Details", section_style))
+    story.append(kv_table(_meta_rows(export)))
+    story.append(Paragraph("Record Counts", section_style))
+    story.append(kv_table(_counts(export)))
+
+    story.append(Paragraph("Profile", section_style))
+    story.append(kv_table(_profile_rows(export["data"]["profile"])))
+
+    # Collection records are rendered as flowable key/value paragraphs
+    # rather than table rows: a single record can carry a JSONB blob
+    # (tool results, gateway metadata) taller than a page, and a table
+    # row cannot split across pages whereas a paragraph can.
+    for label, rows in _collection_sections(export):
+        story.append(Paragraph(f"{label} ({len(rows)})", section_style))
+        if not rows:
+            story.append(Paragraph("No records.", body))
+            continue
+        for index, row in enumerate(rows, start=1):
+            story.append(Paragraph(f"#{index}", item_style))
+            for key, value in row.items():
+                story.append(
+                    Paragraph(
+                        f"<b>{_xml_escape(_label(key))}:</b> "
+                        f"{_xml_escape(_cell(value))}",
+                        body,
+                    )
+                )
+
+    doc.build(story)
+    return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# DOCX
+# ---------------------------------------------------------------------------
+
+
+def render_docx(export: dict[str, Any]) -> bytes:
+    """Render the export as a Word document — a section per data table."""
+    from docx import Document as DocxDocument
+    from docx.shared import Inches, Pt, RGBColor
+
+    accent = RGBColor(0x25, 0x20, 0xFE)
+    grey = RGBColor(0x6B, 0x72, 0x80)
+    document = DocxDocument()
+
+    if _has_logo():
+        document.add_picture(LOGO_PATH, width=Inches(0.9))
+
+    title = document.add_heading("Personal Data Export", level=0)
+    for run in title.runs:
+        run.font.color.rgb = accent
+    subtitle = document.add_paragraph(
+        f"Generated {export['generated_at']} · {export['gdpr_basis']}"
+    )
+    for run in subtitle.runs:
+        run.font.size = Pt(9)
+        run.font.color.rgb = grey
+
+    def kv_section(heading: str, rows: list[tuple[str, str]]) -> None:
+        head = document.add_heading(heading, level=1)
+        for run in head.runs:
+            run.font.color.rgb = accent
+        if not rows:
+            document.add_paragraph("No records.")
+            return
+        table = document.add_table(rows=len(rows), cols=2)
+        table.style = "Light List Accent 1"
+        for i, (key, value) in enumerate(rows):
+            cell_k, cell_v = table.cell(i, 0), table.cell(i, 1)
+            cell_k.text = key
+            cell_v.text = value
+            for paragraph in cell_k.paragraphs:
+                for run in paragraph.runs:
+                    run.bold = True
+
+    kv_section("Export Details", _meta_rows(export))
+    kv_section("Record Counts", _counts(export))
+    kv_section("Profile", _profile_rows(export["data"]["profile"]))
+
+    for label, rows in _collection_sections(export):
+        head = document.add_heading(f"{label} ({len(rows)})", level=1)
+        for run in head.runs:
+            run.font.color.rgb = accent
+        if not rows:
+            document.add_paragraph("No records.")
+            continue
+        for index, row in enumerate(rows, start=1):
+            sub = document.add_heading(f"#{index}", level=2)
+            for run in sub.runs:
+                run.font.color.rgb = grey
+            table = document.add_table(rows=len(row), cols=2)
+            table.style = "Light List Accent 1"
+            for i, (key, value) in enumerate(row.items()):
+                cell_k, cell_v = table.cell(i, 0), table.cell(i, 1)
+                cell_k.text = _label(key)
+                cell_v.text = _cell(value)
+                for paragraph in cell_k.paragraphs:
+                    for run in paragraph.runs:
+                        run.bold = True
+
+    buffer = io.BytesIO()
+    document.save(buffer)
+    return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# XLSX
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_sheet_title(title: str, used: set[str]) -> str:
+    """Excel sheet titles: ≤31 chars, none of ``[]:*?/\\``, unique."""
+    cleaned = title
+    for bad in "[]:*?/\\":
+        cleaned = cleaned.replace(bad, " ")
+    cleaned = cleaned.strip()[:31] or "Sheet"
+    candidate = cleaned
+    suffix = 2
+    while candidate.lower() in used:
+        tail = f" {suffix}"
+        candidate = cleaned[: 31 - len(tail)] + tail
+        suffix += 1
+    used.add(candidate.lower())
+    return candidate
+
+
+def render_xlsx(export: dict[str, Any]) -> bytes:
+    """Render the export as a workbook — one sheet per data table."""
+    workbook = Workbook()
+    accent_fill = PatternFill(
+        start_color=ETORNIE_ACCENT_HEX,
+        end_color=ETORNIE_ACCENT_HEX,
+        fill_type="solid",
+    )
+    header_font = Font(color="FFFFFF", bold=True)
+    label_font = Font(bold=True)
+    used_titles: set[str] = set()
+
+    def kv_sheet(title: str, rows: list[tuple[str, str]]) -> None:
+        sheet = workbook.create_sheet(_sanitize_sheet_title(title, used_titles))
+        sheet["A1"], sheet["B1"] = "Field", "Value"
+        for col in ("A1", "B1"):
+            sheet[col].fill = accent_fill
+            sheet[col].font = header_font
+        for i, (key, value) in enumerate(rows, start=2):
+            sheet.cell(row=i, column=1, value=key).font = label_font
+            sheet.cell(row=i, column=2, value=value).alignment = Alignment(
+                wrap_text=True, vertical="top"
+            )
+        sheet.column_dimensions[get_column_letter(1)].width = 30
+        sheet.column_dimensions[get_column_letter(2)].width = 80
+
+    # First (default) sheet holds the export metadata + record counts.
+    overview = workbook.active
+    overview.title = "Export Details"
+    overview["A1"], overview["B1"] = "Field", "Value"
+    for col in ("A1", "B1"):
+        overview[col].fill = accent_fill
+        overview[col].font = header_font
+    row_cursor = 2
+    for key, value in _meta_rows(export) + [("", "")] + _counts(export):
+        overview.cell(row=row_cursor, column=1, value=key).font = label_font
+        overview.cell(row=row_cursor, column=2, value=value)
+        row_cursor += 1
+    overview.column_dimensions[get_column_letter(1)].width = 30
+    overview.column_dimensions[get_column_letter(2)].width = 80
+
+    kv_sheet("Profile", _profile_rows(export["data"]["profile"]))
+
+    for label, rows in _collection_sections(export):
+        sheet = workbook.create_sheet(_sanitize_sheet_title(label, used_titles))
+        if not rows:
+            sheet["A1"] = "No records."
+            continue
+        columns = _union_keys(rows)
+        for col, key in enumerate(columns, start=1):
+            cell = sheet.cell(row=1, column=col, value=_label(key))
+            cell.fill = accent_fill
+            cell.font = header_font
+        for i, row in enumerate(rows, start=2):
+            for col, key in enumerate(columns, start=1):
+                sheet.cell(row=i, column=col, value=_cell(row.get(key)))
+        for col in range(1, len(columns) + 1):
+            sheet.column_dimensions[get_column_letter(col)].width = 28
+
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    return buffer.getvalue()

--- a/services/api/app/users/router.py
+++ b/services/api/app/users/router.py
@@ -1,3 +1,4 @@
+import json
 import os
 import uuid
 from typing import Any
@@ -16,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.dependencies import get_current_user, require_role
 from app.cases.models import Case
+from app.compliance.data_export import build_user_export
 from app.config import settings
 from app.database import get_db
 from app.services.ukipo.models import UKIPOSubmission
@@ -230,6 +232,65 @@ async def get_my_timeline(
         "count": len(items),
         "items": items,
     }
+
+
+_DATA_EXPORT_FORMATS = {
+    "json": ("application/json", "json"),
+    "pdf": ("application/pdf", "pdf"),
+    "docx": (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "docx",
+    ),
+    "xlsx": (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "xlsx",
+    ),
+}
+
+
+@router.get("/me/export")
+async def export_my_data(
+    format: str = Query("json", pattern="^(json|pdf|docx|xlsx)$"),
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Response:
+    """Export all personal data of the authenticated user (GDPR Art. 20).
+
+    JSON is the canonical structured, machine-readable format the right
+    to data portability requires; ``format=pdf|docx|xlsx`` returns the
+    same data as a branded human-readable document. The caller can only
+    export their own data — the bearer token identifies the subject, so
+    there is no user-id path parameter to authorise against.
+    """
+    payload = await build_user_export(db, current_user)
+    media_type, ext = _DATA_EXPORT_FORMATS[format]
+    filename = f"etornie-data-export-{current_user.id}.{ext}"
+
+    if format == "json":
+        body: bytes | str = json.dumps(payload, ensure_ascii=False, indent=2)
+    else:
+        # Heavy rendering deps (reportlab, python-docx, openpyxl) are
+        # imported lazily so the users module stays cheap to import.
+        from app.compliance.data_export_render import (
+            render_docx,
+            render_pdf,
+            render_xlsx,
+        )
+
+        if format == "pdf":
+            body = render_pdf(payload)
+        elif format == "docx":
+            body = render_docx(payload)
+        else:
+            body = render_xlsx(payload)
+
+    return Response(
+        content=body,
+        media_type=media_type,
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )
 
 
 @router.get("", response_model=UserListResponse)

--- a/services/api/tests/test_data_export.py
+++ b/services/api/tests/test_data_export.py
@@ -1,0 +1,312 @@
+"""Tests for GDPR Article 20 data export (GET /users/me/export).
+
+Exercises the real read path against the in-memory SQLite test DB with
+real rows inserted through the ORM — no mocks, no stubs. Verifies the
+export is scoped to the authenticated subject, includes related rows
+reached through parent tables, and never leaks credentials.
+"""
+import json
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agent.models import AgentMessage, AgentMessageRole, AgentSession
+from app.audit.models import AuditAction, AuditLog
+from app.cases.service import create_case
+from app.etorniegpt.models import ChatMessage
+from app.in_app_notifications.models import (
+    InAppNotification,
+    InAppNotificationType,
+)
+from app.compliance.data_export_render import render_pdf
+from app.users.models import User
+from tests.conftest import auth_headers
+
+
+async def _seed_user_data(db: AsyncSession, user: User) -> dict[str, str]:
+    """Insert one real row per representative table owned by ``user``.
+
+    Returns the identifiers the assertions look for so the test does not
+    depend on field ordering.
+    """
+    case = await create_case(
+        db,
+        title="My Trademark",
+        # Special characters (< > &) exercise the PDF renderer's XML
+        # escaping — reportlab parses Paragraph text as mini-HTML.
+        description="Owned by <subject> & protected in classes 9 > 35",
+        case_type="trademark",
+        client_id=user.id,
+        jurisdiction="Switzerland",
+    )
+
+    chat = ChatMessage(
+        user_id=user.id,
+        question="How long does an EUIPO trademark take?",
+        answer="Compare A&B <fast> vs slow > average; depends on oppositions.",
+        model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    )
+    db.add(chat)
+
+    session = AgentSession(
+        user_id=user.id,
+        title="Filing assistant",
+        model="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    )
+    db.add(session)
+    await db.flush()
+
+    message = AgentMessage(
+        session_id=session.id,
+        role=AgentMessageRole.user,
+        content="I want to register a logo.",
+    )
+    db.add(message)
+
+    notification = InAppNotification(
+        recipient_id=user.id,
+        notification_type=InAppNotificationType.case_created,
+        title="Case created",
+        message="Your case My Trademark was created.",
+        case_id=case.id,
+    )
+    db.add(notification)
+
+    audit = AuditLog(
+        actor_id=user.id,
+        action=AuditAction.note_cancelled,
+        target_type="case_note",
+        target_id=uuid.uuid4(),
+        case_id=case.id,
+        details="cancelled a note",
+    )
+    db.add(audit)
+
+    await db.flush()
+    return {
+        "case_id": str(case.id),
+        "session_id": str(session.id),
+        "message_content": message.content,
+        "chat_question": chat.question,
+    }
+
+
+class TestDataExportAuth:
+    async def test_export_requires_authentication(
+        self, client: AsyncClient
+    ) -> None:
+        response = await client.get("/users/me/export")
+        assert response.status_code == 401
+
+
+class TestDataExportShape:
+    async def test_export_returns_json_attachment(
+        self, client: AsyncClient, client_user: User
+    ) -> None:
+        response = await client.get(
+            "/users/me/export", headers=auth_headers(client_user)
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
+        disposition = response.headers["content-disposition"]
+        assert "attachment" in disposition
+        assert f"etornie-data-export-{client_user.id}.json" in disposition
+
+        payload = response.json()
+        assert payload["export_format"] == "etornie-gdpr-data-export"
+        assert "Article 20" in payload["gdpr_basis"]
+        assert payload["generated_at"]
+        assert payload["subject"]["user_id"] == str(client_user.id)
+        assert payload["subject"]["email"] == client_user.email
+        # Empty account: every collection present and empty-shaped.
+        assert payload["data"]["cases"] == []
+        assert payload["data"]["agent_messages"] == []
+
+    async def test_export_never_leaks_password_hash(
+        self, client: AsyncClient, client_user: User
+    ) -> None:
+        response = await client.get(
+            "/users/me/export", headers=auth_headers(client_user)
+        )
+        assert response.status_code == 200
+        profile = response.json()["data"]["profile"]
+        assert profile["id"] == str(client_user.id)
+        assert "hashed_password" not in profile
+        # And it must not leak anywhere else in the document either.
+        assert "hashed_password" not in response.text
+
+
+class TestDataExportContent:
+    async def test_export_includes_owned_rows(
+        self,
+        client: AsyncClient,
+        client_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        seeded = await _seed_user_data(db_session, client_user)
+
+        response = await client.get(
+            "/users/me/export", headers=auth_headers(client_user)
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+
+        assert {c["id"] for c in data["cases"]} == {seeded["case_id"]}
+        assert data["cases"][0]["title"] == "My Trademark"
+
+        assert {m["question"] for m in data["etorniegpt_chat_messages"]} == {
+            seeded["chat_question"]
+        }
+
+        # Child row reached only through the subject's agent session.
+        assert {s["id"] for s in data["agent_sessions"]} == {
+            seeded["session_id"]
+        }
+        assert {m["content"] for m in data["agent_messages"]} == {
+            seeded["message_content"]
+        }
+
+        assert len(data["in_app_notifications"]) == 1
+        assert data["in_app_notifications"][0]["title"] == "Case created"
+
+        assert len(data["audit_logs"]) == 1
+        assert data["audit_logs"][0]["action"] == "note_cancelled"
+
+class TestDataExportFormats:
+    async def test_invalid_format_is_rejected(
+        self, client: AsyncClient, client_user: User
+    ) -> None:
+        response = await client.get(
+            "/users/me/export",
+            params={"format": "csv"},
+            headers=auth_headers(client_user),
+        )
+        assert response.status_code == 422
+
+    async def test_pdf_export(
+        self,
+        client: AsyncClient,
+        client_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        await _seed_user_data(db_session, client_user)
+        response = await client.get(
+            "/users/me/export",
+            params={"format": "pdf"},
+            headers=auth_headers(client_user),
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/pdf"
+        assert ".pdf" in response.headers["content-disposition"]
+        # Valid PDF files start with the %PDF magic header.
+        assert response.content[:4] == b"%PDF"
+
+    async def test_docx_export(
+        self,
+        client: AsyncClient,
+        client_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        await _seed_user_data(db_session, client_user)
+        response = await client.get(
+            "/users/me/export",
+            params={"format": "docx"},
+            headers=auth_headers(client_user),
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"] == (
+            "application/vnd.openxmlformats-officedocument"
+            ".wordprocessingml.document"
+        )
+        # DOCX/XLSX are ZIP containers — they start with the PK magic.
+        assert response.content[:2] == b"PK"
+
+    async def test_xlsx_export(
+        self,
+        client: AsyncClient,
+        client_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        await _seed_user_data(db_session, client_user)
+        response = await client.get(
+            "/users/me/export",
+            params={"format": "xlsx"},
+            headers=auth_headers(client_user),
+        )
+        assert response.status_code == 200
+        assert response.headers["content-type"] == (
+            "application/vnd.openxmlformats-officedocument"
+            ".spreadsheetml.sheet"
+        )
+        assert response.content[:2] == b"PK"
+
+    def test_pdf_renders_record_taller_than_a_page(self) -> None:
+        # A single agent-message tool_result can be a JSONB blob taller
+        # than a PDF page. Table rows cannot split across pages, so the
+        # renderer must flow such records as paragraphs instead.
+        huge_value = " ".join(f"token{i}" for i in range(4000))
+        export = {
+            "export_format": "etornie-gdpr-data-export",
+            "export_version": "1",
+            "gdpr_basis": "Article 20",
+            "generated_at": "2026-06-01T00:00:00+00:00",
+            "subject": {
+                "user_id": "u1",
+                "email": "a@b.com",
+                "full_name": "X",
+                "wallet_address": None,
+                "public_handle": None,
+            },
+            "data": {
+                "profile": {"id": "u1", "full_name": "X"},
+                "agent_messages": [
+                    {"id": "m1", "tool_result": {"text": huge_value}}
+                ],
+            },
+        }
+        pdf = render_pdf(export)
+        assert pdf[:4] == b"%PDF"
+
+    async def test_empty_account_renders_every_format(
+        self, client: AsyncClient, client_user: User
+    ) -> None:
+        # No seeded data: renderers must still produce valid files.
+        for fmt, magic in (("pdf", b"%PDF"), ("docx", b"PK"), ("xlsx", b"PK")):
+            response = await client.get(
+                "/users/me/export",
+                params={"format": fmt},
+                headers=auth_headers(client_user),
+            )
+            assert response.status_code == 200, fmt
+            assert response.content[: len(magic)] == magic, fmt
+
+
+class TestDataExportScope:
+    async def test_export_is_scoped_to_subject(
+        self,
+        client: AsyncClient,
+        client_user: User,
+        second_lawyer_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        # client_user owns data; second_lawyer_user (a different client)
+        # must not see any of it in their own export.
+        seeded = await _seed_user_data(db_session, client_user)
+
+        response = await client.get(
+            "/users/me/export", headers=auth_headers(second_lawyer_user)
+        )
+        assert response.status_code == 200
+        data = response.json()["data"]
+
+        assert data["cases"] == []
+        assert data["etorniegpt_chat_messages"] == []
+        assert data["agent_sessions"] == []
+        assert data["agent_messages"] == []
+        assert data["in_app_notifications"] == []
+        assert data["audit_logs"] == []
+        # Sanity: the other user's identifiers appear nowhere.
+        assert seeded["case_id"] not in response.text
+        assert seeded["session_id"] not in response.text


### PR DESCRIPTION
Closes #60.

## What
Adds `GET /users/me/export` returning all personal data of the authenticated user as a downloadable file. JSON is the canonical machine-readable Article 20 format; `pdf`/`docx`/`xlsx` render the same data as branded human-readable documents.

## Changes
- **`data_export.py`** — `build_user_export` collects every user-scoped row across 19 tables via SQLAlchemy schema introspection. Withholds credentials (`hashed_password`) and deferred binary columns (avatar bytes); never triggers async lazy-loads.
- **`data_export_render.py`** — generic PDF/DOCX/XLSX renderers driven by the export's shape. PDF flows records as splittable paragraphs (a single JSONB blob can exceed a page) and XML-escapes all text; XLSX writes one sheet per table.
- **`users/router.py`** — `/me/export?format=json|pdf|docx|xlsx`, scoped to the bearer-token subject only (no cross-user access).
- **dashboard profile page** — "Your data" section with JSON / PDF / Word / Excel download buttons.

## Tests
11 tests (`tests/test_data_export.py`), real rows against the test DB, no mocks:
- auth required (401), invalid format rejected (422)
- each format renders (PDF `%PDF`, docx/xlsx `PK` magic bytes), empty account still renders
- `hashed_password` never leaks
- export scoped to the subject (another user sees none of it)
- oversized record (JSONB blob taller than a page) renders without `LayoutError`

## Verified
All 9 real users render every format locally; tested end-to-end via the dashboard.