### PR TITLE
chore: lansman öncesi sağlamlaştırma — pre-commit, IDL, SMTP, ClamAV (#49, #18, #29, #55, #51, #19, #118)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,12 +32,19 @@ WHATSAPP_API_TOKEN=
 WHATSAPP_PHONE_NUMBER_ID=
 WHATSAPP_BUSINESS_ACCOUNT_ID=
 
-# EmailJS
-EMAILJS_PUBLIC_KEY=
-EMAILJS_PRIVATE_KEY=
-EMAILJS_SERVICE_ID=
-EMAILJS_TEMPLATE_ID=
-EMAILJS_CASE_TEMPLATE_ID=
+# Email (SMTP) — server-side transactional mail (registration OTP, case +
+# payment notifications). Works with any relay: Amazon SES, Postmark,
+# Mailgun, Gmail, etc. Leave SMTP_HOST empty to disable email in local dev.
+# Deliverability (SPF/DKIM/DMARC): see docs/EMAIL_DELIVERABILITY.md.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+# Port 587 = STARTTLS (default). For port 465 (implicit TLS) set SMTP_USE_TLS=true.
+SMTP_STARTTLS=true
+SMTP_USE_TLS=false
+SMTP_FROM_EMAIL=
+SMTP_FROM_NAME=Etornie
 
 # Groq (optional - Together AI is primary for EtornieGPT)
 GROQ_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,15 @@ SMTP_USE_TLS=false
 SMTP_FROM_EMAIL=
 SMTP_FROM_NAME=Etornie
 
+# ClamAV malware scanning for uploads (#55). Disabled by default. Set
+# CLAMAV_ENABLED=true to scan. Use CLAMAV_HOST=clamav inside docker compose,
+# or localhost when the backend runs outside compose against the published
+# 3310 port. An enabled-but-unreachable daemon fails CLOSED (upload rejected).
+CLAMAV_ENABLED=false
+CLAMAV_HOST=localhost
+CLAMAV_PORT=3310
+CLAMAV_TIMEOUT=30
+
 # Groq (optional - Together AI is primary for EtornieGPT)
 GROQ_API_KEY=
 GROQ_MODEL=llama-3.3-70b-versatile

--- a/.env.example
+++ b/.env.example
@@ -141,3 +141,12 @@ OTEL_EXPORTER_OTLP_ENDPOINT=
 OTEL_SERVICE_NAME=etornie-api
 OTEL_CONSOLE_EXPORT=false
 OTEL_TRACES_SAMPLE_RATE=1.0
+
+# Helius webhook for on-chain state reconciliation (#19). The
+# /solana/webhooks/helius endpoint is fail-closed: it stays disabled until
+# HELIUS_WEBHOOK_AUTH is set (the shared secret Helius sends as its
+# Authorization header). HELIUS_API_KEY + HELIUS_WEBHOOK_URL are used by
+# services/api/scripts/register_helius_webhook.py. See docs/HELIUS_WEBHOOK.md.
+HELIUS_WEBHOOK_AUTH=
+HELIUS_API_KEY=
+HELIUS_WEBHOOK_URL=

--- a/.env.example
+++ b/.env.example
@@ -125,3 +125,19 @@ NEXT_PUBLIC_SENTRY_DSN=
 ENVIRONMENT=development
 SENTRY_TRACES_SAMPLE_RATE=0.1
 SENTRY_PROFILES_SAMPLE_RATE=0.0
+
+# Structured logging (#51). LOG_FORMAT=console for human-readable local dev,
+# json for production (JSON lines carrying trace_id/span_id + request_id).
+# LOG_LEVEL applies to the app + uvicorn loggers.
+LOG_FORMAT=console
+LOG_LEVEL=INFO
+
+# OpenTelemetry tracing (#51). Disabled by default (real no-op). Set
+# OTEL_ENABLED=true and point OTEL_EXPORTER_OTLP_ENDPOINT at a collector
+# (e.g. http://localhost:4318) to export traces; OTEL_CONSOLE_EXPORT=true also
+# prints spans to stdout. See docs/OBSERVABILITY.md.
+OTEL_ENABLED=false
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_SERVICE_NAME=etornie-api
+OTEL_CONSOLE_EXPORT=false
+OTEL_TRACES_SAMPLE_RATE=1.0

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -36,7 +36,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SOLANA_VERSION: "3.0.15"
+  # Valid Agave release on release.anza.xyz. The previous "3.0.15" did not
+  # exist, so the install step 404'd and every later step hit
+  # `solana: command not found`. Matches the toolchain used in local dev.
+  SOLANA_VERSION: "2.2.3"
   ANCHOR_VERSION: "0.31.1"
   RUST_TOOLCHAIN: "1.85.0"
 
@@ -73,7 +76,11 @@ jobs:
 
       - name: Install Anchor ${{ env.ANCHOR_VERSION }} via avm
         run: |
-          cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
+          # Pin avm to the v${ANCHOR_VERSION} tag. Building it from the repo's
+          # main branch pulls deps that now require rustc >= 1.86/1.91, which
+          # fails against the 1.85 toolchain the SBF build (platform-tools
+          # v1.54) needs.
+          cargo install --git https://github.com/coral-xyz/anchor --tag v${ANCHOR_VERSION} avm --locked --force
           avm install ${ANCHOR_VERSION}
           avm use ${ANCHOR_VERSION}
           anchor --version

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,10 @@ dashboard/.env.local
 .pytest_cache/
 htmlcov/
 
+# Lint / type-check caches (#49 pre-commit hooks)
+.ruff_cache/
+.mypy_cache/
+
 # Anchor / Rust
 .anchor/
 target/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,6 +17,13 @@ paths = [
   '''tests/zk_fixtures/.*''',
   '''.*\.example$''',
   '''.*\.env\.example$''',
+  # Public Groth16 verifying keys — cryptographic *public* data, not secrets.
+  # The generic-api-key / high-entropy rules trip on their long byte arrays.
+  # The vk_*.rs glob covers vk_compliance.rs + vk_file_ownership.rs (and any
+  # future verifying-key module).
+  '''programs/etornie-zk-verifier/src/groth16_vk\.rs''',
+  '''programs/etornie-zk-verifier/src/vk_.*\.rs''',
+  '''scripts/extract_vk\.js''',
 ]
 
 # Literal strings that appear in tests and docs but are not real secrets.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,115 @@
+# Pre-commit hooks for etornie-solana — local hygiene before push (#49).
+#
+# One-time setup:
+#   pipx install pre-commit            # or: pip install pre-commit
+#   pre-commit install                 # installs the git hook
+#
+# Run against everything (first adoption / CI):
+#   pre-commit run --all-files
+#
+# By design pre-commit only checks STAGED files, so the historical
+# backlog in files a commit does not touch never blocks the commit —
+# linting is adopted incrementally, file by file.
+#
+# Tool → scope mapping:
+#   ruff / ruff-format → services/api      (Python lint + format)
+#   mypy               → services/api      (Python types; needs the backend dev env)
+#   eslint             → dashboard         (same command CI runs: `npm run lint`)
+#   prettier           → tests/ scripts/ migrations/ (Anchor + ZK TypeScript)
+#
+# `mypy`, `eslint` and `prettier` run through the project's own toolchains,
+# so they require the matching deps to be installed (see README → Pre-commit).
+
+minimum_pre_commit_version: "3.5.0"
+
+# Generated / vendored trees never get hooked.
+exclude: |
+  (?x)^(
+    idl/.*|
+    .*/?(yarn\.lock|Cargo\.lock|package-lock\.json)|
+    (.*/)?target/.*|
+    (.*/)?\.anchor/.*|
+    (.*/)?node_modules/.*|
+    (.*/)?\.next/.*|
+    (.*/)?\.mypy_cache/.*|
+    circuits/.*\.(zkey|r1cs|wasm|sym|ptau)|
+    (.*/)?build/.*
+  )$
+
+repos:
+  # ---------------------------------------------------------------- hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+        # tsconfig files are JSONC (comments / trailing commas) in this repo.
+        exclude: (?i)(^|/)tsconfig.*\.json$
+
+  # ----------------------------------------------------------- python: ruff
+  # Isolated, pinned — works without the backend venv. Config is read from
+  # services/api/pyproject.toml (ruff walks up from each file).
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        name: ruff (lint, --fix)
+        args: [--fix]
+        files: ^services/api/.*\.py$
+      - id: ruff-format
+        name: ruff (format)
+        files: ^services/api/.*\.py$
+
+  # ----------------------------------------------------------- python: mypy
+  # Runs from services/api so the `app` package + [tool.mypy] config resolve
+  # cleanly, and types are checked against the real installed deps (incl. the
+  # pydantic plugin). Requires the backend dev env on PATH (mypy installed via
+  # `pip install -e ".[dev]"`); see README → Pre-commit.
+  #
+  # The `services/api/` prefix is stripped off each staged path so mypy sees
+  # `app/...`, and only staged files are checked. Paired with
+  # follow_imports=silent (pyproject) this keeps errors scoped to the files a
+  # commit actually touches, so the historical backlog never blocks an
+  # unrelated commit.
+  - repo: local
+    hooks:
+      - id: mypy-api
+        name: mypy (services/api)
+        language: system
+        entry: bash -c 'cd services/api && exec mypy "${@#services/api/}"' --
+        files: ^services/api/.*\.py$
+        require_serial: true
+
+  # ------------------------------------------------------- frontend: eslint
+  # Mirrors CI exactly (`npm run lint`). Lints the whole dashboard project so
+  # eslint-config-next resolves the Next root the same way it does in CI.
+  - repo: local
+    hooks:
+      - id: eslint-dashboard
+        name: eslint (dashboard)
+        language: system
+        entry: bash -c 'cd dashboard && npm run --silent lint'
+        pass_filenames: false
+        files: ^dashboard/.*\.(ts|tsx|js|jsx|mjs|cjs)$
+        require_serial: true
+
+  # --------------------------------------------------- root TS/JS: prettier
+  # Uses the repo's own pinned prettier (v2) so formatting matches `yarn lint`
+  # exactly — no version drift. Honours .prettierignore automatically.
+  - repo: local
+    hooks:
+      - id: prettier-anchor-ts
+        name: prettier (anchor/zk ts + js)
+        language: system
+        entry: npx --no-install prettier --write
+        files: ^(tests|scripts|migrations)/.*\.(ts|js)$

--- a/README.md
+++ b/README.md
@@ -309,6 +309,13 @@ Observability (#51):
   FastAPI / SQLAlchemy / httpx / Redis (disabled by default). See
   [`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md).
 
+On-chain reconciliation (#19):
+- `HELIUS_WEBHOOK_AUTH`, `HELIUS_API_KEY`, `HELIUS_WEBHOOK_URL` — Helius pushes
+  transactions touching the 3 program IDs to `/solana/webhooks/helius`, which
+  decodes the Anchor events and reconciles DB rows against the chain
+  (fail-closed; disabled until the auth secret is set). See
+  [`docs/HELIUS_WEBHOOK.md`](docs/HELIUS_WEBHOOK.md).
+
 Public-facing URL (used by NFT metadata so wallets fetch the right
 host):
 - `API_PUBLIC_URL=http://localhost:8000` (set to a tunnel for

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Tailwind v4; Solana devnet for everything that touches a key.
 | Payments         | x402 over Solana (SOL transfer + memo binding to Groth16 commitment) |
 | Documents        | PyMuPDF, ReportLab, python-docx, openpyxl     |
 | WhatsApp         | WhatsApp Business Cloud API (Meta)            |
-| Email            | EmailJS (OTP verification + case alerts)      |
+| Email            | SMTP via aiosmtplib (SES / Postmark / any relay) |
 | Containerization | Docker, Docker Compose                        |
 
 ## Features
@@ -41,7 +41,7 @@ Tailwind v4; Solana devnet for everything that touches a key.
 - JWT access + refresh token pair
 - Two roles: **admin** and **client** (lawyer role retired —
   [`docs/REMOVED_LAWYER_LAYER.md`](docs/REMOVED_LAWYER_LAYER.md))
-- Email + password registration with EmailJS-delivered OTP
+- Email + password registration with server-side SMTP-delivered OTP
 - Solana wallet sign-in (Phantom / Solflare) — ed25519 nonce challenge
   with Redis-backed single-use nonces, public handles `etornie_<8>`
 - Wallet sign-up restricted to `client` (admin cannot self-elevate)
@@ -149,7 +149,7 @@ and the agent's pay button glue lives in
 
 ### Notifications
 - WhatsApp Business Cloud API (Meta) for case + filing alerts
-- EmailJS for OTP + case-creation notices
+- Server-side SMTP (aiosmtplib) for OTP + case-creation notices
 - Scheduled notifications with retry logic
 
 ## Quick Start
@@ -290,9 +290,10 @@ EUIPO API (sandbox by default — see [Sandbox env docs](https://dev-sandbox.eui
 Notifications:
 - `WHATSAPP_API_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`,
   `WHATSAPP_BUSINESS_ACCOUNT_ID`
-- `EMAILJS_PUBLIC_KEY`, `EMAILJS_PRIVATE_KEY`,
-  `EMAILJS_SERVICE_ID`, `EMAILJS_TEMPLATE_ID`,
-  `EMAILJS_CASE_TEMPLATE_ID`
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`,
+  `SMTP_STARTTLS`, `SMTP_USE_TLS`, `SMTP_FROM_EMAIL`, `SMTP_FROM_NAME`
+  — see [`docs/EMAIL_DELIVERABILITY.md`](docs/EMAIL_DELIVERABILITY.md) for
+  the SPF / DKIM / DMARC records
 
 Public-facing URL (used by NFT metadata so wallets fetch the right
 host):

--- a/README.md
+++ b/README.md
@@ -300,6 +300,15 @@ Uploads / security:
   malware scan on every upload (#55). Disabled by default; when enabled an
   unreachable daemon fails closed. The `clamav` compose service provides it.
 
+Observability (#51):
+- `LOG_FORMAT` (`json` | `console`), `LOG_LEVEL` — structured logging; JSON
+  lines carry `trace_id` / `span_id` + `request_id`.
+- `SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE` — error tracking (empty disables it).
+- `OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`,
+  `OTEL_CONSOLE_EXPORT`, `OTEL_TRACES_SAMPLE_RATE` — OpenTelemetry traces across
+  FastAPI / SQLAlchemy / httpx / Redis (disabled by default). See
+  [`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md).
+
 Public-facing URL (used by NFT metadata so wallets fetch the right
 host):
 - `API_PUBLIC_URL=http://localhost:8000` (set to a tunnel for

--- a/README.md
+++ b/README.md
@@ -295,6 +295,11 @@ Notifications:
   — see [`docs/EMAIL_DELIVERABILITY.md`](docs/EMAIL_DELIVERABILITY.md) for
   the SPF / DKIM / DMARC records
 
+Uploads / security:
+- `CLAMAV_ENABLED`, `CLAMAV_HOST`, `CLAMAV_PORT`, `CLAMAV_TIMEOUT` — ClamAV
+  malware scan on every upload (#55). Disabled by default; when enabled an
+  unreachable daemon fails closed. The `clamav` compose service provides it.
+
 Public-facing URL (used by NFT metadata so wallets fetch the right
 host):
 - `API_PUBLIC_URL=http://localhost:8000` (set to a tunnel for
@@ -310,6 +315,7 @@ ports are namespaced so the stack can run alongside the original
 |---------|-----------|----------------|
 | `etornie-solana-db` | 5433 | 5432 |
 | `etornie-solana-redis` | 6380 | 6379 |
+| `etornie-solana-clamav` | 3310 | 3310 |
 | `etornie-solana-app` | 8001 | 8000 |
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -195,6 +195,33 @@ sed -i '' "s|^API_PUBLIC_URL=.*$|API_PUBLIC_URL=<the-ngrok-url>|" services/api/.
 # restart the backend
 ```
 
+### Pre-commit hooks
+Local lint / format / type-check before every commit
+([`.pre-commit-config.yaml`](.pre-commit-config.yaml)): **ruff** (Python
+lint + format) and **mypy** on `services/api`, **eslint** on the
+dashboard (the same `npm run lint` CI runs), **prettier** on the Anchor /
+ZK TypeScript under `tests/`, `scripts/`, `migrations/`, plus generic
+whitespace / YAML / JSON hygiene.
+
+```bash
+pipx install pre-commit   # or: pip install pre-commit
+pre-commit install        # run from the repo root — installs the git hook
+```
+
+Hooks only check **staged** files, so the existing backlog never blocks a
+commit — linting is adopted file by file. To sweep the whole repo (e.g.
+in CI): `pre-commit run --all-files`.
+
+The `ruff` hook is self-contained, but the others use the project's own
+toolchains, so install those first:
+- **mypy** → backend dev env on `PATH` (`pip install -e ".[dev]"`, venv active)
+- **eslint** → `cd dashboard && npm ci`
+- **prettier** → root `yarn install`
+
+mypy is intentionally lenient for now (see the `[tool.mypy]` block in
+[`services/api/pyproject.toml`](services/api/pyproject.toml)); tighten it
+as the codebase gets annotated.
+
 ## Frontend Pages
 
 | Route                       | Access | Purpose                                          |

--- a/dashboard/src/app/docs/page.tsx
+++ b/dashboard/src/app/docs/page.tsx
@@ -178,7 +178,7 @@ export default function DocsPage() {
               <ol className="list-decimal space-y-1.5 pl-5 text-[color:var(--color-ink)]">
                 <li>
                   Request a verification code on the register page. A six
-                  digit OTP is emailed through EmailJS.
+                  digit OTP is emailed from the server over SMTP.
                 </li>
                 <li>
                   Confirm the code to complete registration. An access token
@@ -299,8 +299,8 @@ export default function DocsPage() {
                   text messages with scheduling and retry.
                 </li>
                 <li>
-                  <strong>Email (EmailJS):</strong> OTP verification and case
-                  creation alerts.
+                  <strong>Email (server-side SMTP):</strong> OTP verification
+                  and case creation alerts.
                 </li>
                 <li>
                   <strong>In-app bell:</strong> real-time portal notifications
@@ -412,7 +412,7 @@ export default function DocsPage() {
                   ["Auth", "JWT, python-jose, passlib, bcrypt"],
                   ["LLM", "Groq Llama 3.3 70B"],
                   ["Embeddings", "Together AI multilingual-e5-large"],
-                  ["Messaging", "WhatsApp Business Cloud, EmailJS"],
+                  ["Messaging", "WhatsApp Business Cloud, SMTP email"],
                   ["Blockchain", "Solana (devnet — case attestations, soul-bound NFTs, ZK file-ownership proofs)"],
                 ].map(([k, v]) => (
                   <div

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,24 @@ services:
       timeout: 5s
       retries: 5
 
+  # Malware scanning for untrusted uploads (#55). The first start downloads
+  # the virus database (~200 MB) and can take a couple of minutes to become
+  # healthy — hence the long start_period. The backend connects to it when
+  # CLAMAV_ENABLED=true (host `clamav` inside the compose network).
+  etornie-solana-clamav:
+    image: clamav/clamav:latest
+    container_name: etornie-solana-clamav
+    ports:
+      - "3310:3310"
+    volumes:
+      - etornie_solana_clamavdb:/var/lib/clamav
+    healthcheck:
+      test: ["CMD", "clamdcheck.sh"]
+      interval: 30s
+      timeout: 10s
+      retries: 6
+      start_period: 180s
+
   etornie-solana-app:
     build:
       context: .
@@ -45,9 +63,12 @@ services:
         condition: service_healthy
       etornie-solana-redis:
         condition: service_healthy
+      etornie-solana-clamav:
+        condition: service_healthy
     volumes:
       - ./services/api/uploads:/app/uploads
 
 volumes:
   etornie_solana_pgdata:
   etornie_solana_redisdata:
+  etornie_solana_clamavdb:

--- a/docs/EMAIL_DELIVERABILITY.md
+++ b/docs/EMAIL_DELIVERABILITY.md
@@ -1,0 +1,105 @@
+# Email deliverability (SPF / DKIM / DMARC)
+
+Etornie sends transactional email — the registration OTP and case /
+payment / filing / NFT notifications — server-side over SMTP
+(`app/notifications/email_transport.py`, introduced in #29, replacing the
+old EmailJS front-end key flow).
+
+SMTP only moves the message to a relay. Whether it lands in the inbox
+instead of spam — or is accepted at all — depends on three DNS records
+on the **From** domain (`SMTP_FROM_EMAIL`). Configure all three before
+sending production mail.
+
+## 1. SMTP configuration
+
+Set these on the backend (`services/api/.env`; see `.env.example`):
+
+| Variable          | Example                          | Notes |
+|-------------------|----------------------------------|-------|
+| `SMTP_HOST`       | `email-smtp.eu-central-1.amazonaws.com` | Empty disables email (local dev). |
+| `SMTP_PORT`       | `587`                            | `587` = STARTTLS, `465` = implicit TLS. |
+| `SMTP_USERNAME`   | SES SMTP user / API key id       | |
+| `SMTP_PASSWORD`   | SES SMTP password / API key      | Secret — never commit. |
+| `SMTP_STARTTLS`   | `true`                           | Use on port 587. |
+| `SMTP_USE_TLS`    | `false`                          | Set `true` (and `SMTP_STARTTLS=false`) for port 465. |
+| `SMTP_FROM_EMAIL` | `no-reply@etornie.ch`            | Must be on a domain you control the DNS for. |
+| `SMTP_FROM_NAME`  | `Etornie`                        | Display name. |
+
+Any standards-compliant relay works (Amazon SES, Postmark, Mailgun,
+SendGrid, Google Workspace). The DNS records below are what each relay's
+dashboard asks you to publish; the exact values come from that provider.
+
+## 2. SPF — authorise the sending hosts
+
+Publish **one** `TXT` record at the apex of the From domain listing the
+relay that sends on your behalf. Example for Amazon SES:
+
+```
+etornie.ch.   TXT   "v=spf1 include:amazonses.com -all"
+```
+
+- `include:` — the provider's SPF domain (SES: `amazonses.com`,
+  Postmark: `spf.mtasv.net`, Mailgun: `mailgun.org`).
+- `-all` — hard-fail anything not listed. Use `~all` (soft-fail) only
+  while testing.
+- Exactly one SPF record per domain; merge multiple senders into a
+  single record with several `include:` tokens.
+
+## 3. DKIM — cryptographically sign the mail
+
+The relay signs each message; the public key lives in DNS so receivers
+can verify the signature. Providers give you the records to publish —
+usually three CNAMEs (SES) or a `TXT` key.
+
+Amazon SES (Easy DKIM) publishes three CNAMEs:
+
+```
+<token1>._domainkey.etornie.ch.   CNAME   <token1>.dkim.amazonses.com.
+<token2>._domainkey.etornie.ch.   CNAME   <token2>.dkim.amazonses.com.
+<token3>._domainkey.etornie.ch.   CNAME   <token3>.dkim.amazonses.com.
+```
+
+Generic `TXT` form (e.g. self-managed or Postmark):
+
+```
+<selector>._domainkey.etornie.ch.   TXT   "v=DKIM1; k=rsa; p=<base64 public key>"
+```
+
+Wait for the provider console to report the domain as **verified**
+before relying on DKIM.
+
+## 4. DMARC — policy + reporting
+
+Tells receivers what to do when SPF/DKIM fail and where to send reports.
+Publish a `TXT` record at `_dmarc`:
+
+```
+_dmarc.etornie.ch.   TXT   "v=DMARC1; p=quarantine; rua=mailto:dmarc@etornie.ch; adkim=s; aspf=s; pct=100"
+```
+
+- `p=` — policy: roll out `none` → `quarantine` → `reject` as confidence
+  grows. Start at `none` (monitor only), end at `reject` for production.
+- `rua=` — mailbox that receives aggregate reports.
+- `adkim=s` / `aspf=s` — strict alignment: the DKIM/SPF domain must match
+  the visible From domain exactly.
+
+DMARC passes when **either** SPF or DKIM passes *and* is aligned with the
+From domain, so `SMTP_FROM_EMAIL` must be on the domain whose SPF/DKIM you
+published above.
+
+## 5. Verify before launch
+
+1. Send a test (e.g. trigger a registration OTP) to a Gmail account.
+2. Open the message → **Show original**: SPF, DKIM, and DMARC should all
+   read **PASS**.
+3. Or use a checker such as <https://www.mail-tester.com>.
+4. Watch the `rua` DMARC reports for a few days before tightening
+   `p=none` → `quarantine` → `reject`.
+
+## Local development
+
+Leave `SMTP_HOST` empty. The transport logs and returns `False` instead
+of sending, so the app runs without an email account. Registration will
+report that the verification email could not be sent — set up a relay (or
+a local catcher like MailHog: `SMTP_HOST=localhost`, `SMTP_PORT=1025`,
+`SMTP_STARTTLS=false`) to exercise the OTP flow end to end.

--- a/docs/HELIUS_WEBHOOK.md
+++ b/docs/HELIUS_WEBHOOK.md
@@ -1,0 +1,68 @@
+# Helius webhook + on-chain state reconciliation (#19)
+
+The backend writes intents (a case attestation, an NFT mint/burn) and confirms
+them synchronously. If that confirmation is dropped — a lost RPC response, a
+slot rollback, a restart mid-flow — the DB and the chain drift. This webhook
+closes the gap: Helius pushes every transaction touching our three programs,
+and we reconcile DB rows against what actually landed on-chain.
+
+## How it works
+
+1. **Helius → us.** A Helius *raw* webhook is registered for the three program
+   IDs. On every matching transaction Helius POSTs the raw tx (including
+   `meta.logMessages`) to `POST /solana/webhooks/helius`.
+2. **Decode.** `app/solana/events.py` decodes the Anchor events from the log
+   messages (`Program data: <base64>` → 8-byte discriminator + Borsh fields).
+   The schemas mirror the committed IDLs and are cross-checked against them in
+   the test suite. Three events are modelled:
+   - `CaseAttestationUpdated` (etornie-attestation)
+   - `CaseNftMinted`, `CaseNftBurned` (etornie-ip-token)
+3. **Reconcile (idempotent).** Each event carries the 16-byte `case_id`
+   (a UUID), so we look up the `Case` and apply:
+   - attestation → back-fill `attestation_tx` if missing and append a
+     `case_events` row (deduped on case + tx + event_type);
+   - mint → `nft_state=minted`, `nft_mint`, `nft_mint_tx`, `client_wallet`;
+   - burn → `nft_state=burned`, `nft_burn_tx`, `nft_burned_at`.
+   Re-delivery is a no-op. A tx with `meta.err` set is ignored.
+
+## Security
+
+Fail-closed. The endpoint rejects every request unless the `Authorization`
+header matches `HELIUS_WEBHOOK_AUTH` (constant-time compare), so it is inert
+until configured. Authorised calls always return `200` — a single malformed tx
+is logged and skipped, never `500`'d, so Helius does not retry-storm.
+
+## Configuration
+
+| Variable | Purpose |
+|----------|---------|
+| `HELIUS_WEBHOOK_AUTH` | Shared secret required in the webhook's `Authorization` header. Empty ⇒ endpoint disabled. |
+| `HELIUS_API_KEY` | Helius API key, for the registration script. |
+| `HELIUS_WEBHOOK_URL` | Public URL of the endpoint. Defaults to `API_PUBLIC_URL` + `/solana/webhooks/helius`. |
+
+## Register the webhook
+
+With the backend env loaded:
+
+```bash
+cd services/api
+python scripts/register_helius_webhook.py
+```
+
+The script registers a raw webhook for the three program IDs pointing at the
+endpoint, with `HELIUS_WEBHOOK_AUTH` as the auth header. It skips creation if a
+webhook already targets that URL. Without `HELIUS_API_KEY` it prints setup
+instructions and exits.
+
+## Metrics
+
+Per-program counters (`received` / `reconciled` / `skipped` / `failed`) are
+accumulated across deliveries, logged (structured) on every webhook call, and
+exposed to admins at `GET /solana/webhooks/helius/metrics`.
+
+## Local testing
+
+A live Helius webhook needs a public URL + a Helius account. To exercise the
+decoder + reconciler without Helius, POST a raw-tx-shaped payload to the
+endpoint with the right `Authorization` header (see `tests/test_solana_events.py`
+for payloads), or run the test suite.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,94 @@
+# Observability (#51)
+
+Three correlated pillars for production triage, all wired in
+`services/api/app/observability.py` and bootstrapped from `app.main`:
+
+1. **Structured logging** — JSON logs, one object per line.
+2. **Error tracking** — Sentry.
+3. **Distributed tracing** — OpenTelemetry, exported over OTLP.
+
+A single `request_id` and the active `trace_id` / `span_id` thread through all
+three, so an error in Sentry, the log line that produced it, and the trace it
+belongs to can be pivoted between freely.
+
+## 1. Structured logging
+
+`configure_logging()` installs a `dictConfig` on the root + uvicorn loggers.
+
+- `LOG_FORMAT=json` (default) → one JSON object per line: `timestamp`, `level`,
+  `logger`, `message`, `request_id`, and — when a span is active — `trace_id` /
+  `span_id`. Any `logger.info(..., extra={...})` fields are merged in.
+- `LOG_FORMAT=console` → human-readable single line for local dev.
+- `LOG_LEVEL` (default `INFO`) applies to the app + uvicorn loggers.
+
+Every request is tagged with a `request_id` by `RequestContextMiddleware`
+(reusing an inbound `X-Request-ID` from a proxy if present, otherwise minting
+one) and the id is echoed on the response `X-Request-ID` header. The middleware
+is **pure ASGI** on purpose — `BaseHTTPMiddleware` runs the app in a separate
+context, so a `ContextVar` set there would not reach the route handlers.
+
+```json
+{"timestamp":"2026-06-02T10:20:01.123456+00:00","level":"INFO","logger":"app.payments.service","message":"payment confirmed","request_id":"a1b2c3…","trace_id":"4bf92f…","span_id":"00f067…"}
+```
+
+## 2. Error tracking (Sentry)
+
+`init_sentry()` initialises Sentry only when `SENTRY_DSN` is set (empty → the
+SDK stays uninitialised and the app runs unchanged). Integrations: FastAPI,
+Starlette, SQLAlchemy, httpx, asyncio, and logging (warnings+ as breadcrumbs,
+errors as events). Secrets are scrubbed in `_before_send`; `send_default_pii`
+is off. Tune with `SENTRY_TRACES_SAMPLE_RATE`.
+
+## 3. Distributed tracing (OpenTelemetry)
+
+`init_tracing(app, engine)` is a **real no-op when `OTEL_ENABLED=false`** (the
+same posture as an empty `SENTRY_DSN`). When enabled it builds a
+`TracerProvider` (resource `service.name=OTEL_SERVICE_NAME`,
+`deployment.environment=ENVIRONMENT`; `ParentBased(TraceIdRatioBased(...))`
+sampler) and auto-instruments the whole request path:
+
+- **FastAPI** — a server span per request, across every route;
+- **SQLAlchemy** — a span per query (instruments `engine.sync_engine`);
+- **httpx** — a client span per outbound call (EUIPO, Solana RPC, SMTP relay …);
+- **Redis** — a span per command.
+
+Spans export over **OTLP/HTTP** to `OTEL_EXPORTER_OTLP_ENDPOINT`
+(`…/v1/traces` is appended). With `OTEL_CONSOLE_EXPORT=true` they also print to
+stdout. If tracing is enabled but no endpoint is set, spans fall back to stdout
+rather than being silently dropped.
+
+### Run a local collector
+
+Any OTLP-compatible backend works. Jaeger all-in-one is the quickest:
+
+```bash
+docker run --rm -p 16686:16686 -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+Then in `services/api/.env`:
+
+```bash
+OTEL_ENABLED=true
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+OTEL_SERVICE_NAME=etornie-api
+```
+
+Restart the backend, make a few requests, and open the Jaeger UI at
+<http://localhost:16686> — you should see `etornie-api` traces with nested
+FastAPI → SQLAlchemy / httpx / Redis spans, and the matching `trace_id` in the
+JSON logs.
+
+## Configuration reference
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LOG_FORMAT` | `json` | `json` or `console` |
+| `LOG_LEVEL` | `INFO` | root / app / uvicorn level |
+| `SENTRY_DSN` | _empty_ | error tracking (empty disables) |
+| `SENTRY_TRACES_SAMPLE_RATE` | `0.1` | Sentry perf sampling |
+| `OTEL_ENABLED` | `false` | master switch for tracing |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _empty_ | OTLP/HTTP collector base URL |
+| `OTEL_SERVICE_NAME` | `etornie-api` | `service.name` resource attr |
+| `OTEL_CONSOLE_EXPORT` | `false` | also print spans to stdout |
+| `OTEL_TRACES_SAMPLE_RATE` | `1.0` | head-based trace sampling ratio |

--- a/idl/etornie_attestation.json
+++ b/idl/etornie_attestation.json
@@ -1,0 +1,305 @@
+{
+  "address": "CpLYWQn39xw1Qei1fqcDF8NkJGiJsME2dKpAfzkN1T2X",
+  "metadata": {
+    "name": "etornie_attestation",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Case lifecycle compressed attestations for Etornie"
+  },
+  "instructions": [
+    {
+      "name": "create_case_attestation",
+      "discriminator": [
+        165,
+        86,
+        244,
+        190,
+        152,
+        112,
+        150,
+        122
+      ],
+      "accounts": [
+        {
+          "name": "attestation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "case_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "Backend operator — pays rent and acts as co-signer so users do",
+            "not need SOL in their wallet."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "creator",
+          "docs": [
+            "The case creator (user wallet). Signing this instruction is a",
+            "cryptographic proof that the wallet owner authorized the case",
+            "attestation; the pubkey is recorded as `creator` on the PDA."
+          ],
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "case_id",
+          "type": {
+            "array": [
+              "u8",
+              16
+            ]
+          }
+        },
+        {
+          "name": "metadata_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "client_wallet",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "update_case_attestation",
+      "docs": [
+        "Record a lifecycle event against an existing case attestation.",
+        "",
+        "The main PDA's ``metadata_hash`` is overwritten with the fresh",
+        "hash (current case state at event time) and a typed ``emit!``",
+        "event is written to the tx log so historical timelines can be",
+        "reconstructed from Solana tx history."
+      ],
+      "discriminator": [
+        184,
+        212,
+        255,
+        56,
+        65,
+        123,
+        77,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "attestation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "attestation.case_id",
+                "account": "CaseAttestation"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "Backend operator — pays fees so users do not need SOL."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "actor",
+          "docs": [
+            "The actor triggering the event (case creator, lawyer, admin).",
+            "Signing this instruction authorizes the on-chain update."
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "metadata_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "event_type",
+          "type": "u8"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "CaseAttestation",
+      "discriminator": [
+        57,
+        196,
+        113,
+        84,
+        182,
+        107,
+        157,
+        123
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "CaseAttestationUpdated",
+      "discriminator": [
+        242,
+        135,
+        167,
+        44,
+        46,
+        36,
+        234,
+        172
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "AttestationAlreadyExists",
+      "msg": "Attestation already exists for this case id"
+    }
+  ],
+  "types": [
+    {
+      "name": "CaseAttestation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "case_id",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "metadata_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "client_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "created_at",
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CaseAttestationUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "case_id",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "old_metadata_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "new_metadata_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "event_type",
+            "type": "u8"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/idl/etornie_attestation.ts
+++ b/idl/etornie_attestation.ts
@@ -1,0 +1,311 @@
+/**
+ * Program IDL in camelCase format in order to be used in JS/TS.
+ *
+ * Note that this is only a type helper and is not the actual IDL. The original
+ * IDL can be found at `target/idl/etornie_attestation.json`.
+ */
+export type EtornieAttestation = {
+  "address": "CpLYWQn39xw1Qei1fqcDF8NkJGiJsME2dKpAfzkN1T2X",
+  "metadata": {
+    "name": "etornieAttestation",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Case lifecycle compressed attestations for Etornie"
+  },
+  "instructions": [
+    {
+      "name": "createCaseAttestation",
+      "discriminator": [
+        165,
+        86,
+        244,
+        190,
+        152,
+        112,
+        150,
+        122
+      ],
+      "accounts": [
+        {
+          "name": "attestation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "caseId"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "Backend operator — pays rent and acts as co-signer so users do",
+            "not need SOL in their wallet."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "creator",
+          "docs": [
+            "The case creator (user wallet). Signing this instruction is a",
+            "cryptographic proof that the wallet owner authorized the case",
+            "attestation; the pubkey is recorded as `creator` on the PDA."
+          ],
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "caseId",
+          "type": {
+            "array": [
+              "u8",
+              16
+            ]
+          }
+        },
+        {
+          "name": "metadataHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "clientWallet",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "updateCaseAttestation",
+      "docs": [
+        "Record a lifecycle event against an existing case attestation.",
+        "",
+        "The main PDA's ``metadata_hash`` is overwritten with the fresh",
+        "hash (current case state at event time) and a typed ``emit!``",
+        "event is written to the tx log so historical timelines can be",
+        "reconstructed from Solana tx history."
+      ],
+      "discriminator": [
+        184,
+        212,
+        255,
+        56,
+        65,
+        123,
+        77,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "attestation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "attestation.case_id",
+                "account": "caseAttestation"
+              }
+            ]
+          }
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "Backend operator — pays fees so users do not need SOL."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "actor",
+          "docs": [
+            "The actor triggering the event (case creator, lawyer, admin).",
+            "Signing this instruction authorizes the on-chain update."
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "metadataHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "eventType",
+          "type": "u8"
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "caseAttestation",
+      "discriminator": [
+        57,
+        196,
+        113,
+        84,
+        182,
+        107,
+        157,
+        123
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "caseAttestationUpdated",
+      "discriminator": [
+        242,
+        135,
+        167,
+        44,
+        46,
+        36,
+        234,
+        172
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "attestationAlreadyExists",
+      "msg": "Attestation already exists for this case id"
+    }
+  ],
+  "types": [
+    {
+      "name": "caseAttestation",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "caseId",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "metadataHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "clientWallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "createdAt",
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "caseAttestationUpdated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "caseId",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "oldMetadataHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "newMetadataHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "eventType",
+            "type": "u8"
+          },
+          {
+            "name": "actor",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    }
+  ]
+};

--- a/idl/etornie_ip_token.json
+++ b/idl/etornie_ip_token.json
@@ -1,0 +1,425 @@
+{
+  "address": "6WrZ6NmuQtfpufrLbk5prQCKuF4isX1JwbrvxGFxT2gF",
+  "metadata": {
+    "name": "etornie_ip_token",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Soul-bound Case NFT program for Etornie: Token-2022 + Light Protocol compression"
+  },
+  "instructions": [
+    {
+      "name": "burn_case_nft",
+      "docs": [
+        "Thaw the client's frozen ATA, burn the 1-unit supply, mark record burned.",
+        "",
+        "Only the operator needs to sign — the program PDA acts as freeze",
+        "authority (thaw) and mint authority (burn). This is intended to be",
+        "called when the case reaches a terminal closed state; the",
+        "backend must enforce that precondition off-chain before invoking."
+      ],
+      "discriminator": [
+        135,
+        82,
+        163,
+        145,
+        195,
+        199,
+        248,
+        207
+      ],
+      "accounts": [
+        {
+          "name": "case_nft_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101,
+                  95,
+                  110,
+                  102,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "case_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "nft_authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true,
+          "relations": [
+            "case_nft_record"
+          ]
+        },
+        {
+          "name": "client_token_account",
+          "writable": true
+        },
+        {
+          "name": "operator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "_case_id",
+          "type": {
+            "array": [
+              "u8",
+              16
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "mint_case_nft",
+      "docs": [
+        "Mint a soul-bound case NFT into the client's frozen ATA.",
+        "",
+        "The mint must already be created client-side with:",
+        "- decimals = 0",
+        "- mint_authority = nft_authority PDA",
+        "- freeze_authority = nft_authority PDA",
+        "- DefaultAccountState = Frozen extension",
+        "- MetadataPointer + TokenMetadata extensions",
+        "",
+        "The client's ATA starts frozen (DefaultAccountState), so the NFT",
+        "cannot be transferred, delegated, or burned by the holder. Only",
+        "`burn_case_nft` can thaw → burn via program PDA signing."
+      ],
+      "discriminator": [
+        37,
+        75,
+        52,
+        141,
+        2,
+        156,
+        79,
+        104
+      ],
+      "accounts": [
+        {
+          "name": "case_nft_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101,
+                  95,
+                  110,
+                  102,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "case_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "nft_authority",
+          "docs": [
+            "Derived from [NFT_AUTHORITY_SEED]; signed via invoke_signed."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true
+        },
+        {
+          "name": "client_token_account",
+          "writable": true
+        },
+        {
+          "name": "client",
+          "signer": true
+        },
+        {
+          "name": "operator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "case_id",
+          "type": {
+            "array": [
+              "u8",
+              16
+            ]
+          }
+        },
+        {
+          "name": "metadata_uri_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "CaseNftRecord",
+      "discriminator": [
+        77,
+        20,
+        229,
+        240,
+        123,
+        49,
+        45,
+        115
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "CaseNftBurned",
+      "discriminator": [
+        65,
+        120,
+        160,
+        68,
+        228,
+        3,
+        113,
+        138
+      ]
+    },
+    {
+      "name": "CaseNftMinted",
+      "discriminator": [
+        251,
+        117,
+        139,
+        107,
+        151,
+        7,
+        234,
+        115
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "AlreadyBurned",
+      "msg": "Case NFT has already been burned"
+    }
+  ],
+  "types": [
+    {
+      "name": "CaseNftBurned",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "case_id",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CaseNftMinted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "case_id",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "client_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "metadata_uri_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CaseNftRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "case_id",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "client_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "metadata_uri_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "minted_at",
+            "type": "i64"
+          },
+          {
+            "name": "burned_at",
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/idl/etornie_ip_token.ts
+++ b/idl/etornie_ip_token.ts
@@ -1,0 +1,431 @@
+/**
+ * Program IDL in camelCase format in order to be used in JS/TS.
+ *
+ * Note that this is only a type helper and is not the actual IDL. The original
+ * IDL can be found at `target/idl/etornie_ip_token.json`.
+ */
+export type EtornieIpToken = {
+  "address": "6WrZ6NmuQtfpufrLbk5prQCKuF4isX1JwbrvxGFxT2gF",
+  "metadata": {
+    "name": "etornieIpToken",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Soul-bound Case NFT program for Etornie: Token-2022 + Light Protocol compression"
+  },
+  "instructions": [
+    {
+      "name": "burnCaseNft",
+      "docs": [
+        "Thaw the client's frozen ATA, burn the 1-unit supply, mark record burned.",
+        "",
+        "Only the operator needs to sign — the program PDA acts as freeze",
+        "authority (thaw) and mint authority (burn). This is intended to be",
+        "called when the case reaches a terminal closed state; the",
+        "backend must enforce that precondition off-chain before invoking."
+      ],
+      "discriminator": [
+        135,
+        82,
+        163,
+        145,
+        195,
+        199,
+        248,
+        207
+      ],
+      "accounts": [
+        {
+          "name": "caseNftRecord",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101,
+                  95,
+                  110,
+                  102,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "caseId"
+              }
+            ]
+          }
+        },
+        {
+          "name": "nftAuthority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true,
+          "relations": [
+            "caseNftRecord"
+          ]
+        },
+        {
+          "name": "clientTokenAccount",
+          "writable": true
+        },
+        {
+          "name": "operator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "tokenProgram",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "caseId",
+          "type": {
+            "array": [
+              "u8",
+              16
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "mintCaseNft",
+      "docs": [
+        "Mint a soul-bound case NFT into the client's frozen ATA.",
+        "",
+        "The mint must already be created client-side with:",
+        "- decimals = 0",
+        "- mint_authority = nft_authority PDA",
+        "- freeze_authority = nft_authority PDA",
+        "- DefaultAccountState = Frozen extension",
+        "- MetadataPointer + TokenMetadata extensions",
+        "",
+        "The client's ATA starts frozen (DefaultAccountState), so the NFT",
+        "cannot be transferred, delegated, or burned by the holder. Only",
+        "`burn_case_nft` can thaw → burn via program PDA signing."
+      ],
+      "discriminator": [
+        37,
+        75,
+        52,
+        141,
+        2,
+        156,
+        79,
+        104
+      ],
+      "accounts": [
+        {
+          "name": "caseNftRecord",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101,
+                  95,
+                  110,
+                  102,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "caseId"
+              }
+            ]
+          }
+        },
+        {
+          "name": "nftAuthority",
+          "docs": [
+            "Derived from [NFT_AUTHORITY_SEED]; signed via invoke_signed."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  97,
+                  115,
+                  101,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "writable": true
+        },
+        {
+          "name": "clientTokenAccount",
+          "writable": true
+        },
+        {
+          "name": "client",
+          "signer": true
+        },
+        {
+          "name": "operator",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "tokenProgram",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "caseId",
+          "type": {
+            "array": [
+              "u8",
+              16
+            ]
+          }
+        },
+        {
+          "name": "metadataUriHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "caseNftRecord",
+      "discriminator": [
+        77,
+        20,
+        229,
+        240,
+        123,
+        49,
+        45,
+        115
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "caseNftBurned",
+      "discriminator": [
+        65,
+        120,
+        160,
+        68,
+        228,
+        3,
+        113,
+        138
+      ]
+    },
+    {
+      "name": "caseNftMinted",
+      "discriminator": [
+        251,
+        117,
+        139,
+        107,
+        151,
+        7,
+        234,
+        115
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "alreadyBurned",
+      "msg": "Case NFT has already been burned"
+    }
+  ],
+  "types": [
+    {
+      "name": "caseNftBurned",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "caseId",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "caseNftMinted",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "caseId",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "clientWallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "metadataUriHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "caseNftRecord",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "caseId",
+            "type": {
+              "array": [
+                "u8",
+                16
+              ]
+            }
+          },
+          {
+            "name": "mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "clientWallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "metadataUriHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "mintedAt",
+            "type": "i64"
+          },
+          {
+            "name": "burnedAt",
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    }
+  ]
+};

--- a/scripts/nft/burn.ts
+++ b/scripts/nft/burn.ts
@@ -27,7 +27,7 @@ import {
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
-import type { EtornieIpToken } from "../../target/types/etornie_ip_token";
+import type { EtornieIpToken } from "../../idl/etornie_ip_token";
 
 interface Input {
   case_id_hex: string;
@@ -87,7 +87,7 @@ async function main(): Promise<void> {
 
   const idlPath = resolve(
     process.cwd(),
-    "target/idl/etornie_ip_token.json",
+    "idl/etornie_ip_token.json",
   );
   const idl = JSON.parse(readFileSync(idlPath, "utf-8"));
   const program = new Program<EtornieIpToken>(idl as any, provider);

--- a/services/api/app/admin/router.py
+++ b/services/api/app/admin/router.py
@@ -322,7 +322,7 @@ async def refund_payment(
     """Issue a Stripe refund for an admin-selected payment intent.
 
     Re-uses the service-layer ``refund_payment_intent`` so the same
-    auto-refund hooks (chat confirmation, EmailJS notify, audit log)
+    auto-refund hooks (chat confirmation, email notify, audit log)
     fire whether the trigger is the auto-pipeline or this endpoint.
     """
     intent = (

--- a/services/api/app/agent/router.py
+++ b/services/api/app/agent/router.py
@@ -41,6 +41,7 @@ from app.agent.schemas import (
 from app.auth.dependencies import get_current_user
 from app.config import settings
 from app.database import get_db
+from app.security.virus_scan import scan_upload
 from app.services.x402_core import (
     build_explorer_urls,
     compute_expected_memo,
@@ -607,6 +608,9 @@ async def upload_to_session_endpoint(
                 f"File exceeds {_MAX_UPLOAD_BYTES // (1024 * 1024)} MiB upload limit"
             ),
         )
+
+    # Reject malware before the bytes are stored / vision-indexed (#55).
+    await scan_upload(raw, filename=file.filename)
 
     try:
         upload = await upload_service.store_upload(

--- a/services/api/app/auth/email_verification.py
+++ b/services/api/app/auth/email_verification.py
@@ -2,10 +2,10 @@ import json
 import random
 from datetime import datetime, timedelta, timezone
 
-import httpx
 import redis
 
 from app.config import settings
+from app.notifications.email_transport import send_email
 
 _OTP_TTL_SECONDS = 600  # 10 minutes
 _KEY_PREFIX = "otp:"
@@ -27,30 +27,27 @@ def generate_code() -> str:
 
 
 async def send_verification_email(to_email: str, to_name: str, code: str) -> bool:
-    """Send verification code via EmailJS REST API."""
-    if not settings.emailjs_public_key or not settings.emailjs_service_id:
-        raise Exception("EmailJS not configured")
+    """Email a 6-digit verification code via the shared SMTP transport.
 
-    expires_at = datetime.now() + timedelta(minutes=10)
-    expires_str = expires_at.strftime("%H:%M")
-
-    url = "https://api.emailjs.com/api/v1.0/email/send"
-    payload = {
-        "service_id": settings.emailjs_service_id,
-        "template_id": settings.emailjs_template_id,
-        "user_id": settings.emailjs_public_key,
-        "accessToken": settings.emailjs_private_key,
-        "template_params": {
-            "passcode": code,
-            "time": expires_str,
-            "to_name": to_name,
-            "email": to_email,
-        },
-    }
-
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        response = await client.post(url, json=payload)
-        return response.status_code == 200
+    Returns True when the relay accepts the message. The registration
+    endpoint turns a False into a user-facing error, so a sign-up never
+    silently proceeds without the code having been sent.
+    """
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=_OTP_TTL_SECONDS)
+    minutes = _OTP_TTL_SECONDS // 60
+    subject = "Your Etornie verification code"
+    body = (
+        f"Hi {to_name or 'there'},\n\n"
+        "Use this code to finish creating your Etornie account:\n\n"
+        f"    {code}\n\n"
+        f"It expires in {minutes} minutes "
+        f"(at {expires_at.strftime('%H:%M UTC')}).\n\n"
+        "If you didn't request this, you can safely ignore this email.\n\n"
+        "— Etornie"
+    )
+    return await send_email(
+        to_email=to_email, to_name=to_name, subject=subject, body=body
+    )
 
 
 def store_pending(email: str, code: str, registration_data: dict) -> None:

--- a/services/api/app/auth/router.py
+++ b/services/api/app/auth/router.py
@@ -82,7 +82,7 @@ async def register_request(
     """Step 1: Request email verification for registration.
 
     Generates a 6-digit code, stores pending verification data,
-    and sends the code via EmailJS.
+    and emails the code via the server-side SMTP transport.
     """
     existing = await get_user_by_email(db, data.email)
     if existing is not None:

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -161,6 +161,16 @@ class Settings(BaseSettings):
     solana_zk_verifier_enabled: bool = True
     api_public_url: str = "http://localhost:8000"
 
+    # Helius webhook for on-chain event reconciliation (#19). Helius POSTs
+    # transactions touching the 3 program IDs to /solana/webhooks/helius;
+    # ``helius_webhook_auth`` is the shared secret we require in the webhook's
+    # Authorization header (empty → the endpoint rejects every call,
+    # fail-closed). ``helius_api_key`` + ``helius_webhook_url`` are used by
+    # scripts/register_helius_webhook.py. See docs/HELIUS_WEBHOOK.md.
+    helius_webhook_auth: str = ""
+    helius_api_key: str = ""
+    helius_webhook_url: str = ""
+
     # EtornieGPT x402 payment flow (Faz 5.6)
     etorniegpt_payment_vault: str = ""
     etorniegpt_payment_lamports: int = 100_000  # 0.0001 SOL ~ $0.02

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -26,6 +26,24 @@ class Settings(BaseSettings):
     sentry_traces_sample_rate: float = 0.1
     sentry_profiles_sample_rate: float = 0.0
 
+    # Structured logging. ``log_format`` is "json" for machine-readable
+    # production logs (one JSON object per line, carrying trace_id / span_id
+    # + request_id) or "console" for human-readable local dev. ``log_level``
+    # is applied to the root, app and uvicorn loggers.
+    log_format: str = "json"
+    log_level: str = "INFO"
+
+    # OpenTelemetry tracing. Disabled by default so local dev needs no
+    # collector — init is then a real no-op (same posture as an empty
+    # SENTRY_DSN). When enabled, spans export over OTLP/HTTP to
+    # ``otel_exporter_otlp_endpoint`` (e.g. http://localhost:4318); set
+    # ``otel_console_export`` to also print spans to stdout for debugging.
+    otel_enabled: bool = False
+    otel_exporter_otlp_endpoint: str = ""
+    otel_service_name: str = "etornie-api"
+    otel_console_export: bool = False
+    otel_traces_sample_rate: float = 1.0
+
     # Database
     database_url: str
 

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -103,6 +103,16 @@ class Settings(BaseSettings):
     # File storage
     upload_dir: str = "./uploads"
 
+    # ClamAV malware scanning for untrusted uploads (#55). Disabled by
+    # default so local dev needs no daemon. When enabled, an unreachable or
+    # erroring daemon fails CLOSED — the upload is rejected rather than waved
+    # through, so this P0 control cannot be silently bypassed by taking the
+    # scanner offline. The docker-compose `clamav` service listens on 3310.
+    clamav_enabled: bool = False
+    clamav_host: str = "clamav"
+    clamav_port: int = 3310
+    clamav_timeout: float = 30.0
+
     # CORS
     cors_origins: list[str]
     # Optional regex for additional allowed origins — useful for

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -70,12 +70,22 @@ class Settings(BaseSettings):
     whatsapp_business_account_id: str = ""
     whatsapp_api_version: str = "v22.0"
 
-    # EmailJS
-    emailjs_public_key: str = ""
-    emailjs_private_key: str = ""
-    emailjs_service_id: str = ""
-    emailjs_template_id: str = ""  # OTP verification
-    emailjs_case_template_id: str = ""  # New case notification
+    # Email (SMTP) — server-side transactional mail: registration OTP, case
+    # and payment/filing/NFT notifications. Provider-agnostic; point these at
+    # Amazon SES, Postmark, Mailgun, Gmail, or any relay's SMTP endpoint.
+    # An empty ``smtp_host`` leaves email sending disabled, so local dev runs
+    # without an email account (see app/notifications/email_transport.py).
+    # Deliverability (SPF/DKIM/DMARC): docs/EMAIL_DELIVERABILITY.md.
+    smtp_host: str = ""
+    smtp_port: int = 587
+    smtp_username: str = ""
+    smtp_password: str = ""
+    # Port 587 uses STARTTLS (default). For port 465 set smtp_use_tls=True;
+    # it implies smtp_starttls is ignored (the two are mutually exclusive).
+    smtp_starttls: bool = True
+    smtp_use_tls: bool = False
+    smtp_from_email: str = ""
+    smtp_from_name: str = "Etornie"
 
     # Groq (EtornieGPT)
     groq_api_key: str = ""

--- a/services/api/app/documents/router.py
+++ b/services/api/app/documents/router.py
@@ -25,6 +25,7 @@ from app.documents.service import (
     review_document,
 )
 from app.required_documents.service import link_document_to_requirement
+from app.security.virus_scan import scan_upload
 from app.solana.client import (
     SolanaClientError,
     fetch_file_ownership_record,
@@ -126,6 +127,9 @@ async def upload_document_endpoint(
 
     # Write file contents
     content = await file.read()
+
+    # Reject malware before the bytes touch disk or the RAG index (#55).
+    await scan_upload(content, filename=file.filename)
 
     # Verify client-side sha256 matches server-side sha256 before committing.
     if file_hash_hex is not None:

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -35,6 +35,7 @@ from app.renewals.router import router as renewals_router
 from app.required_documents.router import router as required_documents_router
 from app.services.euipo.router import router as euipo_router
 from app.services.ukipo.router import router as ukipo_router
+from app.solana.webhook_router import router as solana_webhook_router
 from app.users.router import router as users_router
 from app.zk.router import router as zk_router
 
@@ -121,6 +122,7 @@ app.include_router(etorniegpt_router)
 app.include_router(proposals_router)
 app.include_router(euipo_router)
 app.include_router(ukipo_router)
+app.include_router(solana_webhook_router)
 app.include_router(zk_router)
 app.include_router(braid_router)
 app.include_router(braid_admin_router)

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -18,7 +18,12 @@ from app.cases.router import router as cases_router
 from app.config import settings
 from app.documents.router import router as documents_router
 from app.errors import UserFacingError
-from app.observability import capture_exception, init_sentry
+from app.observability import (
+    RequestContextMiddleware,
+    configure_logging,
+    init_sentry,
+    init_tracing,
+)
 from app.security.headers import SecurityHeadersMiddleware
 from app.etorniegpt.router import router as etorniegpt_router
 from app.in_app_notifications.router import router as in_app_notifications_router
@@ -37,11 +42,13 @@ from app.zk.router import router as zk_router
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Startup
-    init_sentry()
-    yield
-    # Shutdown
     from app.database import engine
 
+    configure_logging()
+    init_sentry()
+    init_tracing(app, engine)
+    yield
+    # Shutdown
     await engine.dispose()
 
 
@@ -65,6 +72,10 @@ app.add_middleware(
     SecurityHeadersMiddleware,
     enable_hsts=settings.environment.lower() in {"production", "staging"},
 )
+
+# Bind a request_id to every request so all of its log lines correlate; the
+# caller gets it back via the X-Request-ID response header.
+app.add_middleware(RequestContextMiddleware)
 
 
 _user_error_logger = logging.getLogger("app.user_error")

--- a/services/api/app/notifications/case_notifications.py
+++ b/services/api/app/notifications/case_notifications.py
@@ -4,11 +4,11 @@ import json
 import logging
 from datetime import datetime, timezone
 
-import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cases.models import Case
 from app.config import settings
+from app.notifications.email_transport import send_email
 from app.notifications.models import NotificationType
 from app.notifications.scheduler import process_pending_notifications
 from app.notifications.service import create_notification
@@ -34,43 +34,47 @@ async def _process_now(db: AsyncSession) -> None:
         logger.warning("Failed to process notifications immediately: %s", exc)
 
 
-async def send_case_created_email(client_user: User, case: Case) -> bool:
-    """Send email notification to client about new case via EmailJS."""
-    if not settings.emailjs_public_key or not settings.emailjs_case_template_id:
-        logger.warning("EmailJS case template not configured, skipping email")
-        return False
+def _case_created_content(name: str | None, case: Case) -> tuple[str, str]:
+    """Render the (subject, body) for a new-case notification email.
 
+    Shared by the registered-client and guest senders so the wording
+    lives in exactly one place.
+    """
+    case_type = (
+        case.case_type.value
+        if hasattr(case.case_type, "value")
+        else str(case.case_type)
+    )
+    deadline = str(case.deadline) if case.deadline else "Not set"
+    subject = f"New case opened — {case.case_number}"
+    body = (
+        f"Hi {name or 'there'},\n\n"
+        "A new case has been opened for you on Etornie:\n\n"
+        f"Case number: {case.case_number}\n"
+        f"Title: {case.title}\n"
+        f"Type: {case_type}\n"
+        f"Deadline: {deadline}\n\n"
+        "You can follow its progress from your Etornie dashboard.\n\n"
+        "— Etornie"
+    )
+    return subject, body
+
+
+async def send_case_created_email(client_user: User, case: Case) -> bool:
+    """Email the client about a newly opened case via the SMTP transport."""
     if not client_user.email:
         return False
 
-    url = "https://api.emailjs.com/api/v1.0/email/send"
-    payload = {
-        "service_id": settings.emailjs_service_id,
-        "template_id": settings.emailjs_case_template_id,
-        "user_id": settings.emailjs_public_key,
-        "accessToken": settings.emailjs_private_key,
-        "template_params": {
-            "to_name": client_user.full_name,
-            "email": client_user.email,
-            "case_number": case.case_number,
-            "case_title": case.title,
-            "case_type": case.case_type.value if hasattr(case.case_type, "value") else str(case.case_type),
-            "deadline": str(case.deadline) if case.deadline else "Not set",
-        },
-    }
-
-    try:
-        async with httpx.AsyncClient(timeout=15.0) as http_client:
-            response = await http_client.post(url, json=payload)
-            if response.status_code == 200:
-                logger.info("Case creation email sent to %s", client_user.email)
-                return True
-            else:
-                logger.warning("EmailJS returned %s: %s", response.status_code, response.text)
-                return False
-    except Exception as exc:
-        logger.warning("Failed to send case creation email: %s", exc)
-        return False
+    subject, body = _case_created_content(client_user.full_name, case)
+    sent = await send_email(
+        to_email=client_user.email,
+        to_name=client_user.full_name,
+        subject=subject,
+        body=body,
+    )
+    if sent:
+        logger.info("Case creation email sent to %s", client_user.email)
+    return sent
 
 
 async def send_case_created_whatsapp(
@@ -131,39 +135,15 @@ async def send_case_created_whatsapp(
 async def send_case_created_email_to_guest(
     email: str, name: str, case: Case
 ) -> bool:
-    """Send email notification to an unregistered (guest) client."""
-    if not settings.emailjs_public_key or not settings.emailjs_case_template_id:
-        logger.warning("EmailJS case template not configured, skipping email")
+    """Email an unregistered (guest) client about a newly opened case."""
+    if not email:
         return False
 
-    url = "https://api.emailjs.com/api/v1.0/email/send"
-    payload = {
-        "service_id": settings.emailjs_service_id,
-        "template_id": settings.emailjs_case_template_id,
-        "user_id": settings.emailjs_public_key,
-        "accessToken": settings.emailjs_private_key,
-        "template_params": {
-            "to_name": name,
-            "email": email,
-            "case_number": case.case_number,
-            "case_title": case.title,
-            "case_type": case.case_type.value if hasattr(case.case_type, "value") else str(case.case_type),
-            "deadline": str(case.deadline) if case.deadline else "Not set",
-        },
-    }
-
-    try:
-        async with httpx.AsyncClient(timeout=15.0) as http_client:
-            response = await http_client.post(url, json=payload)
-            if response.status_code == 200:
-                logger.info("Case creation email sent to guest %s", email)
-                return True
-            else:
-                logger.warning("EmailJS returned %s: %s", response.status_code, response.text)
-                return False
-    except Exception as exc:
-        logger.warning("Failed to send case creation email to guest: %s", exc)
-        return False
+    subject, body = _case_created_content(name, case)
+    sent = await send_email(to_email=email, to_name=name, subject=subject, body=body)
+    if sent:
+        logger.info("Case creation email sent to guest %s", email)
+    return sent
 
 
 async def send_case_created_whatsapp_to_guest(

--- a/services/api/app/notifications/email_dispatcher.py
+++ b/services/api/app/notifications/email_dispatcher.py
@@ -3,18 +3,18 @@
 Single entry point the payment / filing / NFT hooks call after a
 real event lands. Pulls the recipient address off the
 :class:`app.users.models.User` row, honours the
-``email_notifications_enabled`` toggle, and ships the message via the
-already-configured EmailJS REST API (same provider the OTP flow
-uses). Stays inert when EmailJS is not configured so local dev does
-not require any external account.
+``email_notifications_enabled`` toggle, and hands the rendered
+subject + body to the shared SMTP transport
+(:mod:`app.notifications.email_transport`). Stays inert when SMTP is
+not configured so local dev does not require an email account.
 
 Why this module
 - One place that knows the opt-in rules → callers cannot
   accidentally send a notification to a user who did not consent.
-- One place that knows about EmailJS payload shape → swapping the
-  provider later (Resend, Postmark, SES) only touches this file.
+- One place that owns the notification wording (the content helpers
+  below) so tone can change without grepping call sites.
 - All sends are fire-and-forget (logged, never re-raised) so a flaky
-  third-party never breaks the payment confirmation path.
+  relay never breaks the payment confirmation path.
 """
 from __future__ import annotations
 
@@ -22,13 +22,11 @@ import asyncio
 import logging
 import uuid
 from dataclasses import dataclass
-from typing import Any
 
-import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
+from app.notifications.email_transport import send_email
 from app.users.models import User
 
 logger = logging.getLogger(__name__)
@@ -36,12 +34,11 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class NotificationContent:
-    """Render output: a subject + a body the email template substitutes in.
+    """Render output: a subject + a plain-text body for one email.
 
-    EmailJS templates have a fixed set of variables they substitute
-    (``to_name``, ``subject``, ``message`` …). Keep this dataclass
-    minimal so any template the operator wires up just needs to know
-    these three fields.
+    The SMTP transport maps ``subject`` to the email subject and
+    ``message`` to the body, so the content helpers below own the full
+    wording.
     """
 
     subject: str
@@ -68,56 +65,6 @@ def _resolve_recipient(user: User) -> str | None:
     return user.email
 
 
-async def _send_via_emailjs(
-    *, to_email: str, to_name: str, content: NotificationContent
-) -> bool:
-    """Ship a single notification through the EmailJS REST API.
-
-    Returns True on a 200 response, False otherwise. Never raises —
-    the caller should treat email delivery as best-effort.
-    """
-    if not settings.emailjs_service_id or not settings.emailjs_public_key:
-        logger.info("EmailJS not configured; skipping notification to %s", to_email)
-        return False
-
-    template_id = settings.emailjs_case_template_id or settings.emailjs_template_id
-    if not template_id:
-        logger.info("No EmailJS template_id configured; skipping notification")
-        return False
-
-    payload: dict[str, Any] = {
-        "service_id": settings.emailjs_service_id,
-        "template_id": template_id,
-        "user_id": settings.emailjs_public_key,
-        "accessToken": settings.emailjs_private_key,
-        "template_params": {
-            "to_name": to_name,
-            "email": to_email,
-            "subject": content.subject,
-            "message": content.message,
-        },
-    }
-    try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            response = await client.post(
-                "https://api.emailjs.com/api/v1.0/email/send", json=payload
-            )
-    except httpx.HTTPError as exc:
-        logger.warning(
-            "EmailJS request failed for %s: %s", to_email, exc
-        )
-        return False
-    if response.status_code != 200:
-        logger.warning(
-            "EmailJS returned %s for %s: %s",
-            response.status_code,
-            to_email,
-            response.text[:200],
-        )
-        return False
-    return True
-
-
 async def send_notification(
     db: AsyncSession,
     *,
@@ -127,7 +74,7 @@ async def send_notification(
     """Send a notification to ``user_id`` if they have opted in.
 
     Returns True when an email was dispatched, False otherwise
-    (no opt-in, no recipient, EmailJS not configured, delivery
+    (no opt-in, no recipient, SMTP not configured, delivery
     failure). Never raises — callers can treat this purely as a
     fire-and-forget side effect.
     """
@@ -144,10 +91,11 @@ async def send_notification(
             user_id,
         )
         return False
-    return await _send_via_emailjs(
+    return await send_email(
         to_email=recipient,
         to_name=user.full_name or "Etornie user",
-        content=content,
+        subject=content.subject,
+        body=content.message,
     )
 
 
@@ -162,7 +110,7 @@ def schedule_notification(
     The Stripe webhook handler should not block on an email delivery,
     so callers that do not need the return value just call this. The
     asyncio task lives on the event loop the request is running in;
-    failures are logged inside ``_send_via_emailjs``.
+    failures are logged inside the SMTP transport.
     """
     asyncio.get_event_loop().create_task(
         send_notification(db, user_id=user_id, content=content)

--- a/services/api/app/notifications/email_transport.py
+++ b/services/api/app/notifications/email_transport.py
@@ -1,0 +1,97 @@
+"""Server-side SMTP transport — the single seam every email goes through.
+
+Replaces the previous EmailJS REST usage (#29). EmailJS is a front-end-key
+product: using its key server-side exposes it and gives no delivery
+guarantees. This module ships transactional mail (registration OTP, case +
+payment/filing/NFT notifications) over plain SMTP instead.
+
+Provider-agnostic: point the ``SMTP_*`` settings at Amazon SES, Postmark,
+Mailgun, Gmail, or any relay's SMTP endpoint. See
+``docs/EMAIL_DELIVERABILITY.md`` for the SPF / DKIM / DMARC records a domain
+needs before these messages reach the inbox.
+
+Stays inert — logs and returns ``False``, never raises — when SMTP is not
+configured, so local dev needs no email account and a flaky relay never
+breaks a request path. Callers treat delivery as best-effort (the
+registration flow additionally turns a ``False`` into a user-facing error).
+"""
+
+from __future__ import annotations
+
+import logging
+from email.message import EmailMessage
+from email.utils import formataddr
+
+import aiosmtplib
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT_SECONDS = 15.0
+
+
+def is_configured() -> bool:
+    """True when enough SMTP settings are present to attempt a send.
+
+    A relay host and a From address are the minimum; username/password are
+    optional because some relays (e.g. an in-VPC SES endpoint) authenticate
+    by network identity rather than SMTP AUTH.
+    """
+    return bool(settings.smtp_host and settings.smtp_from_email)
+
+
+def _build_message(
+    *, to_email: str, to_name: str | None, subject: str, body: str
+) -> EmailMessage:
+    """Compose a plain-text message with properly encoded headers."""
+    message = EmailMessage()
+    message["From"] = formataddr(
+        (settings.smtp_from_name or "Etornie", settings.smtp_from_email)
+    )
+    message["To"] = formataddr((to_name, to_email)) if to_name else to_email
+    message["Subject"] = subject
+    message.set_content(body)
+    return message
+
+
+async def send_email(
+    *, to_email: str, to_name: str | None, subject: str, body: str
+) -> bool:
+    """Send one plain-text email. Returns ``True`` on success.
+
+    Never raises: a missing configuration or a relay failure is logged and
+    reported as ``False`` so callers can treat delivery as best-effort.
+    """
+    if not is_configured():
+        logger.info("SMTP not configured; skipping email to %s", to_email)
+        return False
+    if not to_email:
+        return False
+
+    message = _build_message(
+        to_email=to_email, to_name=to_name, subject=subject, body=body
+    )
+
+    # Port 465 wants implicit TLS; 587 wants STARTTLS. They are mutually
+    # exclusive — never offer STARTTLS on top of an already-wrapped socket.
+    use_tls = settings.smtp_use_tls
+    start_tls = settings.smtp_starttls and not use_tls
+
+    try:
+        await aiosmtplib.send(
+            message,
+            hostname=settings.smtp_host,
+            port=settings.smtp_port,
+            username=settings.smtp_username or None,
+            password=settings.smtp_password or None,
+            use_tls=use_tls,
+            start_tls=start_tls,
+            timeout=_TIMEOUT_SECONDS,
+        )
+    except (aiosmtplib.SMTPException, OSError) as exc:
+        logger.warning("SMTP send to %s failed: %s", to_email, exc)
+        return False
+
+    logger.info("Email sent to %s (subject=%r)", to_email, subject)
+    return True

--- a/services/api/app/observability.py
+++ b/services/api/app/observability.py
@@ -13,18 +13,27 @@ Why this lives in a dedicated module
 3. Lets tests import ``init_sentry()`` and call it explicitly with
    a test DSN when they want to assert the integration is wired.
 """
+
 from __future__ import annotations
 
+import json
 import logging
+import logging.config
+import uuid
+from contextvars import ContextVar
+from datetime import datetime, timezone
 from typing import Any
 
 import sentry_sdk
+from opentelemetry import trace as otel_trace
 from sentry_sdk.integrations.asyncio import AsyncioIntegration
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.httpx import HttpxIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.config import settings
 
@@ -138,3 +147,253 @@ def capture_exception(exc: BaseException, **extra: Any) -> str | None:
         for k, v in extra.items():
             scope.set_extra(k, v)
     return sentry_sdk.capture_exception(exc)
+
+
+# ---------------------------------------------------------------------------
+# Structured logging — JSON lines correlated to traces + a per-request id.
+# ---------------------------------------------------------------------------
+
+# Bound for the lifetime of one request by ``RequestContextMiddleware`` so
+# every log line emitted while handling it carries the same id.
+_request_id_ctx: ContextVar[str] = ContextVar("request_id", default="-")
+
+# Attributes the stdlib sets on every LogRecord. Anything else a call site
+# attaches via ``logger.info(..., extra={...})`` is surfaced in the JSON log.
+_RESERVED_LOG_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+        "message",
+        "asctime",
+        "request_id",
+        "otel_trace_id",
+        "otel_span_id",
+    }
+)
+
+
+class _ContextFilter(logging.Filter):
+    """Attach request_id + the active OTel trace/span ids to every record.
+
+    Runs on the handler before formatting, so both the JSON and console
+    formatters can rely on these attributes always being present.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = _request_id_ctx.get()
+        span = otel_trace.get_current_span()
+        ctx = span.get_span_context() if span is not None else None
+        if ctx is not None and ctx.is_valid:
+            record.otel_trace_id = format(ctx.trace_id, "032x")
+            record.otel_span_id = format(ctx.span_id, "016x")
+        else:
+            record.otel_trace_id = ""
+            record.otel_span_id = ""
+        return True
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Render each record as one JSON object — stable keys for a log store,
+    trace_id/span_id for trace correlation, plus any ``extra=`` fields."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", "-"),
+        }
+        trace_id = getattr(record, "otel_trace_id", "")
+        if trace_id:
+            payload["trace_id"] = trace_id
+            payload["span_id"] = getattr(record, "otel_span_id", "")
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+        for key, value in record.__dict__.items():
+            if key not in _RESERVED_LOG_FIELDS and not key.startswith("_"):
+                payload[key] = value
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def configure_logging() -> None:
+    """Install structured logging on the root + uvicorn loggers.
+
+    ``LOG_FORMAT=json`` (default) emits one JSON object per line; ``console``
+    is human-readable for local dev. Idempotent — safe to call repeatedly.
+    """
+    use_json = settings.log_format.lower() == "json"
+    level = settings.log_level.upper()
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "filters": {"context": {"()": _ContextFilter}},
+            "formatters": {
+                "json": {"()": JsonLogFormatter},
+                "console": {
+                    "format": (
+                        "%(asctime)s %(levelname)-7s %(name)s "
+                        "[req=%(request_id)s trace=%(otel_trace_id)s] %(message)s"
+                    ),
+                    "defaults": {"request_id": "-", "otel_trace_id": ""},
+                },
+            },
+            "handlers": {
+                "default": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                    "formatter": "json" if use_json else "console",
+                    "filters": ["context"],
+                }
+            },
+            "root": {"level": level, "handlers": ["default"]},
+            "loggers": {
+                name: {
+                    "level": level,
+                    "handlers": ["default"],
+                    "propagate": False,
+                }
+                for name in ("uvicorn", "uvicorn.error", "uvicorn.access")
+            },
+        }
+    )
+
+
+class RequestContextMiddleware:
+    """Pure-ASGI middleware that binds a request_id for the whole request.
+
+    Implemented as raw ASGI (not ``BaseHTTPMiddleware``) on purpose: the
+    latter runs the downstream app in a separate context, so a ContextVar set
+    there would be invisible to the route handlers. Setting it here — in the
+    same context that calls ``self.app(...)`` — propagates it everywhere the
+    request touches, so every log line gets the id. An inbound ``X-Request-ID``
+    (e.g. from a proxy) is reused so one id ties logs together across services;
+    otherwise a fresh one is minted. The id is echoed on the response.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        header_map = dict(scope.get("headers") or [])
+        incoming = header_map.get(b"x-request-id")
+        request_id = incoming.decode("latin-1") if incoming else uuid.uuid4().hex
+        token = _request_id_ctx.set(request_id)
+
+        async def send_with_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                MutableHeaders(scope=message)["X-Request-ID"] = request_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_id)
+        finally:
+            _request_id_ctx.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# OpenTelemetry tracing — whole-app auto-instrumentation.
+# ---------------------------------------------------------------------------
+
+
+def init_tracing(app: Any, engine: Any) -> bool:
+    """Set up OTel tracing + instrument FastAPI / SQLAlchemy / httpx / Redis.
+
+    No-op (returns False) when ``OTEL_ENABLED`` is false — a real off switch,
+    the same posture as an empty ``SENTRY_DSN``. When enabled with no OTLP
+    endpoint configured, spans go to stdout rather than being silently
+    dropped, so "enabled" never means "lost".
+    """
+    if not settings.otel_enabled:
+        logger.info("OpenTelemetry disabled (OTEL_ENABLED=false)")
+        return False
+
+    # Heavy SDK + instrumentation imports are local so they only load when
+    # tracing is actually switched on.
+    from opentelemetry import trace
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+    from opentelemetry.instrumentation.redis import RedisInstrumentor
+    from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        SimpleSpanProcessor,
+    )
+    from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+
+    resource = Resource.create(
+        {
+            "service.name": settings.otel_service_name,
+            "deployment.environment": settings.environment,
+        }
+    )
+    provider = TracerProvider(
+        resource=resource,
+        sampler=ParentBased(TraceIdRatioBased(settings.otel_traces_sample_rate)),
+    )
+
+    exported = False
+    if settings.otel_exporter_otlp_endpoint:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        endpoint = settings.otel_exporter_otlp_endpoint.rstrip("/") + "/v1/traces"
+        provider.add_span_processor(
+            BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
+        )
+        exported = True
+    if settings.otel_console_export or not exported:
+        if not exported:
+            logger.warning(
+                "OTEL_ENABLED but no OTLP endpoint set; exporting spans to stdout"
+            )
+        provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+    trace.set_tracer_provider(provider)
+
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+    SQLAlchemyInstrumentor().instrument(
+        engine=engine.sync_engine, tracer_provider=provider
+    )
+    HTTPXClientInstrumentor().instrument(tracer_provider=provider)
+    RedisInstrumentor().instrument(tracer_provider=provider)
+
+    logger.info(
+        "OpenTelemetry initialised (service=%s, endpoint=%s, sample_rate=%s)",
+        settings.otel_service_name,
+        settings.otel_exporter_otlp_endpoint or "stdout",
+        settings.otel_traces_sample_rate,
+    )
+    return True

--- a/services/api/app/payments/service.py
+++ b/services/api/app/payments/service.py
@@ -871,7 +871,7 @@ async def _generate_compliance_after_confirmation(
 
     # Opt-in email — only fires for users who explicitly enabled it
     # and have either ``notification_email`` or login ``email`` set.
-    # Fire-and-forget so a flaky EmailJS does not slow the webhook
+    # Fire-and-forget so a flaky email relay does not slow the webhook
     # response and trigger Stripe retries.
     from app.notifications.email_dispatcher import (
         payment_received_content,

--- a/services/api/app/security/virus_scan.py
+++ b/services/api/app/security/virus_scan.py
@@ -1,0 +1,104 @@
+"""ClamAV malware scanning for untrusted uploads (#55).
+
+Every file an untrusted client uploads — case documents, agent chat
+attachments, avatars, UK IPO mark images — is streamed to a ClamAV daemon
+(clamd) before it is persisted or indexed, so a matched file never reaches
+disk or the RAG index.
+
+The clamd protocol library is synchronous, so the INSTREAM call runs in a
+worker thread (``asyncio.to_thread``) to keep the event loop free.
+
+Posture
+- Disabled by default (``CLAMAV_ENABLED=false``) so local dev needs no
+  daemon; ``scan_upload`` is then a no-op.
+- When enabled, a daemon that is unreachable or errors is treated as
+  FAIL-CLOSED — the upload is rejected (503) rather than waved through, so a
+  P0 control cannot be silently bypassed by taking the scanner offline.
+
+Errors are surfaced as :class:`app.errors.UserFacingError` subclasses, so the
+exception handler registered in ``app.main`` turns them into a clean response
+automatically — callers just ``await scan_upload(...)`` with no try/except.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from app.config import settings
+from app.errors import ErrorCategory, UserFacingError
+
+logger = logging.getLogger(__name__)
+
+
+class InfectedFileError(UserFacingError):
+    """Raised when ClamAV matches a signature in an uploaded file."""
+
+    def __init__(self, signature: str, *, filename: str | None = None) -> None:
+        super().__init__(
+            "This file was rejected by our malware scanner and was not stored.",
+            technical_detail=f"clamav signature={signature!r} filename={filename!r}",
+            category=ErrorCategory.validation,
+            http_status=400,
+        )
+        self.signature = signature
+
+
+class VirusScanUnavailableError(UserFacingError):
+    """Raised (fail-closed) when scanning is enabled but cannot complete."""
+
+    def __init__(self, technical_detail: str) -> None:
+        super().__init__(
+            "File scanning is temporarily unavailable. Please try again shortly.",
+            technical_detail=technical_detail,
+            category=ErrorCategory.validation,
+            http_status=503,
+        )
+
+
+def _scan_stream(data: bytes) -> tuple[str, str | None]:
+    """Blocking clamd INSTREAM scan. Returns ``(status, signature)``.
+
+    ``status`` is ``"OK"``, ``"FOUND"`` or ``"ERROR"`` per the clamd
+    protocol. ``clamd`` is imported lazily so the module stays importable
+    (and dev/tests run) without the package when scanning is disabled.
+    """
+    import io
+
+    import clamd
+
+    client = clamd.ClamdNetworkSocket(
+        host=settings.clamav_host,
+        port=settings.clamav_port,
+        timeout=settings.clamav_timeout,
+    )
+    # clamd returns e.g. {"stream": ("FOUND", "Eicar-Test-Signature")}
+    # or {"stream": ("OK", None)}.
+    status, signature = client.instream(io.BytesIO(data))["stream"]
+    return status, signature
+
+
+async def scan_upload(data: bytes, *, filename: str | None = None) -> None:
+    """Scan ``data`` for malware; return ``None`` when clean.
+
+    No-op when ``CLAMAV_ENABLED`` is false. Raises :class:`InfectedFileError`
+    when a signature matches, or :class:`VirusScanUnavailableError`
+    (fail-closed) when an enabled scan cannot complete.
+    """
+    if not settings.clamav_enabled:
+        return
+
+    try:
+        status, signature = await asyncio.to_thread(_scan_stream, data)
+    except Exception as exc:
+        # Any failure to reach / complete the scan fails closed: a P0
+        # control must not be bypassed just because the daemon is down.
+        logger.error("ClamAV scan failed (fail-closed) for %s: %s", filename, exc)
+        raise VirusScanUnavailableError(f"{type(exc).__name__}: {exc}") from exc
+
+    if status == "FOUND":
+        logger.warning("ClamAV rejected upload %s: %s", filename, signature)
+        raise InfectedFileError(signature or "unknown", filename=filename)
+    if status != "OK":
+        logger.error("ClamAV returned %s for %s: %s", status, filename, signature)
+        raise VirusScanUnavailableError(f"clamd status={status} signature={signature}")

--- a/services/api/app/services/ukipo/router.py
+++ b/services/api/app/services/ukipo/router.py
@@ -33,6 +33,7 @@ from app.auth.dependencies import get_current_user
 from app.cases.service import get_case
 from app.config import settings
 from app.database import get_db
+from app.security.virus_scan import scan_upload
 from app.services.ukipo.schemas import (
     UKIPOPaymentRecordRequest,
     UKIPOPaymentRequirementsResponse,
@@ -243,6 +244,8 @@ async def upload_mark_image_endpoint(
     content = await file.read()
     if not content:
         raise HTTPException(status_code=400, detail="empty file")
+    # Reject malware before the mark image is persisted (#55).
+    await scan_upload(content, filename=file.filename)
     with open(abs_path, "wb") as f:
         f.write(content)
     return UKIPOMarkImageUploadResponse(path=abs_path)

--- a/services/api/app/solana/events.py
+++ b/services/api/app/solana/events.py
@@ -1,0 +1,339 @@
+"""Anchor event decoding for on-chain reconciliation (#19).
+
+Helius delivers the log messages of every transaction touching our three
+program IDs. Anchor programs emit events as ``Program data: <base64>`` log
+lines, where the bytes are an 8-byte event discriminator followed by the
+Borsh-serialized event fields. We decode the three events our programs emit so
+the webhook consumer can reconcile DB rows against the chain.
+
+The schemas below mirror the committed IDLs (``idl/etornie_attestation.json``,
+``idl/etornie_ip_token.json``) — discriminators and field layouts are taken
+verbatim from them, and ``test_solana_events.py`` cross-checks them against the
+IDLs so the two cannot silently drift. They are embedded (rather than loading
+the IDL at runtime) so decoding has no filesystem dependency and behaves
+identically in the container, in CI and in tests — ``idl/`` lives at the repo
+root and is not shipped inside the backend image.
+
+The event fields are all fixed-size (no Borsh var-length types), so decoding is
+a straight walk over byte offsets.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Final
+
+import base58
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cases.models import Case, CaseEvent, CaseNftState
+
+logger = logging.getLogger(__name__)
+
+_LOG_PREFIX: Final = "Program data: "
+
+# field kind -> byte width
+_KIND_SIZE: Final[dict[str, int]] = {
+    "bytes16": 16,  # [u8; 16]  — a UUID (case_id)
+    "hash32": 32,  # [u8; 32]  — a SHA-256 / metadata hash
+    "pubkey": 32,  # Pubkey    — base58-encoded on decode
+    "u8": 1,
+    "i64": 8,
+}
+
+
+@dataclass(frozen=True)
+class _Field:
+    name: str
+    kind: str
+
+    @property
+    def size(self) -> int:
+        return _KIND_SIZE[self.kind]
+
+
+@dataclass(frozen=True)
+class EventSchema:
+    program: str
+    name: str
+    discriminator: bytes
+    fields: tuple[_Field, ...]
+
+
+# Mirrors idl/*.json (cross-checked in test_solana_events.py).
+EVENT_SCHEMAS: Final[tuple[EventSchema, ...]] = (
+    EventSchema(
+        program="etornie_attestation",
+        name="CaseAttestationUpdated",
+        discriminator=bytes((242, 135, 167, 44, 46, 36, 234, 172)),
+        fields=(
+            _Field("case_id", "bytes16"),
+            _Field("old_metadata_hash", "hash32"),
+            _Field("new_metadata_hash", "hash32"),
+            _Field("event_type", "u8"),
+            _Field("actor", "pubkey"),
+            _Field("operator", "pubkey"),
+            _Field("timestamp", "i64"),
+        ),
+    ),
+    EventSchema(
+        program="etornie_ip_token",
+        name="CaseNftMinted",
+        discriminator=bytes((251, 117, 139, 107, 151, 7, 234, 115)),
+        fields=(
+            _Field("case_id", "bytes16"),
+            _Field("mint", "pubkey"),
+            _Field("client_wallet", "pubkey"),
+            _Field("operator", "pubkey"),
+            _Field("metadata_uri_hash", "hash32"),
+            _Field("timestamp", "i64"),
+        ),
+    ),
+    EventSchema(
+        program="etornie_ip_token",
+        name="CaseNftBurned",
+        discriminator=bytes((65, 120, 160, 68, 228, 3, 113, 138)),
+        fields=(
+            _Field("case_id", "bytes16"),
+            _Field("mint", "pubkey"),
+            _Field("operator", "pubkey"),
+            _Field("timestamp", "i64"),
+        ),
+    ),
+)
+
+_BY_DISCRIMINATOR: Final[dict[bytes, EventSchema]] = {
+    s.discriminator: s for s in EVENT_SCHEMAS
+}
+
+
+@dataclass(frozen=True)
+class DecodedEvent:
+    """One decoded Anchor event. ``case_id`` is pulled out because every event
+    carries it and the reconciler keys off it; ``values`` holds all fields
+    (UUID / hex / base58 / int) by name."""
+
+    program: str
+    name: str
+    case_id: uuid.UUID
+    values: dict[str, object]
+
+
+def _decode_value(kind: str, raw: bytes) -> object:
+    if kind == "bytes16":
+        return uuid.UUID(bytes=raw)
+    if kind == "hash32":
+        return raw.hex()
+    if kind == "pubkey":
+        return base58.b58encode(raw).decode("ascii")
+    if kind == "u8":
+        return raw[0]
+    if kind == "i64":
+        return int.from_bytes(raw, "little", signed=True)
+    raise ValueError(f"unknown field kind: {kind}")
+
+
+def decode_event(payload: bytes) -> DecodedEvent | None:
+    """Decode one event payload (8-byte discriminator + Borsh fields).
+
+    Returns ``None`` when the discriminator is not one of ours or the payload
+    is truncated — both are normal (we see every event from the programs, not
+    just the ones we model).
+    """
+    if len(payload) < 8:
+        return None
+    schema = _BY_DISCRIMINATOR.get(payload[:8])
+    if schema is None:
+        return None
+
+    offset = 8
+    values: dict[str, object] = {}
+    for fld in schema.fields:
+        chunk = payload[offset : offset + fld.size]
+        if len(chunk) != fld.size:
+            return None  # truncated / malformed
+        values[fld.name] = _decode_value(fld.kind, chunk)
+        offset += fld.size
+
+    case_id = values["case_id"]
+    assert isinstance(case_id, uuid.UUID)  # noqa: S101 — layout guarantees it
+    return DecodedEvent(
+        program=schema.program,
+        name=schema.name,
+        case_id=case_id,
+        values=values,
+    )
+
+
+def decode_log_events(log_messages: list[str]) -> list[DecodedEvent]:
+    """Decode every event we recognise from a transaction's log messages."""
+    decoded: list[DecodedEvent] = []
+    for line in log_messages:
+        if not line.startswith(_LOG_PREFIX):
+            continue
+        encoded = line[len(_LOG_PREFIX) :].strip()
+        try:
+            payload = base64.b64decode(encoded, validate=True)
+        except (ValueError, TypeError):
+            continue
+        event = decode_event(payload)
+        if event is not None:
+            decoded.append(event)
+    return decoded
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation — apply decoded events to the DB, idempotently.
+# ---------------------------------------------------------------------------
+
+# Per-program counters, accumulated across webhook deliveries (#19 AC: "per
+# program reconciliation metrics"). Surfaced via reconciliation_metrics() and
+# logged per delivery by the webhook handler.
+_METRIC_KEYS: Final = ("received", "reconciled", "skipped", "failed")
+_metrics: dict[str, dict[str, int]] = {}
+
+
+def _bump(program: str, key: str) -> None:
+    _metrics.setdefault(program, dict.fromkeys(_METRIC_KEYS, 0))[key] += 1
+
+
+def reconciliation_metrics() -> dict[str, dict[str, int]]:
+    """Snapshot of cumulative per-program reconciliation counters."""
+    return {program: dict(counts) for program, counts in _metrics.items()}
+
+
+@dataclass
+class ReconcileResult:
+    received: int = 0
+    reconciled: int = 0
+    skipped: int = 0
+    failed: int = 0
+    by_program: dict[str, dict[str, int]] = field(default_factory=dict)
+
+
+async def reconcile_events(
+    db: AsyncSession, events: list[DecodedEvent], signature: str
+) -> ReconcileResult:
+    """Apply each decoded event to its Case row, idempotently.
+
+    ``reconciled`` counts events that changed DB state, ``skipped`` those
+    already in sync (or for an unknown case), ``failed`` those that raised. A
+    single bad event never aborts the batch. The session is committed once at
+    the end.
+    """
+    result = ReconcileResult()
+    for event in events:
+        result.received += 1
+        _bump(event.program, "received")
+        try:
+            changed = await _reconcile_one(db, event, signature)
+        except Exception:
+            logger.exception(
+                "reconcile failed: event=%s case=%s tx=%s",
+                event.name,
+                event.case_id,
+                signature,
+            )
+            result.failed += 1
+            _bump(event.program, "failed")
+            continue
+        if changed:
+            result.reconciled += 1
+            _bump(event.program, "reconciled")
+        else:
+            result.skipped += 1
+            _bump(event.program, "skipped")
+
+    if result.reconciled:
+        await db.commit()
+    result.by_program = reconciliation_metrics()
+    return result
+
+
+async def _reconcile_one(db: AsyncSession, event: DecodedEvent, signature: str) -> bool:
+    """Reconcile one event. Returns True when it changed DB state."""
+    case = (
+        await db.execute(select(Case).where(Case.id == event.case_id))
+    ).scalar_one_or_none()
+    if case is None:
+        logger.warning(
+            "reconcile: no case %s for %s (tx %s)",
+            event.case_id,
+            event.name,
+            signature,
+        )
+        return False
+
+    if event.name == "CaseAttestationUpdated":
+        return await _reconcile_attestation(db, case, event, signature)
+    if event.name == "CaseNftMinted":
+        return _reconcile_nft_minted(case, event, signature)
+    if event.name == "CaseNftBurned":
+        return _reconcile_nft_burned(case, event, signature)
+    return False
+
+
+async def _reconcile_attestation(
+    db: AsyncSession, case: Case, event: DecodedEvent, signature: str
+) -> bool:
+    """Back-fill a missing attestation tx and record the lifecycle event.
+
+    Idempotent on (case, tx, event_type): a re-delivered webhook does not
+    duplicate the CaseEvent row.
+    """
+    event_type = int(event.values["event_type"])  # type: ignore[call-overload]
+    already = (
+        await db.execute(
+            select(CaseEvent.id).where(
+                CaseEvent.case_id == case.id,
+                CaseEvent.tx_signature == signature,
+                CaseEvent.event_type == event_type,
+            )
+        )
+    ).first()
+    if already is not None:
+        return False
+
+    db.add(
+        CaseEvent(
+            case_id=case.id,
+            event_type=event_type,
+            tx_signature=signature,
+            actor_wallet=str(event.values["actor"]),
+            metadata_hash=str(event.values["new_metadata_hash"]),
+        )
+    )
+    if not case.attestation_tx:
+        case.attestation_tx = signature
+    return True
+
+
+def _reconcile_nft_minted(case: Case, event: DecodedEvent, signature: str) -> bool:
+    mint = str(event.values["mint"])
+    if case.nft_state == CaseNftState.minted and case.nft_mint == mint:
+        return False
+    case.nft_mint = mint
+    case.nft_state = CaseNftState.minted
+    case.nft_mint_tx = signature
+    if not case.client_wallet:
+        case.client_wallet = str(event.values["client_wallet"])
+    return True
+
+
+def _reconcile_nft_burned(case: Case, event: DecodedEvent, signature: str) -> bool:
+    if case.nft_state == CaseNftState.burned:
+        return False
+    case.nft_state = CaseNftState.burned
+    case.nft_burn_tx = signature
+    raw_ts = event.values.get("timestamp")
+    case.nft_burned_at = (
+        datetime.fromtimestamp(int(raw_ts), tz=timezone.utc)  # type: ignore[arg-type]
+        if raw_ts
+        else datetime.now(timezone.utc)
+    )
+    return True

--- a/services/api/app/solana/webhook_router.py
+++ b/services/api/app/solana/webhook_router.py
@@ -1,0 +1,114 @@
+"""Helius transaction webhook → on-chain state reconciliation (#19).
+
+Helius POSTs the raw transactions touching our three program IDs here; we
+decode the Anchor events from each tx's log messages and reconcile the
+corresponding DB rows (see :mod:`app.solana.events`). This closes the gap where
+a dropped confirmation or a slot rollback left the DB out of sync with the
+chain.
+
+Security: fail-closed. The endpoint rejects every call unless the webhook's
+Authorization header matches ``HELIUS_WEBHOOK_AUTH``, so it is inert until
+configured. Authorised calls always return 200 — a single malformed tx is
+logged and skipped rather than 500'd, so Helius does not enter a retry storm.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import require_role
+from app.config import settings
+from app.database import get_db
+from app.solana.events import (
+    ReconcileResult,
+    decode_log_events,
+    reconcile_events,
+    reconciliation_metrics,
+)
+from app.users.models import User, UserRole
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/solana", tags=["solana"])
+
+
+def _extract_tx(tx: dict[str, Any]) -> tuple[str | None, list[str]]:
+    """Pull ``(signature, log_messages)`` out of one Helius raw-webhook tx.
+
+    Skips transactions that failed on-chain (``meta.err`` set) — state is never
+    reconciled from a tx the cluster rejected.
+    """
+    meta = tx.get("meta") or {}
+    if meta.get("err") is not None:
+        return None, []
+    logs = meta.get("logMessages") or tx.get("logs") or []
+    txn = tx.get("transaction") or {}
+    signatures = txn.get("signatures") if isinstance(txn, dict) else None
+    signature = (signatures[0] if signatures else None) or tx.get("signature")
+    return signature, logs
+
+
+@router.post("/webhooks/helius", status_code=status.HTTP_200_OK)
+async def helius_webhook(
+    request: Request, db: AsyncSession = Depends(get_db)
+) -> dict[str, int]:
+    """Receive a Helius webhook batch and reconcile every recognised event."""
+    expected = settings.helius_webhook_auth
+    provided = request.headers.get("authorization", "")
+    if not expected or not hmac.compare_digest(provided, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized"
+        )
+
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="invalid JSON body"
+        ) from None
+
+    transactions = payload if isinstance(payload, list) else [payload]
+    total = ReconcileResult()
+    for tx in transactions:
+        if not isinstance(tx, dict):
+            continue
+        signature, logs = _extract_tx(tx)
+        if not signature or not logs:
+            continue
+        events = decode_log_events(logs)
+        if not events:
+            continue
+        res = await reconcile_events(db, events, signature)
+        total.received += res.received
+        total.reconciled += res.reconciled
+        total.skipped += res.skipped
+        total.failed += res.failed
+
+    logger.info(
+        "helius webhook: txs=%d received=%d reconciled=%d skipped=%d failed=%d",
+        len(transactions),
+        total.received,
+        total.reconciled,
+        total.skipped,
+        total.failed,
+        extra={"reconcile_metrics": reconciliation_metrics()},
+    )
+    return {
+        "received": total.received,
+        "reconciled": total.reconciled,
+        "skipped": total.skipped,
+        "failed": total.failed,
+    }
+
+
+@router.get("/webhooks/helius/metrics")
+async def helius_webhook_metrics(
+    _admin: User = Depends(require_role(UserRole.admin)),
+) -> dict[str, dict[str, int]]:
+    """Cumulative per-program reconciliation counters (admin only)."""
+    return reconciliation_metrics()

--- a/services/api/app/users/router.py
+++ b/services/api/app/users/router.py
@@ -20,6 +20,7 @@ from app.cases.models import Case
 from app.compliance.data_export import build_user_export
 from app.config import settings
 from app.database import get_db
+from app.security.virus_scan import scan_upload
 from app.services.ukipo.models import UKIPOSubmission
 from app.users.models import User, UserRole
 from app.users.schemas import UserListResponse, UserResponse, UserUpdate
@@ -66,6 +67,9 @@ async def upload_my_avatar(
             "Unsupported avatar mime type. Allowed: "
             + ", ".join(sorted(_AVATAR_ALLOWED_MIME.keys())),
         )
+
+    # Reject malware before the avatar bytes are persisted (#55).
+    await scan_upload(raw, filename=file.filename)
 
     # Store the bytes in the DB so the avatar survives container restarts and
     # redeploys (the previous on-disk location was ephemeral). Clean up any

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "passlib[bcrypt]>=1.7.4",
     "bcrypt>=4.0.0,<5.0.0",
     "httpx>=0.28.0",
+    "aiosmtplib>=3.0.0",
     "pgvector>=0.3.6",
     "python-multipart>=0.0.12",
     "pydantic[email]>=2.0.0",
@@ -83,8 +84,10 @@ select = [
     "SIM",  # flake8-simplify
 ]
 ignore = [
-    "E501",  # line length is owned by the formatter
-    "B008",  # FastAPI Depends()/Query() in arg defaults is the framework idiom
+    "E501",   # line length is owned by the formatter
+    "B008",   # FastAPI Depends()/Query() in arg defaults is the framework idiom
+    "UP017",  # codebase standardises on timezone.utc; the datetime.UTC rewrite
+              # is inconsistent with it and unsafe under `from datetime import datetime`
 ]
 
 [tool.ruff.lint.isort]

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -39,6 +39,9 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "httpx>=0.28.0",
     "aiosqlite>=0.20.0",
+    "ruff>=0.8.0",
+    "mypy>=1.13.0",
+    "pre-commit>=3.5.0",
 ]
 
 [build-system]
@@ -55,3 +58,61 @@ markers = [
     "unit: pure-Python unit tests with no I/O",
     "integration: tests that exercise the database or HTTP stack",
 ]
+
+# --------------------------------------------------------------------------- #
+# Lint / format / type-check config (#49 pre-commit hooks).                    #
+# Shared by the pre-commit hooks and by manual runs (`ruff check .`, `mypy     #
+# app`). ruff discovers this file by walking up from each linted file.         #
+# --------------------------------------------------------------------------- #
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+# Alembic autogenerates migration bodies; leave them to their own conventions.
+extend-exclude = ["alembic/versions"]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes — unused imports, undefined names, ...
+    "I",    # isort — import ordering
+    "UP",   # pyupgrade — modernise for the py312 target
+    "B",    # flake8-bugbear — likely bugs
+    "C4",   # flake8-comprehensions
+    "SIM",  # flake8-simplify
+]
+ignore = [
+    "E501",  # line length is owned by the formatter
+    "B008",  # FastAPI Depends()/Query() in arg defaults is the framework idiom
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["app"]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests lean on fixtures / asserts that bugbear flags without real value.
+"tests/*" = ["B"]
+
+[tool.mypy]
+python_version = "3.12"
+# First-adoption posture: surface real type errors without drowning the team
+# in pre-existing untyped-call noise. follow_imports=silent + per-staged-file
+# invocation (see .pre-commit-config.yaml) keeps errors scoped to touched
+# files. Tighten incrementally — see the #49 PR notes.
+plugins = ["pydantic.mypy"]
+ignore_missing_imports = true
+follow_imports = "silent"
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
+check_untyped_defs = false
+disallow_untyped_defs = false
+exclude = [
+    '^alembic/',
+    '^tests/',
+]
+
+[tool.pydantic-mypy]
+init_typed = true
+warn_required_dynamic_aliases = true

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "bcrypt>=4.0.0,<5.0.0",
     "httpx>=0.28.0",
     "aiosmtplib>=3.0.0",
+    "clamd>=1.0.2",
     "pgvector>=0.3.6",
     "python-multipart>=0.0.12",
     "pydantic[email]>=2.0.0",

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -33,6 +33,12 @@ dependencies = [
     "openpyxl>=3.1.0",
     "stripe>=11.0.0",
     "sentry-sdk[fastapi]>=2.0.0",
+    "opentelemetry-sdk>=1.27.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.27.0",
+    "opentelemetry-instrumentation-fastapi>=0.48b0",
+    "opentelemetry-instrumentation-sqlalchemy>=0.48b0",
+    "opentelemetry-instrumentation-httpx>=0.48b0",
+    "opentelemetry-instrumentation-redis>=0.48b0",
 ]
 
 [project.optional-dependencies]

--- a/services/api/scripts/register_helius_webhook.py
+++ b/services/api/scripts/register_helius_webhook.py
@@ -1,0 +1,82 @@
+"""Register the Helius webhook for on-chain reconciliation (#19).
+
+Run from ``services/api`` with the backend env loaded:
+
+    python scripts/register_helius_webhook.py
+
+Requires ``HELIUS_API_KEY`` and ``HELIUS_WEBHOOK_AUTH``. Registers a *raw*
+webhook for the three program IDs, pointing at
+``<HELIUS_WEBHOOK_URL or API_PUBLIC_URL>/solana/webhooks/helius`` with the
+shared secret as the ``Authorization`` header. Skips creation if a webhook
+already targets that URL. See docs/HELIUS_WEBHOOK.md.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import httpx
+
+from app.config import settings
+
+_HELIUS_API: str = "https://api.helius.xyz/v0/webhooks"
+
+
+def _webhook_url() -> str:
+    if settings.helius_webhook_url:
+        return settings.helius_webhook_url.rstrip("/")
+    return settings.api_public_url.rstrip("/") + "/solana/webhooks/helius"
+
+
+def main() -> int:
+    if not settings.helius_api_key:
+        print(
+            "HELIUS_API_KEY is not set. Set it (plus HELIUS_WEBHOOK_AUTH and "
+            "API_PUBLIC_URL or HELIUS_WEBHOOK_URL), then re-run.\n"
+            "Get an API key at https://dashboard.helius.dev."
+        )
+        return 1
+    if not settings.helius_webhook_auth:
+        print(
+            "HELIUS_WEBHOOK_AUTH is empty — refusing to register an "
+            "unauthenticated webhook (the receiving endpoint is fail-closed)."
+        )
+        return 1
+
+    program_ids = [
+        settings.solana_attestation_program_id,
+        settings.solana_nft_program_id,
+        settings.solana_zk_verifier_program_id,
+    ]
+    url = _webhook_url()
+    params = {"api-key": settings.helius_api_key}
+    body = {
+        "webhookURL": url,
+        "transactionTypes": ["Any"],
+        "accountAddresses": program_ids,
+        "webhookType": "raw",
+        "authHeader": settings.helius_webhook_auth,
+    }
+
+    with httpx.Client(timeout=30.0) as client:
+        existing = client.get(_HELIUS_API, params=params)
+        existing.raise_for_status()
+        for hook in existing.json():
+            if hook.get("webhookURL") == url:
+                print(
+                    f"A webhook already targets {url} "
+                    f"(id {hook.get('webhookID')}). Delete it in the Helius "
+                    "dashboard to re-create."
+                )
+                return 0
+        resp = client.post(_HELIUS_API, params=params, json=body)
+        resp.raise_for_status()
+        created = resp.json()
+
+    print(f"Registered Helius webhook {created.get('webhookID')} -> {url}")
+    print(f"  programs: {', '.join(program_ids)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/api/tests/test_auth.py
+++ b/services/api/tests/test_auth.py
@@ -219,18 +219,12 @@ class TestEmailVerification:
         """Clear pending verifications between tests."""
         yield
 
-    @patch("app.auth.email_verification.httpx.AsyncClient")
+    @patch("app.auth.email_verification.send_email", new_callable=AsyncMock)
     async def test_register_request_sends_code(
-        self, mock_client_cls: AsyncMock, client: AsyncClient
+        self, mock_send: AsyncMock, client: AsyncClient
     ) -> None:
-        """Mock EmailJS HTTP call, verify 200 response."""
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_http_instance = AsyncMock()
-        mock_http_instance.post.return_value = mock_response
-        mock_http_instance.__aenter__ = AsyncMock(return_value=mock_http_instance)
-        mock_http_instance.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_http_instance
+        """Mock the SMTP transport, verify 200 response."""
+        mock_send.return_value = True
 
         response = await client.post(
             "/auth/register/request",
@@ -244,13 +238,14 @@ class TestEmailVerification:
         )
         assert response.status_code == 200
         assert response.json()["message"] == "Verification code sent to your email"
-        mock_http_instance.post.assert_called_once()
+        mock_send.assert_awaited_once()
 
-    @patch("app.auth.email_verification.httpx.AsyncClient")
+    @patch("app.auth.email_verification.send_email", new_callable=AsyncMock)
     async def test_register_request_duplicate_email(
-        self, mock_client_cls: AsyncMock, client: AsyncClient
+        self, mock_send: AsyncMock, client: AsyncClient
     ) -> None:
         """Existing email returns 409."""
+        mock_send.return_value = True
         # First, create a user via direct register
         await client.post(
             "/auth/register",
@@ -273,18 +268,12 @@ class TestEmailVerification:
         assert response.status_code == 409
         assert "already registered" in response.json()["detail"]
 
-    @patch("app.auth.email_verification.httpx.AsyncClient")
+    @patch("app.auth.email_verification.send_email", new_callable=AsyncMock)
     async def test_register_verify_valid_code(
-        self, mock_client_cls: AsyncMock, client: AsyncClient
+        self, mock_send: AsyncMock, client: AsyncClient
     ) -> None:
         """Verify with correct code creates user."""
-        mock_response = AsyncMock()
-        mock_response.status_code = 200
-        mock_http_instance = AsyncMock()
-        mock_http_instance.post.return_value = mock_response
-        mock_http_instance.__aenter__ = AsyncMock(return_value=mock_http_instance)
-        mock_http_instance.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_http_instance
+        mock_send.return_value = True
 
         # Step 1: Request verification
         await client.post(

--- a/services/api/tests/test_case_notifications.py
+++ b/services/api/tests/test_case_notifications.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import AsyncMock, patch
 
-import httpx
-import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,124 +9,65 @@ from app.cases.models import Case
 from app.notifications.case_notifications import (
     notify_case_created,
     send_case_created_email,
+    send_case_created_email_to_guest,
     send_case_created_whatsapp,
 )
 from app.notifications.models import Notification, NotificationType
 from app.users.models import User
 
 
-def _emailjs_success_response() -> httpx.Response:
-    """Build a mock EmailJS success response."""
-    return httpx.Response(
-        status_code=200,
-        text="OK",
-        request=httpx.Request("POST", "https://api.emailjs.com/api/v1.0/email/send"),
-    )
-
-
-def _emailjs_error_response() -> httpx.Response:
-    """Build a mock EmailJS error response."""
-    return httpx.Response(
-        status_code=400,
-        text="Bad Request",
-        request=httpx.Request("POST", "https://api.emailjs.com/api/v1.0/email/send"),
-    )
-
-
 class TestCaseCreatedEmail:
-    """Tests for send_case_created_email."""
+    """Tests for send_case_created_email (SMTP transport)."""
 
     async def test_case_created_sends_email(
         self,
         client_user: User,
         case_fixture: Case,
     ) -> None:
-        """Email is sent with correct params when EmailJS is configured."""
-        mock_response = _emailjs_success_response()
-        mock_post = AsyncMock(return_value=mock_response)
-
-        with (
-            patch("app.notifications.case_notifications.settings") as mock_settings,
-            patch("httpx.AsyncClient") as mock_client_cls,
-        ):
-            mock_settings.emailjs_public_key = "test-key"
-            mock_settings.emailjs_private_key = "test-private-key"
-            mock_settings.emailjs_service_id = "test-service"
-            mock_settings.emailjs_case_template_id = "test-case-template"
-
-            mock_http_instance = AsyncMock()
-            mock_http_instance.post = mock_post
-            mock_http_instance.__aenter__ = AsyncMock(return_value=mock_http_instance)
-            mock_http_instance.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = mock_http_instance
-
+        """Email goes out with the case details in subject + body."""
+        with patch(
+            "app.notifications.case_notifications.send_email",
+            new=AsyncMock(return_value=True),
+        ) as mock_send:
             result = await send_case_created_email(client_user, case_fixture)
 
         assert result is True
-        mock_post.assert_called_once()
-        call_kwargs = mock_post.call_args
-        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
-        assert payload["template_id"] == "test-case-template"
-        assert payload["template_params"]["to_name"] == client_user.full_name
-        assert payload["template_params"]["email"] == client_user.email
-        assert payload["template_params"]["case_number"] == case_fixture.case_number
-        assert payload["template_params"]["case_title"] == case_fixture.title
+        mock_send.assert_awaited_once()
+        kwargs = mock_send.call_args.kwargs
+        assert kwargs["to_email"] == client_user.email
+        assert kwargs["to_name"] == client_user.full_name
+        assert case_fixture.case_number in kwargs["subject"]
+        assert case_fixture.case_number in kwargs["body"]
+        assert case_fixture.title in kwargs["body"]
 
-    async def test_case_created_email_skips_when_not_configured(
+    async def test_case_created_email_returns_false_when_transport_fails(
         self,
         client_user: User,
         case_fixture: Case,
     ) -> None:
-        """No error when EmailJS case template is not configured."""
-        with patch("app.notifications.case_notifications.settings") as mock_settings:
-            mock_settings.emailjs_public_key = ""
-            mock_settings.emailjs_case_template_id = ""
-
+        """A relay failure (transport returns False) propagates as False."""
+        with patch(
+            "app.notifications.case_notifications.send_email",
+            new=AsyncMock(return_value=False),
+        ) as mock_send:
             result = await send_case_created_email(client_user, case_fixture)
 
         assert result is False
+        mock_send.assert_awaited_once()
 
-    async def test_case_created_email_skips_when_template_id_missing(
+    async def test_guest_email_skips_without_address(
         self,
-        client_user: User,
         case_fixture: Case,
     ) -> None:
-        """No error when only case template ID is missing."""
-        with patch("app.notifications.case_notifications.settings") as mock_settings:
-            mock_settings.emailjs_public_key = "test-key"
-            mock_settings.emailjs_case_template_id = ""
-
-            result = await send_case_created_email(client_user, case_fixture)
-
-        assert result is False
-
-    async def test_case_created_email_returns_false_on_api_error(
-        self,
-        client_user: User,
-        case_fixture: Case,
-    ) -> None:
-        """Returns False when EmailJS returns an error status."""
-        mock_response = _emailjs_error_response()
-        mock_post = AsyncMock(return_value=mock_response)
-
-        with (
-            patch("app.notifications.case_notifications.settings") as mock_settings,
-            patch("httpx.AsyncClient") as mock_client_cls,
-        ):
-            mock_settings.emailjs_public_key = "test-key"
-            mock_settings.emailjs_private_key = "test-private-key"
-            mock_settings.emailjs_service_id = "test-service"
-            mock_settings.emailjs_case_template_id = "test-case-template"
-
-            mock_http_instance = AsyncMock()
-            mock_http_instance.post = mock_post
-            mock_http_instance.__aenter__ = AsyncMock(return_value=mock_http_instance)
-            mock_http_instance.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = mock_http_instance
-
-            result = await send_case_created_email(client_user, case_fixture)
+        """No recipient address → return False without touching the transport."""
+        with patch(
+            "app.notifications.case_notifications.send_email",
+            new=AsyncMock(return_value=True),
+        ) as mock_send:
+            result = await send_case_created_email_to_guest("", "Guest", case_fixture)
 
         assert result is False
+        mock_send.assert_not_awaited()
 
 
 class TestCaseCreatedWhatsApp:
@@ -223,25 +162,19 @@ class TestNotifyCaseCreated:
         case_fixture: Case,
     ) -> None:
         """notify_case_created returns status for both channels."""
-        mock_response = _emailjs_success_response()
-        mock_post = AsyncMock(return_value=mock_response)
-
         with (
+            patch(
+                "app.notifications.case_notifications.send_email",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "app.notifications.case_notifications._process_now",
+                new=AsyncMock(),
+            ),
             patch("app.notifications.case_notifications.settings") as mock_settings,
-            patch("httpx.AsyncClient") as mock_client_cls,
         ):
-            mock_settings.emailjs_public_key = "test-key"
-            mock_settings.emailjs_private_key = "test-private-key"
-            mock_settings.emailjs_service_id = "test-service"
-            mock_settings.emailjs_case_template_id = "test-case-template"
             mock_settings.whatsapp_api_token = "test-token"
             mock_settings.whatsapp_phone_number_id = "123456"
-
-            mock_http_instance = AsyncMock()
-            mock_http_instance.post = mock_post
-            mock_http_instance.__aenter__ = AsyncMock(return_value=mock_http_instance)
-            mock_http_instance.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = mock_http_instance
 
             result = await notify_case_created(
                 db_session, case_fixture, client_user, admin_user.id

--- a/services/api/tests/test_email_transport.py
+++ b/services/api/tests/test_email_transport.py
@@ -1,0 +1,120 @@
+"""Tests for the server-side SMTP email transport + OTP email (#29).
+
+Pure unit tests — ``aiosmtplib.send`` is mocked so nothing leaves the box.
+They lock in the behaviour the rest of the email stack relies on:
+
+- not configured  -> return False, never touch the relay;
+- port 587        -> STARTTLS; port 465 -> implicit TLS (never both);
+- relay error     -> swallowed, reported as False;
+- the OTP body actually carries the code.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import aiosmtplib
+import pytest
+
+from app.auth.email_verification import send_verification_email
+from app.notifications import email_transport
+from app.notifications.email_transport import is_configured, send_email
+
+
+def _smtp_settings(**overrides: object) -> SimpleNamespace:
+    base: dict[str, object] = {
+        "smtp_host": "smtp.example.com",
+        "smtp_port": 587,
+        "smtp_username": "",
+        "smtp_password": "",
+        "smtp_starttls": True,
+        "smtp_use_tls": False,
+        "smtp_from_email": "no-reply@etornie.ch",
+        "smtp_from_name": "Etornie",
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.unit
+class TestSmtpTransport:
+    async def test_skips_when_not_configured(self) -> None:
+        fake = _smtp_settings(smtp_host="", smtp_from_email="")
+        with (
+            patch.object(email_transport, "settings", fake),
+            patch("aiosmtplib.send", new=AsyncMock()) as mock_send,
+        ):
+            sent = await send_email(
+                to_email="a@example.com", to_name="A", subject="s", body="b"
+            )
+        assert sent is False
+        mock_send.assert_not_awaited()
+
+    async def test_sends_when_configured(self) -> None:
+        with (
+            patch.object(email_transport, "settings", _smtp_settings()),
+            patch("aiosmtplib.send", new=AsyncMock()) as mock_send,
+        ):
+            sent = await send_email(
+                to_email="client@example.com",
+                to_name="Client",
+                subject="Hello",
+                body="Body text",
+            )
+        assert sent is True
+        mock_send.assert_awaited_once()
+        message = mock_send.call_args.args[0]
+        assert message["To"] == "Client <client@example.com>"
+        assert message["From"] == "Etornie <no-reply@etornie.ch>"
+        assert message["Subject"] == "Hello"
+        assert "Body text" in message.get_content()
+        assert mock_send.call_args.kwargs["start_tls"] is True
+        assert mock_send.call_args.kwargs["use_tls"] is False
+
+    async def test_implicit_tls_disables_starttls(self) -> None:
+        # Port 465 / implicit TLS must never also offer STARTTLS.
+        fake = _smtp_settings(smtp_port=465, smtp_use_tls=True, smtp_starttls=True)
+        with (
+            patch.object(email_transport, "settings", fake),
+            patch("aiosmtplib.send", new=AsyncMock()) as mock_send,
+        ):
+            await send_email(
+                to_email="c@example.com", to_name=None, subject="s", body="b"
+            )
+        assert mock_send.call_args.kwargs["use_tls"] is True
+        assert mock_send.call_args.kwargs["start_tls"] is False
+
+    async def test_returns_false_on_smtp_error(self) -> None:
+        with (
+            patch.object(email_transport, "settings", _smtp_settings()),
+            patch(
+                "aiosmtplib.send",
+                new=AsyncMock(side_effect=aiosmtplib.SMTPException("boom")),
+            ),
+        ):
+            sent = await send_email(
+                to_email="c@example.com", to_name=None, subject="s", body="b"
+            )
+        assert sent is False
+
+    def test_is_configured(self) -> None:
+        with patch.object(email_transport, "settings", _smtp_settings()):
+            assert is_configured() is True
+        with patch.object(email_transport, "settings", _smtp_settings(smtp_host="")):
+            assert is_configured() is False
+
+
+@pytest.mark.unit
+class TestOtpEmail:
+    async def test_otp_email_carries_code(self) -> None:
+        with patch(
+            "app.auth.email_verification.send_email",
+            new=AsyncMock(return_value=True),
+        ) as mock_send:
+            sent = await send_verification_email("user@example.com", "User", "123456")
+        assert sent is True
+        kwargs = mock_send.call_args.kwargs
+        assert kwargs["to_email"] == "user@example.com"
+        assert "123456" in kwargs["body"]
+        assert "verification code" in kwargs["subject"].lower()

--- a/services/api/tests/test_observability.py
+++ b/services/api/tests/test_observability.py
@@ -1,0 +1,106 @@
+"""Tests for the observability layer (#51) — structured logging + tracing gate.
+
+A real in-memory OpenTelemetry TracerProvider (no mocks) proves the JSON log
+lines pick up the active trace/span ids, and that tracing init is a true no-op
+when disabled.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from app import observability
+from app.observability import (
+    JsonLogFormatter,
+    _ContextFilter,
+    _request_id_ctx,
+    configure_logging,
+    init_tracing,
+)
+
+
+def _record(msg: str = "hello") -> logging.LogRecord:
+    return logging.LogRecord(
+        name="test.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+@pytest.mark.unit
+class TestJsonFormatter:
+    def test_required_fields_present(self) -> None:
+        record = _record("payment confirmed")
+        _ContextFilter().filter(record)
+        data = json.loads(JsonLogFormatter().format(record))
+        assert data["level"] == "INFO"
+        assert data["logger"] == "test.logger"
+        assert data["message"] == "payment confirmed"
+        assert "timestamp" in data
+        assert "request_id" in data
+        # No span active → no trace fields should leak in.
+        assert "trace_id" not in data
+
+    def test_request_id_propagates(self) -> None:
+        token = _request_id_ctx.set("req-123")
+        try:
+            record = _record()
+            _ContextFilter().filter(record)
+            data = json.loads(JsonLogFormatter().format(record))
+        finally:
+            _request_id_ctx.reset(token)
+        assert data["request_id"] == "req-123"
+
+    def test_extra_fields_surface(self) -> None:
+        record = _record()
+        record.case_number = "ETR-2026-0042"  # mimics logger.info(..., extra=)
+        _ContextFilter().filter(record)
+        data = json.loads(JsonLogFormatter().format(record))
+        assert data["case_number"] == "ETR-2026-0042"
+
+    def test_trace_ids_present_under_active_span(self) -> None:
+        from opentelemetry.sdk.trace import TracerProvider
+
+        tracer = TracerProvider().get_tracer("test")
+        with tracer.start_as_current_span("unit-span"):
+            record = _record()
+            _ContextFilter().filter(record)
+            data = json.loads(JsonLogFormatter().format(record))
+        assert len(data["trace_id"]) == 32
+        assert len(data["span_id"]) == 16
+
+
+@pytest.mark.unit
+class TestConfigureLogging:
+    def test_idempotent_and_installs_context_handler(self) -> None:
+        root = logging.getLogger()
+        saved_handlers = root.handlers[:]
+        saved_level = root.level
+        try:
+            configure_logging()
+            configure_logging()  # second call must not raise
+            assert root.handlers
+            assert any(
+                any(isinstance(f, _ContextFilter) for f in h.filters)
+                for h in root.handlers
+            )
+        finally:
+            root.handlers[:] = saved_handlers
+            root.setLevel(saved_level)
+
+
+@pytest.mark.unit
+class TestTracingGate:
+    def test_disabled_is_noop(self) -> None:
+        from unittest.mock import patch
+
+        with patch.object(observability.settings, "otel_enabled", False):
+            result = init_tracing(app=None, engine=None)
+        assert result is False

--- a/services/api/tests/test_solana_events.py
+++ b/services/api/tests/test_solana_events.py
@@ -1,0 +1,174 @@
+"""Tests for the Helius event decoder + reconciler (#19).
+
+Real decoding (bytes built exactly as the on-chain program emits them) and real
+DB reconciliation (the test session + a Case fixture). No mocks except patching
+the webhook auth secret. A cross-check asserts the embedded event schemas still
+match the committed IDLs, so they cannot silently drift.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import base58
+import pytest
+
+from app.cases.models import CaseNftState
+from app.solana.events import (
+    EVENT_SCHEMAS,
+    DecodedEvent,
+    decode_log_events,
+    reconcile_events,
+)
+
+_MINTED_DISCRIMINATOR = bytes((251, 117, 139, 107, 151, 7, 234, 115))
+
+
+def _program_data_line(payload: bytes) -> str:
+    return "Program data: " + base64.b64encode(payload).decode("ascii")
+
+
+@pytest.mark.unit
+class TestDecode:
+    def test_decode_minted_event(self) -> None:
+        case_id = uuid.uuid4()
+        mint = bytes(range(32))
+        wallet = bytes(range(32, 64))
+        operator = bytes([7] * 32)
+        meta_hash = bytes([9] * 32)
+        ts = 1_700_000_000
+        payload = (
+            _MINTED_DISCRIMINATOR
+            + case_id.bytes
+            + mint
+            + wallet
+            + operator
+            + meta_hash
+            + ts.to_bytes(8, "little", signed=True)
+        )
+        events = decode_log_events(
+            ["Program log: noise", _program_data_line(payload), "not data"]
+        )
+        assert len(events) == 1
+        event = events[0]
+        assert event.name == "CaseNftMinted"
+        assert event.program == "etornie_ip_token"
+        assert event.case_id == case_id
+        assert event.values["mint"] == base58.b58encode(mint).decode("ascii")
+        assert event.values["client_wallet"] == base58.b58encode(wallet).decode("ascii")
+        assert event.values["metadata_uri_hash"] == meta_hash.hex()
+        assert event.values["timestamp"] == ts
+
+    def test_unknown_discriminator_ignored(self) -> None:
+        payload = bytes(range(8)) + bytes(64)  # not one of ours
+        assert decode_log_events([_program_data_line(payload)]) == []
+
+    def test_non_event_lines_ignored(self) -> None:
+        assert decode_log_events(["Program log: hi", "Program invoke [1]"]) == []
+
+
+@pytest.mark.unit
+class TestSchemasMatchIDL:
+    def test_discriminators_match_committed_idls(self) -> None:
+        idl_dir = Path(__file__).resolve().parents[3] / "idl"
+        if not idl_dir.exists():
+            pytest.skip("idl/ not present in this checkout")
+        from_idl: dict[tuple[str, str], list[int]] = {}
+        for fname, program in (
+            ("etornie_attestation.json", "etornie_attestation"),
+            ("etornie_ip_token.json", "etornie_ip_token"),
+        ):
+            idl = json.loads((idl_dir / fname).read_text())
+            for event in idl.get("events", []):
+                from_idl[(program, event["name"])] = event["discriminator"]
+        for schema in EVENT_SCHEMAS:
+            key = (schema.program, schema.name)
+            assert key in from_idl, f"{key} missing from committed IDL"
+            assert from_idl[key] == list(schema.discriminator), (
+                f"discriminator drift for {key}"
+            )
+
+
+@pytest.mark.integration
+class TestReconcile:
+    async def test_mint_reconciles_and_is_idempotent(
+        self, db_session, case_fixture
+    ) -> None:
+        mint = base58.b58encode(bytes([3] * 32)).decode("ascii")
+        event = DecodedEvent(
+            program="etornie_ip_token",
+            name="CaseNftMinted",
+            case_id=case_fixture.id,
+            values={
+                "case_id": case_fixture.id,
+                "mint": mint,
+                "client_wallet": base58.b58encode(bytes([4] * 32)).decode("ascii"),
+                "operator": base58.b58encode(bytes([5] * 32)).decode("ascii"),
+                "metadata_uri_hash": "00" * 32,
+                "timestamp": 1_700_000_000,
+            },
+        )
+        result = await reconcile_events(db_session, [event], "sig-mint-1")
+        assert result.reconciled == 1
+
+        await db_session.refresh(case_fixture)
+        assert case_fixture.nft_state == CaseNftState.minted
+        assert case_fixture.nft_mint == mint
+        assert case_fixture.nft_mint_tx == "sig-mint-1"
+
+        # Re-delivery must not change anything.
+        again = await reconcile_events(db_session, [event], "sig-mint-1")
+        assert again.reconciled == 0
+        assert again.skipped == 1
+
+    async def test_unknown_case_is_skipped(self, db_session) -> None:
+        event = DecodedEvent(
+            program="etornie_ip_token",
+            name="CaseNftBurned",
+            case_id=uuid.uuid4(),  # no such case
+            values={"case_id": uuid.uuid4(), "mint": "x", "timestamp": 1},
+        )
+        result = await reconcile_events(db_session, [event], "sig-x")
+        assert result.reconciled == 0
+        assert result.skipped == 1
+
+
+@pytest.mark.integration
+class TestWebhookAuth:
+    async def test_rejects_wrong_auth(self, client) -> None:
+        from app.config import settings
+
+        with patch.object(settings, "helius_webhook_auth", "secret-xyz"):
+            resp = await client.post(
+                "/solana/webhooks/helius",
+                json=[],
+                headers={"Authorization": "wrong"},
+            )
+        assert resp.status_code == 401
+
+    async def test_rejects_when_unconfigured(self, client) -> None:
+        from app.config import settings
+
+        with patch.object(settings, "helius_webhook_auth", ""):
+            resp = await client.post(
+                "/solana/webhooks/helius",
+                json=[],
+                headers={"Authorization": "anything"},
+            )
+        assert resp.status_code == 401
+
+    async def test_accepts_correct_auth(self, client) -> None:
+        from app.config import settings
+
+        with patch.object(settings, "helius_webhook_auth", "secret-xyz"):
+            resp = await client.post(
+                "/solana/webhooks/helius",
+                json=[],
+                headers={"Authorization": "secret-xyz"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["received"] == 0

--- a/services/api/tests/test_virus_scan.py
+++ b/services/api/tests/test_virus_scan.py
@@ -1,0 +1,83 @@
+"""Tests for ClamAV upload scanning (#55).
+
+``_scan_stream`` (the blocking clamd INSTREAM call) is mocked, so these run
+without a daemon or the ``clamd`` package installed. They pin the contract the
+upload handlers depend on:
+
+- disabled            -> no-op, daemon never touched;
+- clean ("OK")        -> passes;
+- infected ("FOUND")  -> InfectedFileError (400);
+- daemon error / bad status -> VirusScanUnavailableError (503, fail-closed).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.security import virus_scan
+from app.security.virus_scan import (
+    InfectedFileError,
+    VirusScanUnavailableError,
+    scan_upload,
+)
+
+
+@pytest.mark.unit
+class TestScanUpload:
+    async def test_disabled_is_noop(self) -> None:
+        mock_scan = MagicMock()
+        with (
+            patch.object(virus_scan.settings, "clamav_enabled", False),
+            patch.object(virus_scan, "_scan_stream", mock_scan),
+        ):
+            result = await scan_upload(b"anything", filename="x.pdf")
+        assert result is None
+        mock_scan.assert_not_called()
+
+    async def test_clean_passes(self) -> None:
+        with (
+            patch.object(virus_scan.settings, "clamav_enabled", True),
+            patch.object(
+                virus_scan, "_scan_stream", MagicMock(return_value=("OK", None))
+            ),
+        ):
+            assert await scan_upload(b"clean bytes", filename="ok.pdf") is None
+
+    async def test_infected_raises_400(self) -> None:
+        with (
+            patch.object(virus_scan.settings, "clamav_enabled", True),
+            patch.object(
+                virus_scan,
+                "_scan_stream",
+                MagicMock(return_value=("FOUND", "Eicar-Test-Signature")),
+            ),
+            pytest.raises(InfectedFileError) as excinfo,
+        ):
+            await scan_upload(b"X5O!P%@AP[4...", filename="evil.pdf")
+        assert excinfo.value.http_status == 400
+        assert excinfo.value.signature == "Eicar-Test-Signature"
+
+    async def test_daemon_error_fails_closed_503(self) -> None:
+        with (
+            patch.object(virus_scan.settings, "clamav_enabled", True),
+            patch.object(
+                virus_scan,
+                "_scan_stream",
+                MagicMock(side_effect=ConnectionError("clamd unreachable")),
+            ),
+            pytest.raises(VirusScanUnavailableError) as excinfo,
+        ):
+            await scan_upload(b"bytes", filename="x.pdf")
+        assert excinfo.value.http_status == 503
+
+    async def test_unexpected_status_fails_closed(self) -> None:
+        with (
+            patch.object(virus_scan.settings, "clamav_enabled", True),
+            patch.object(
+                virus_scan, "_scan_stream", MagicMock(return_value=("ERROR", "boom"))
+            ),
+            pytest.raises(VirusScanUnavailableError),
+        ):
+            await scan_upload(b"bytes", filename="x.pdf")

--- a/tests/attestation.ts
+++ b/tests/attestation.ts
@@ -6,7 +6,7 @@ import { resolve } from "path";
 import * as crypto from "crypto";
 import { assert } from "chai";
 
-import type { EtornieAttestation } from "../target/types/etornie_attestation";
+import type { EtornieAttestation } from "../idl/etornie_attestation";
 
 // Resolve paths from project root (process.cwd()) to work under both
 // CJS (__dirname) and ESM (no __dirname) module resolution — ts-mocha
@@ -14,7 +14,7 @@ import type { EtornieAttestation } from "../target/types/etornie_attestation";
 const PROJECT_ROOT = process.cwd();
 const idl = JSON.parse(
   readFileSync(
-    resolve(PROJECT_ROOT, "target/idl/etornie_attestation.json"),
+    resolve(PROJECT_ROOT, "idl/etornie_attestation.json"),
     "utf-8",
   ),
 );

--- a/tests/ip_token.ts
+++ b/tests/ip_token.ts
@@ -35,7 +35,7 @@ import { resolve } from "path";
 import * as crypto from "crypto";
 import { assert } from "chai";
 
-import type { EtornieIpToken } from "../target/types/etornie_ip_token";
+import type { EtornieIpToken } from "../idl/etornie_ip_token";
 
 const PROJECT_ROOT = process.cwd();
 const PROGRAM_ID = new PublicKey(
@@ -45,7 +45,7 @@ const DEVNET_URL = "https://api.devnet.solana.com";
 
 const idl = JSON.parse(
   readFileSync(
-    resolve(PROJECT_ROOT, "target/idl/etornie_ip_token.json"),
+    resolve(PROJECT_ROOT, "idl/etornie_ip_token.json"),
     "utf-8",
   ),
 );


### PR DESCRIPTION
# Lansman öncesi sağlamlaştırma: pre-commit, IDL'ler, SMTP e-posta, ClamAV (#49, #18, #29, #55)

Bu PR, `mehmethayirli` + `dr-wilson-empty`'e ortak atanmış dört issue'yu **tek dalda, her biri ayrı commit** olacak şekilde toplar. Admin merge'ini beklemeden ardışık ilerleyebilmek için bilinçli olarak tek branch'te biriktirildi; her commit kendi başına anlamlı ve geri alınabilir.

| Commit | Issue | Konu |
|--------|-------|------|
| `7482161` | #49 | pre-commit hooks (ruff, mypy, prettier, eslint) |
| `a85760b` | #18 | 3 program için IDL üretimi |
| `365831b` | #29 | EmailJS → server-side SMTP |
| `2d8a245` | #55 | Upload'larda ClamAV virüs taraması |

> **Kapsam disiplini:** Her issue yalnızca kendi kapsamında ele alındı. Yol boyunca karşılaşılan "toy"/eksik noktalara dokunulduğunda bu mesajda **not** olarak belirtildi.

---

## #49 — pre-commit hooks (ruff, mypy, prettier, eslint)

Push öncesi yerel lint/format/tip kontrolü. `Closes #49`.

**Ne yapıldı**
- **`.pre-commit-config.yaml`** (yeni): genel hijyen hook'ları (trailing whitespace, EOF, satır sonu, merge-conflict, büyük dosya, YAML/TOML/JSON kontrolü) + dört aracın her biri ait olduğu yere bağlandı:
  - **ruff** (lint `--fix` + format) → `services/api` (izole, pinli mirror; venv gerektirmez)
  - **mypy** → `services/api` (local hook; gerçek bağımlılıklar + pydantic eklentisi)
  - **eslint** → dashboard (CI'ın koştuğu `npm run lint`'in aynısı)
  - **prettier** → `tests/`, `scripts/`, `migrations/` altındaki Anchor/ZK TypeScript'i (repo'nun kendi pinli v2'si — sürüm kayması yok)
- **`services/api/pyproject.toml`**: `[tool.ruff]` + `[tool.mypy]` config; `dev` extra'sına `ruff`/`mypy`/`pre-commit`.
- **`.gitignore`**: `.ruff_cache/`, `.mypy_cache/`.
- **`README`**: "Pre-commit hooks" kurulum bölümü + araç başına önkoşullar.

**Önemli kararlar / nüanslar**
- **Kademeli benimseme:** Hook'lar yalnızca **stage'lenmiş** dosyaları denetler → mevcut 201 dosyalık birikmiş backlog hiçbir commit'i bloklamaz; lint dosya-dosya benimsenir.
- **mypy** `follow_imports=silent` + dosya-başına çağrı (`services/api/` öneki soyularak `app` paketi temiz çözülür) → hata kapsamı yalnızca dokunulan dosyayla sınırlı. İlk aşamada **bilinçli olarak gevşek** (`check_untyped_defs=false`) tutuldu; kod tabanı tiplendikçe sıkılaştırılabilir.
- **eslint** tüm dashboard'u CI ile birebir denetler (`eslint-config-next` Next kökünü aynı şekilde çözsün diye); main zaten yeşil.
- **ruff `UP017` ignore'a alındı**: kod tabanı baştan sona `timezone.utc` kullanıyor ve `datetime.UTC` autofix'i `from datetime import datetime` (sınıf adı modül adını gölgeliyor) altında **hatalı/riskli**. Tutarlılık için kapatıldı.
- **`idl/` tamamen hook dışı** (üretilmiş artifact'ler).
- **Doğrulama:** `pre-commit validate-config` ✓, `check-yaml`/`check-toml` mirror hook'ları temiz koştu, `ruff check`/`format --check` config'le çalışıyor, `exclude` regex 9 örnek yolda doğru, mypy önek-soyma `app/main.py` üretiyor.

**Notlar**
- Backend'de **daha önce hiç ruff/mypy config'i yoktu** (CI yalnızca `pytest` koşuyordu) — bu temel eksik kapatıldı.
- `pre-commit run --all-files` mevcut bir lint backlog'unu yüzeye çıkaracaktır (örn. `services/api/app/main.py`'de sırasız import bloğu + kullanılmayan `capture_exception` importu). **Kasıtlı olarak dokunulmadı** — bu PR aracı ekler; backlog temizliği kademelidir.

---

## #18 — 3 program için IDL üretimi

`idl/` yalnızca `etornie_zk_verifier.json` içeriyordu. Eksik iki IDL üretildi ve TS tüketicileri committed kopyalara bağlandı. `Closes #18`.

**Ne yapıldı**
- `anchor idl build -p <program> -o <json> --out-ts <ts>` ile **`idl/etornie_attestation.{json,ts}`** ve **`idl/etornie_ip_token.{json,ts}`** üretildi. `idl/` artık **üç** programın IDL'ini (+ self-contained TS tiplerini) içeriyor.
- **`tests/attestation.ts`**, **`tests/ip_token.ts`**, **`scripts/nft/burn.ts`**: IDL JSON'unu ve tipini gitignore'lu build çıktısı (`target/idl` + `target/types`) yerine **committed `idl/`**'den okuyor — zk-verifier testlerinin mevcut deseniyle aynı; böylece bu tüketiciler artık `anchor build` gerektirmiyor.

**Önemli kararlar / nüanslar**
- **Tipleme değişmedi** — yalnızca tipin geldiği yol `target/`'tan `idl/`'e taşındı (en düşük riskli yaklaşım); `Program<EtornieIpToken>` jenerikleri aynen korundu.
- **AC #3 "regenerate clients" nüansı:** Backend (`solana/client.py`) ve frontend instruction'ları **elle** kuruyor — Anchor "generated client" mimarisi yok. Gerçek IDL/tip tüketicileri TS testleri + NFT burn script'i; onlar committed artifact'lere yönlendirildi.

**Doğrulama**
- Üç IDL de `spec 0.1.0`; address'lerin üçü de `Anchor.toml [programs.devnet]` ile eşleşiyor; üretilen `.ts` tipleri self-contained (target-relative import yok); `tests/`+`scripts/` içinde kalan `target/idl|target/types` referansı yok.
- **Dürüst sınır:** `anchor test` (entegrasyon katmanı; yerel validator + funded keypair + 3 programın SBF build'i ister) yerelde **çalıştırılmadı** — CI'ın işi (`.github/workflows/anchor.yml`). IDL'ler yerel `anchor-cli 0.32.1` ile üretildi; programlar `anchor-lang 0.31.1`'i pinliyor (asıl IDL emitter'ı), bu CI'ın `ANCHOR_VERSION`'ıyla uyumlu.

---

## #29 — EmailJS → server-side SMTP

EmailJS bir frontend-key ürünü; server-side kullanımı public key'i ifşa eder ve teslimat garantisi vermez. Tüm transactional e-posta (kayıt OTP'si, dava + ödeme/dosyalama/NFT bildirimleri) tek bir server-side SMTP transport'una taşındı. `Closes #29`.

**Ne yapıldı**
- **`app/notifications/email_transport.py`** (yeni): her e-postanın geçtiği tek seam — `aiosmtplib` + `EmailMessage` üzerinden `send_email()`. SMTP yapılandırılmamışsa log+`False` döner, **asla raise etmez**.
- **3 EmailJS çağrısı** bu transport'a çevrildi: `auth/email_verification.py` (OTP), `notifications/email_dispatcher.py`, `notifications/case_notifications.py` (2 fonksiyon). OTP ve dava e-postalarının gövdeleri — eskiden EmailJS'in barındırdığı template'lerdeydi — artık **Python'da** oluşturuluyor.
- **`config.py`**: `emailjs_*` → `smtp_*` (host/port/username/password/starttls/use_tls/from_email/from_name). `.env.example` + `README` güncellendi.
- **`docs/EMAIL_DELIVERABILITY.md`** (yeni): SPF / DKIM / DMARC DNS kayıtları + SMTP kurulumu (AC #2 "deliverability documented").
- **`dashboard/src/app/docs/page.tsx`**: EmailJS değinmeleri → server-side SMTP.

**Önemli kararlar / nüanslar**
- **SMTP (aiosmtplib)**, SES-API değil: sağlayıcıdan bağımsız (SES/Postmark/Mailgun/Gmail hepsi SMTP konuşur), AWS SDK gerektirmez; SES yine SMTP endpoint'inden kullanılabilir.
- **587 STARTTLS** varsayılan; **465 implicit TLS** `SMTP_USE_TLS` ile. İkisi transport'ta karşılıklı dışlayıcı.
- **OTP kayıt davranışı korundu:** `send_verification_email` gönderim başarısızsa `False` döner; register endpoint'i bunu zaten `if not sent: raise` ile kullanıcıya hata olarak yansıtıyor.
- 3 yerde tekrarlanan EmailJS payload'u **tek transport'ta birleşti (DRY)**; bildirim metinleri artık kodda, versiyon kontrolünde.

**Notlar**
- Frontend aslında **hiçbir zaman EmailJS ile göndermiyordu** (bağımlılık yok) — gönderim hep server-side'dı; "frontend stops using it" kriteri bir docs-metni güncellemesiydi.
- `ruff UP017` config'de ignore (yukarıdaki #49 gerekçesi). Dokunulan dosyalarda ufak pürüzler giderildi: `test_case_notifications.py`'de kullanılmayan `pytest` importu + 3 yanıltıcı "EmailJS" yorum/docstring'i.
- **Testler:** `test_email_transport.py` (yeni — config gating, 587/465 TLS seçimi, relay hatası, OTP gövdesinin kodu taşıması); `test_case_notifications.py` EmailJS HTTP mock'ları → transport mock'larına çevrildi; `test_email_dispatcher.py` değişmedi (yalnızca korunan opt-in kurallarını + içerik şablonlarını test ediyor).
- **QA:** Manuel gönderim doğrulaması için **#116** açıldı (MuhammedAkinci'ye atandı) — 3 test yöntemi içeriyor (Mailpit/MailHog, gerçek relay, birim testleri).

---

## #55 — Upload'larda ClamAV virüs taraması

Güvenilmeyen istemciler patent dosyaları, avatar ve UK IPO marka görselleri yüklüyor. Her upload, baytlar diske/RAG indeksine ulaşmadan **önce** bir ClamAV daemon'ına akıtılıp eşleşmeler reddediliyor. `Closes #55`.

**Ne yapıldı**
- **`app/security/virus_scan.py`** (yeni): `scan_upload()` — `clamd` INSTREAM'i `asyncio.to_thread` ile (clamd senkron; event loop bloklanmasın). Kapalıyken no-op; eşleşmede `InfectedFileError` (400); açıkken tarama tamamlanamazsa `VirusScanUnavailableError` (503). İkisi de `UserFacingError` alt sınıfı → `app.main`'deki global handler temiz yanıta çevirir; çağıranlarda try/except yok.
- **4 upload giriş noktasına** bağlandı (baytlar okunduktan hemen sonra, kalıcılaşmadan önce): `documents/router.py`, `agent/router.py`, `users/router.py` (avatar), `services/ukipo/router.py`.
- **`config.py`**: `clamav_enabled` (varsayılan `false`)/`host`/`port`/`timeout`. **`pyproject`**: `clamd`.
- **`docker-compose.yml`**: `clamav` servisi (3310 + healthcheck + DB volume), app `depends_on`. `.env.example` + `README` `CLAMAV_*` ve servisi belgeliyor.

**Önemli kararlar / nüanslar**
- **Kapsam:** Issue "document upload" diyor; ama **dört güvenilmeyen upload noktasının tümü** kapsandı — aynı saldırı yüzeyi, tek paylaşılan tarayıcı.
- **Güvenlik duruşu:** Dev'de kapalı (daemon gerekmez). Açıkken erişilemez/hatalı daemon **fail-closed** (upload reddedilir, 503) — P0 kontrol, scanner kapatılarak sessizce baypas edilemesin.
- **`clamd` + `asyncio.to_thread`** (olgun senkron istemci); `clamd` lazy import edilir, böylece kapalı dev/test kurmayı gerektirmez.
- Hata yüzeyi `UserFacingError` üzerinden — mevcut hata katmanıyla tam uyumlu.

**Notlar**
- **Testler:** `test_virus_scan.py` (yeni) — disabled/clean/infected/daemon-error/bad-status, fail-closed dahil; `clamd` mock'lu (daemon/paket gerekmez).
- Dokunulan 4 router dosyasında **mevcut lint backlog'u** var (14 ruff bulgusu) — `HEAD` ile **birebir aynı** (yalnız satır numaraları kaymış), yani #55 getirmedi. #49 hook'u dokunulan dosyalarda yüzeye çıkaracak; kademeli temizlenir.
- **Dürüst sınır:** `pytest` ve gerçek-clamd **EICAR** uçtan-uca testi yerelde **çalıştırılmadı** (backend venv + clamd ister) — CI/QA'in işi. Prod'a güvenmeden önce 1 kez EICAR uçtan-uca koşmaya değer.

---

## Genel doğrulama ve dürüst sınırlar

- **Statik kontroller (yerelde geçti):** `ruff check` eklemeler temiz · yeni dosyalar `ruff format` temiz · `py_compile` tüm dokunulan/yeni dosyalarda temiz · YAML/TOML geçerli.
- **`pytest` hiçbir yerde çalıştırılmadı:** çıplak ortam (venv yok, Python 3.14 wheel riski, bazı testler Redis/clamd ister). Test paketleri CI'ın işi — `backend-test.yml` (pytest) ve `anchor.yml` (anchor test).
- **Push/PR yok:** çalışma bilinçli olarak tek dalda biriktirildi.

## Takipler / bağımlılıklar
- **#116** — #29 için manuel QA (MuhammedAkinci).
- **#21** (operator key → KMS/Vault) bu dalın **doğal devamı** ama **admin kararını bekliyor**: hangi managed signing backend'i (Vault Transit / AWS Secrets Manager / Fireblocks) — soru #21'e yorum olarak bırakıldı. Solana ed25519 kullandığı için AWS KMS native imzalayamıyor; öneri **HashiCorp Vault (Transit)**.
- **#20** (fee sponsorship) #21'in signer soyutlamasına bağlı.
