### PR TITLE
ci: fix red checks — gitleaks VK allowlist + Solana install (#118)

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -36,7 +36,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SOLANA_VERSION: "3.0.15"
+  # Valid Agave release on release.anza.xyz. The previous "3.0.15" did not
+  # exist, so the install step 404'd and every later step hit
+  # `solana: command not found`. Matches the toolchain used in local dev.
+  SOLANA_VERSION: "2.2.3"
   ANCHOR_VERSION: "0.31.1"
   RUST_TOOLCHAIN: "1.85.0"
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,6 +17,13 @@ paths = [
   '''tests/zk_fixtures/.*''',
   '''.*\.example$''',
   '''.*\.env\.example$''',
+  # Public Groth16 verifying keys — cryptographic *public* data, not secrets.
+  # The generic-api-key / high-entropy rules trip on their long byte arrays.
+  # The vk_*.rs glob covers vk_compliance.rs + vk_file_ownership.rs (and any
+  # future verifying-key module).
+  '''programs/etornie-zk-verifier/src/groth16_vk\.rs''',
+  '''programs/etornie-zk-verifier/src/vk_.*\.rs''',
+  '''scripts/extract_vk\.js''',
 ]
 
 # Literal strings that appear in tests and docs but are not real secrets.


### PR DESCRIPTION
## #118 — kod-dışı kırmızı CI check'lerini düzeltir

#117 review'ında çıkan, **her PR'da** kırmızı veren ve incelenen kodla ilgisi olmayan iki CI check'i düzeltir. `Closes #118`.

### 1. gitleaks — public Groth16 verifying key'leri allowlist'le
`generic-api-key` / yüksek-entropi kuralları, `etornie-zk-verifier` VK modüllerindeki + `scripts/extract_vk.js`'teki `VERIFYINGKEY` byte dizilerini yakalıyordu. Verifying key tanımı gereği **public** kriptografik veridir, secret değil. `.gitleaks.toml`'da ilgili dosyaları allowlist'ledim: `groth16_vk.rs`, `vk_*.rs` glob'u (→ `vk_compliance.rs` + `vk_file_ownership.rs`) ve `extract_vk.js`. `lib.rs` yalnızca VK isimlerini import ediyor (entropi yok) → dokunulmadı.

### 2. anchor build-and-test — bozuk Solana install'ı düzelt
`SOLANA_VERSION` `"3.0.15"` idi; bu sürüm release.anza.xyz'de **yok** → install adımı 404, sonraki adımlar `solana: command not found` ile patlıyordu. Geçerli bir Agave sürümüne (`"2.2.3"`, yerel dev ile aynı) çevirdim. URL/host doğruydu, yalnız sürüm hatalıydı.

Bağımsız (main'den) branch → merge edilince **tüm açık PR'larda** (#117 dahil) bu iki kırmızıyı yeşiller.
