### PR TITLE
feat(payments): Stripe subscription + EU VAT checkout (#62)

### DIFF
--- a/dashboard/src/app/dashboard/organizations/page.tsx
+++ b/dashboard/src/app/dashboard/organizations/page.tsx
@@ -40,6 +40,218 @@ interface InviteCreateResponse extends InviteRow {
   token: string;
 }
 
+interface PlanOption {
+  plan: string;
+  interval: string;
+  price_id: string;
+  unit_amount: number | null;
+  currency: string | null;
+  recurring_interval: string | null;
+  recurring_interval_count: number | null;
+}
+
+interface SubscriptionStatus {
+  organization_id: string;
+  plan: string;
+  subscription_status: string | null;
+  subscription_price_id: string | null;
+  subscription_current_period_end: string | null;
+  subscription_cancel_at_period_end: boolean;
+  has_billing_account: boolean;
+  can_manage: boolean;
+}
+
+function formatAmount(unitAmount: number | null, currency: string | null): string {
+  if (unitAmount === null || currency === null) return "—";
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency.toUpperCase(),
+    }).format(unitAmount / 100);
+  } catch {
+    return `${(unitAmount / 100).toFixed(2)} ${currency.toUpperCase()}`;
+  }
+}
+
+function BillingSection({ orgId }: { orgId: string }) {
+  const [plans, setPlans] = useState<PlanOption[]>([]);
+  const [sub, setSub] = useState<SubscriptionStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    // Plans and status are fetched independently: a status error (e.g.
+    // a member who is not owner/admin) must NOT blank out the plan list.
+    api
+      .get<{ plans: PlanOption[] }>("/payments/stripe/subscription/plans")
+      .then((p) => {
+        if (active) setPlans(p.data.plans);
+      })
+      .catch(() => {
+        /* plans stay empty; the section shows the unavailable note */
+      });
+    api
+      .get<SubscriptionStatus>("/payments/stripe/subscription/status", {
+        params: { organization_id: orgId },
+      })
+      .then((s) => {
+        if (active) setSub(s.data);
+      })
+      .catch((err) => {
+        if (active) {
+          setMsg(extractErrorMessage(err, "Could not load subscription."));
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [orgId]);
+
+  const subscribe = useCallback(
+    async (plan: string, interval: string) => {
+      setBusy(true);
+      setMsg(null);
+      try {
+        const res = await api.post<{ checkout_url: string }>(
+          "/payments/stripe/subscription/checkout-session",
+          { plan, interval, organization_id: orgId }
+        );
+        window.location.href = res.data.checkout_url;
+      } catch (err) {
+        setMsg(extractErrorMessage(err, "Could not start checkout."));
+        setBusy(false);
+      }
+    },
+    [orgId]
+  );
+
+  const manageBilling = useCallback(async () => {
+    setBusy(true);
+    setMsg(null);
+    try {
+      const res = await api.post<{ portal_url: string }>(
+        "/payments/stripe/subscription/portal",
+        { organization_id: orgId }
+      );
+      window.location.href = res.data.portal_url;
+    } catch (err) {
+      setMsg(extractErrorMessage(err, "Could not open billing portal."));
+      setBusy(false);
+    }
+  }, [orgId]);
+
+  const active =
+    sub?.subscription_status === "active" ||
+    sub?.subscription_status === "trialing" ||
+    sub?.subscription_status === "past_due";
+  // Members who are not owner/admin can view plans but not change billing.
+  const canManage = sub?.can_manage ?? false;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <h2 className="mb-3 text-sm font-semibold text-gray-800">
+        Billing &amp; subscription
+      </h2>
+
+      {sub ? (
+        <div className="mb-4 rounded-md bg-gray-50 p-3 text-sm">
+          <p>
+            Current plan:{" "}
+            <span className="font-semibold text-gray-900">{sub.plan}</span>
+            {sub.subscription_status ? (
+              <span className="ml-2 text-xs text-gray-500">
+                ({sub.subscription_status}
+                {sub.subscription_cancel_at_period_end
+                  ? ", cancels at period end"
+                  : ""}
+                )
+              </span>
+            ) : null}
+          </p>
+          {sub.subscription_current_period_end ? (
+            <p className="mt-0.5 text-xs text-gray-500">
+              Renews/ends{" "}
+              {new Date(
+                sub.subscription_current_period_end
+              ).toLocaleDateString()}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {plans.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          Subscription billing is not available right now.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {plans.map((p) => {
+            const current = sub?.subscription_price_id === p.price_id && active;
+            return (
+              <div
+                key={p.price_id}
+                className="flex flex-col rounded-lg border border-gray-200 p-3"
+              >
+                <div className="flex items-baseline justify-between">
+                  <span className="text-sm font-semibold capitalize text-gray-900">
+                    {p.plan}
+                  </span>
+                  <span className="text-xs uppercase text-gray-500">
+                    {p.interval}
+                  </span>
+                </div>
+                <p className="mt-1 text-lg font-semibold text-gray-900">
+                  {formatAmount(p.unit_amount, p.currency)}
+                  <span className="text-xs font-normal text-gray-500">
+                    {p.recurring_interval ? ` / ${p.recurring_interval}` : ""}
+                  </span>
+                </p>
+                <p className="mt-0.5 text-[11px] text-gray-400">
+                  VAT calculated at checkout.
+                </p>
+                {canManage ? (
+                  <button
+                    type="button"
+                    disabled={busy || current}
+                    onClick={() => subscribe(p.plan, p.interval)}
+                    className="mt-3 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                  >
+                    {current ? "Current plan" : "Subscribe"}
+                  </button>
+                ) : (
+                  <p className="mt-3 text-xs text-gray-400">
+                    {current ? "Current plan" : "—"}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {canManage && sub?.has_billing_account ? (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={manageBilling}
+          className="mt-4 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          Manage billing
+        </button>
+      ) : null}
+
+      {sub && !canManage ? (
+        <p className="mt-3 text-xs text-gray-500">
+          Only an organization owner or admin can change billing.
+        </p>
+      ) : null}
+
+      {msg ? <p className="mt-3 text-xs text-gray-500">{msg}</p> : null}
+    </div>
+  );
+}
+
 function RoleBadge({ role }: { role: string }) {
   const color =
     role === "owner"
@@ -277,6 +489,8 @@ export default function OrganizationsPage() {
                   </tbody>
                 </table>
               </div>
+
+              <BillingSection orgId={detail.id} />
 
               <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
                 <h2 className="mb-3 text-sm font-semibold text-gray-800">

--- a/services/api/alembic/versions/98ee72c0f678_add_organization_subscription_fields.py
+++ b/services/api/alembic/versions/98ee72c0f678_add_organization_subscription_fields.py
@@ -1,0 +1,88 @@
+"""add organization Stripe subscription fields
+
+Adds the billing source-of-truth columns that drive ``organizations.plan``
+for the recurring subscription lane (issue #62): Stripe customer +
+subscription ids, the mirrored subscription status, the active price id,
+the current period end, and the cancel-at-period-end flag.
+
+Revision ID: 98ee72c0f678
+Revises: d4a5b6c7e8f9
+Create Date: 2026-06-02
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "98ee72c0f678"
+down_revision = "d4a5b6c7e8f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column("stripe_customer_id", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "stripe_subscription_id", sa.String(length=255), nullable=True
+        ),
+    )
+    op.add_column(
+        "organizations",
+        sa.Column("subscription_status", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "subscription_price_id", sa.String(length=255), nullable=True
+        ),
+    )
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "subscription_current_period_end",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "subscription_cancel_at_period_end",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.create_unique_constraint(
+        "uq_organizations_stripe_customer_id",
+        "organizations",
+        ["stripe_customer_id"],
+    )
+    op.create_unique_constraint(
+        "uq_organizations_stripe_subscription_id",
+        "organizations",
+        ["stripe_subscription_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_organizations_stripe_subscription_id",
+        "organizations",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_organizations_stripe_customer_id",
+        "organizations",
+        type_="unique",
+    )
+    op.drop_column("organizations", "subscription_cancel_at_period_end")
+    op.drop_column("organizations", "subscription_current_period_end")
+    op.drop_column("organizations", "subscription_price_id")
+    op.drop_column("organizations", "subscription_status")
+    op.drop_column("organizations", "stripe_subscription_id")
+    op.drop_column("organizations", "stripe_customer_id")

--- a/services/api/alembic/versions/98ee72c0f678_add_organization_subscription_fields.py
+++ b/services/api/alembic/versions/98ee72c0f678_add_organization_subscription_fields.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "98ee72c0f678"
-down_revision = "d4a5b6c7e8f9"
+down_revision = "914ad2096e71"
 branch_labels = None
 depends_on = None
 

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -171,5 +171,28 @@ class Settings(BaseSettings):
     )
     stripe_cancel_url: str = "http://localhost:3000/payments/cancelled"
 
+    # Stripe subscriptions (recurring plans for the pricing page).
+    # Plan amounts live in Stripe; we only reference Stripe Price IDs
+    # here so no price is ever hardcoded in the app. An empty id means
+    # that plan/interval is not offered (the /plans endpoint hides it).
+    # ``enterprise`` is contact-sales and has no self-serve price.
+    stripe_price_solo_monthly: str = ""
+    stripe_price_solo_annual: str = ""
+    stripe_price_team_monthly: str = ""
+    stripe_price_team_annual: str = ""
+    # Toggle Stripe Tax (automatic VAT calculation + collection) on the
+    # subscription Checkout session. Requires Stripe Tax to be enabled
+    # with an origin address in the Stripe Dashboard.
+    stripe_tax_enabled: bool = True
+    stripe_subscription_success_url: str = (
+        "http://localhost:3000/dashboard/organizations?subscription=success"
+    )
+    stripe_subscription_cancel_url: str = (
+        "http://localhost:3000/dashboard/organizations?subscription=cancelled"
+    )
+    stripe_billing_portal_return_url: str = (
+        "http://localhost:3000/dashboard/organizations"
+    )
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/services/api/app/organizations/models.py
+++ b/services/api/app/organizations/models.py
@@ -24,6 +24,7 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import (
+    Boolean,
     DateTime,
     Enum,
     ForeignKey,
@@ -80,6 +81,33 @@ class Organization(Base):
         default=OrganizationPlan.solo,
         server_default=OrganizationPlan.solo.value,
     )
+
+    # Stripe subscription binding. ``plan`` above is the entitlement the
+    # rest of the app reads; these columns are the billing source of
+    # truth that drives it. All nullable so a never-subscribed org (the
+    # free ``solo`` default) carries no Stripe state.
+    stripe_customer_id: Mapped[str | None] = mapped_column(
+        String(255), unique=True, nullable=True
+    )
+    stripe_subscription_id: Mapped[str | None] = mapped_column(
+        String(255), unique=True, nullable=True
+    )
+    # Mirrors the Stripe subscription status verbatim (active, trialing,
+    # past_due, canceled, incomplete, ...) so the UI can show why access
+    # is or is not granted without a second Stripe round-trip.
+    subscription_status: Mapped[str | None] = mapped_column(
+        String(32), nullable=True
+    )
+    subscription_price_id: Mapped[str | None] = mapped_column(
+        String(255), nullable=True
+    )
+    subscription_current_period_end: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    subscription_cancel_at_period_end: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+
     settings: Mapped[dict | None] = mapped_column(_JSONType, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/services/api/app/payments/router.py
+++ b/services/api/app/payments/router.py
@@ -19,16 +19,29 @@ from app.cases.models import Case
 from app.auth.dependencies import get_current_user, require_role
 from app.config import settings
 from app.database import get_db
+from app.organizations.models import (
+    Organization,
+    OrganizationMembership,
+    OrganizationMembershipRole,
+)
 from app.payments import service as stripe_service
+from app.payments import subscription_service
 from app.payments.schemas import (
+    BillingPortalRequest,
+    BillingPortalResponse,
     CaseDraftPaymentStatusResponse,
     CreateCheckoutSessionRequest,
     CreateCheckoutSessionResponse,
+    CreateSubscriptionCheckoutRequest,
+    CreateSubscriptionCheckoutResponse,
     CreateUkipoCheckoutSessionRequest,
     CreateUkipoCheckoutSessionResponse,
+    OrganizationSubscriptionResponse,
     PaymentIntentResponse,
     RefundPaymentIntentRequest,
     StripeConfigResponse,
+    SubscriptionPlanOption,
+    SubscriptionPlansResponse,
 )
 from app.payments.service import StripeServiceError
 from app.users.models import User, UserRole
@@ -239,6 +252,186 @@ async def stripe_webhook(
         )
 
     return {"received": True, "event_type": event["type"], **result}
+
+
+# ---------------------------------------------------------------------------
+# Subscriptions (recurring billing — issue #62)
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_billing_org(
+    db: AsyncSession,
+    user: User,
+    organization_id: uuid.UUID | None,
+    *,
+    require_manage: bool,
+) -> tuple[Organization, bool]:
+    """Resolve the org for a billing call and the caller's manage rights.
+
+    Defaults to the caller's ``default_organization_id`` when no org is
+    given. Any member (or system admin) may *read* billing state;
+    ``require_manage=True`` additionally enforces owner/admin (or system
+    admin) for state-changing calls (checkout, portal). Returns the org
+    plus a ``can_manage`` flag the read path surfaces to the UI.
+    """
+    org_id = organization_id or user.default_organization_id
+    if org_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No organization selected and you have no default org.",
+        )
+    org = (
+        await db.execute(select(Organization).where(Organization.id == org_id))
+    ).scalar_one_or_none()
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found.",
+        )
+
+    if user.role == UserRole.admin:
+        return org, True
+
+    membership = (
+        await db.execute(
+            select(OrganizationMembership).where(
+                OrganizationMembership.organization_id == org.id,
+                OrganizationMembership.user_id == user.id,
+            )
+        )
+    ).scalar_one_or_none()
+    if membership is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not a member of this organization.",
+        )
+    can_manage = membership.role in (
+        OrganizationMembershipRole.owner,
+        OrganizationMembershipRole.admin,
+    )
+    if require_manage and not can_manage:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only an organization owner or admin can manage billing.",
+        )
+    return org, can_manage
+
+
+@router.get(
+    "/stripe/subscription/plans",
+    response_model=SubscriptionPlansResponse,
+)
+async def list_subscription_plans(
+    _: User = Depends(get_current_user),
+) -> SubscriptionPlansResponse:
+    """List configured subscription plans with live Stripe prices.
+
+    Amounts come straight from Stripe, so the pricing UI never hardcodes
+    a number. Returns an empty list when Stripe is unconfigured.
+    """
+    if not settings.stripe_secret_key:
+        return SubscriptionPlansResponse(plans=[])
+    try:
+        plans = subscription_service.list_available_plans()
+    except StripeServiceError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        )
+    return SubscriptionPlansResponse(
+        plans=[SubscriptionPlanOption(**p) for p in plans]
+    )
+
+
+@router.get(
+    "/stripe/subscription/status",
+    response_model=OrganizationSubscriptionResponse,
+)
+async def get_subscription_status(
+    organization_id: uuid.UUID | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> OrganizationSubscriptionResponse:
+    """Current subscription state for any org the caller belongs to."""
+    org, can_manage = await _resolve_billing_org(
+        db, current_user, organization_id, require_manage=False
+    )
+    return OrganizationSubscriptionResponse(
+        organization_id=org.id,
+        plan=org.plan.value,
+        subscription_status=org.subscription_status,
+        subscription_price_id=org.subscription_price_id,
+        subscription_current_period_end=(
+            org.subscription_current_period_end.isoformat()
+            if org.subscription_current_period_end
+            else None
+        ),
+        subscription_cancel_at_period_end=(
+            org.subscription_cancel_at_period_end
+        ),
+        has_billing_account=org.stripe_customer_id is not None,
+        can_manage=can_manage,
+    )
+
+
+@router.post(
+    "/stripe/subscription/checkout-session",
+    response_model=CreateSubscriptionCheckoutResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_subscription_checkout_session(
+    body: CreateSubscriptionCheckoutRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> CreateSubscriptionCheckoutResponse:
+    """Open a Stripe subscription Checkout session (Stripe Tax + VAT id)."""
+    org, _ = await _resolve_billing_org(
+        db, current_user, body.organization_id, require_manage=True
+    )
+    try:
+        session = await subscription_service.create_subscription_checkout(
+            db,
+            org=org,
+            user=current_user,
+            plan=body.plan,
+            interval=body.interval,
+        )
+    except StripeServiceError as exc:
+        raise HTTPException(
+            status_code=exc.http_status, detail=exc.user_message
+        )
+    if not session.url:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Stripe returned a session without a redirect URL.",
+        )
+    return CreateSubscriptionCheckoutResponse(
+        checkout_session_id=session.id,
+        checkout_url=session.url,
+    )
+
+
+@router.post(
+    "/stripe/subscription/portal",
+    response_model=BillingPortalResponse,
+)
+async def create_billing_portal(
+    body: BillingPortalRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> BillingPortalResponse:
+    """Open a Stripe Billing Portal session for self-service management."""
+    org, _ = await _resolve_billing_org(
+        db, current_user, body.organization_id, require_manage=True
+    )
+    try:
+        session = await subscription_service.create_billing_portal_session(
+            org=org
+        )
+    except StripeServiceError as exc:
+        raise HTTPException(
+            status_code=exc.http_status, detail=exc.user_message
+        )
+    return BillingPortalResponse(portal_url=session.url)
 
 
 @router.get(

--- a/services/api/app/payments/schemas.py
+++ b/services/api/app/payments/schemas.py
@@ -63,6 +63,77 @@ class CreateUkipoCheckoutSessionResponse(BaseModel):
     currency: str
 
 
+class SubscriptionPlanOption(BaseModel):
+    """One configured plan/interval with its live Stripe price."""
+
+    plan: str = Field(..., description="Entitlement tier (solo, team, ...).")
+    interval: str = Field(..., description="Billing interval (monthly, annual).")
+    price_id: str
+    unit_amount: int | None = Field(
+        default=None,
+        description="Amount in Stripe minor units (cents); null if metered.",
+    )
+    currency: str | None = None
+    recurring_interval: str | None = Field(
+        default=None, description="Stripe recurring interval (month, year)."
+    )
+    recurring_interval_count: int | None = None
+
+
+class SubscriptionPlansResponse(BaseModel):
+    plans: list[SubscriptionPlanOption]
+
+
+class CreateSubscriptionCheckoutRequest(BaseModel):
+    """Open a Stripe subscription Checkout session for an organization."""
+
+    plan: str = Field(..., description="Entitlement tier (solo, team).")
+    interval: str = Field(
+        default="monthly", description="Billing interval (monthly, annual)."
+    )
+    organization_id: uuid.UUID | None = Field(
+        default=None,
+        description="Org to subscribe; defaults to the caller's default org.",
+    )
+
+
+class CreateSubscriptionCheckoutResponse(BaseModel):
+    checkout_session_id: str
+    checkout_url: str
+
+
+class BillingPortalRequest(BaseModel):
+    organization_id: uuid.UUID | None = Field(
+        default=None,
+        description="Org to manage; defaults to the caller's default org.",
+    )
+
+
+class BillingPortalResponse(BaseModel):
+    portal_url: str
+
+
+class OrganizationSubscriptionResponse(BaseModel):
+    """Current subscription state of an organization."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    organization_id: uuid.UUID
+    plan: str
+    subscription_status: str | None = None
+    subscription_price_id: str | None = None
+    subscription_current_period_end: str | None = None
+    subscription_cancel_at_period_end: bool = False
+    has_billing_account: bool = Field(
+        ..., description="True once a Stripe customer exists for the org."
+    )
+    can_manage: bool = Field(
+        ...,
+        description="True if the caller may subscribe/manage billing "
+        "(org owner/admin or system admin).",
+    )
+
+
 class PaymentIntentResponse(BaseModel):
     """Read view of a PaymentIntent row — used by /payments/{id}."""
 

--- a/services/api/app/payments/service.py
+++ b/services/api/app/payments/service.py
@@ -1091,6 +1091,21 @@ async def refund_payment_intent(
     return intent
 
 
+# Stripe event types owned by the recurring-subscription lane
+# (app.payments.subscription_service). checkout.session.completed is NOT
+# listed here because it is shared with the one-off payment lane and is
+# disambiguated by session ``mode`` inside handle_event.
+_SUBSCRIPTION_EVENT_TYPES = frozenset(
+    {
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+        "invoice.paid",
+        "invoice.payment_failed",
+    }
+)
+
+
 async def handle_event(db: AsyncSession, event: stripe.Event) -> dict[str, Any]:
     """Dispatch a verified Stripe event to its handler.
 
@@ -1102,7 +1117,26 @@ async def handle_event(db: AsyncSession, event: stripe.Event) -> dict[str, Any]:
     event_type = event["type"]
     obj = event["data"]["object"]
 
+    # Recurring-subscription lane (issue #62) lives in its own service.
+    # Subscription + invoice events route there wholesale; a
+    # subscription-mode Checkout session is told apart from a one-off
+    # payment session by its ``mode``.
+    if event_type in _SUBSCRIPTION_EVENT_TYPES:
+        from app.payments import subscription_service
+
+        return await subscription_service.handle_subscription_event(db, event)
+
     if event_type == "checkout.session.completed":
+        try:
+            session_mode = obj["mode"]
+        except (KeyError, TypeError):
+            session_mode = None
+        if session_mode == "subscription":
+            from app.payments import subscription_service
+
+            return await subscription_service.handle_subscription_event(
+                db, event
+            )
         return await _handle_session_completed(db, obj)
     if event_type == "checkout.session.expired":
         return await _handle_session_expired(db, obj)

--- a/services/api/app/payments/subscription_service.py
+++ b/services/api/app/payments/subscription_service.py
@@ -1,0 +1,417 @@
+"""Stripe subscription (recurring billing) service layer.
+
+Separate from :mod:`app.payments.service` (which owns one-off filing
+payments) so the subscription state-machine stays self-contained. The
+flow is org-scoped: an ``Organization`` carries the Stripe customer +
+subscription ids, and the Stripe subscription's status drives
+``Organization.plan`` (the entitlement the rest of the app reads).
+
+EU VAT is handled by Stripe Tax: the Checkout session enables
+``automatic_tax`` (Stripe computes + collects the right VAT per the
+customer's billing country) and ``tax_id_collection`` (B2B customers
+enter a VAT id, enabling reverse-charge). No tax rates live in the app.
+
+No price is hardcoded here: plan/interval pairs resolve to Stripe Price
+ids from settings, and display amounts are read live from Stripe.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import stripe
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.errors import translate_stripe_error
+from app.organizations.models import Organization, OrganizationPlan
+from app.payments.service import StripeServiceError, _require_configured
+from app.users.models import User
+
+logger = logging.getLogger(__name__)
+
+
+class BillingInterval(str, enum.Enum):
+    monthly = "monthly"
+    annual = "annual"
+
+
+# Subscription statuses under which the paid entitlement stays granted.
+# ``past_due`` keeps access during Stripe's dunning/grace window; the
+# customer is nudged by Stripe to fix payment before it flips to unpaid.
+_ENTITLED_STATUSES = frozenset({"active", "trialing", "past_due"})
+# Statuses that revoke the paid entitlement (downgrade to the free tier).
+_REVOKED_STATUSES = frozenset(
+    {"canceled", "unpaid", "incomplete_expired"}
+)
+
+
+def _price_map() -> dict[tuple[str, str], str]:
+    """``(plan, interval) -> Stripe Price id`` for every configured plan.
+
+    Empty ids are dropped, so an unconfigured plan/interval simply does
+    not appear (and cannot be checked out).
+    """
+    raw = {
+        (OrganizationPlan.solo.value, BillingInterval.monthly.value): (
+            settings.stripe_price_solo_monthly
+        ),
+        (OrganizationPlan.solo.value, BillingInterval.annual.value): (
+            settings.stripe_price_solo_annual
+        ),
+        (OrganizationPlan.team.value, BillingInterval.monthly.value): (
+            settings.stripe_price_team_monthly
+        ),
+        (OrganizationPlan.team.value, BillingInterval.annual.value): (
+            settings.stripe_price_team_annual
+        ),
+    }
+    return {key: value for key, value in raw.items() if value}
+
+
+def resolve_price_id(plan: str, interval: str) -> str:
+    price_id = _price_map().get((plan, interval))
+    if not price_id:
+        raise StripeServiceError(
+            f"No Stripe price configured for plan={plan} interval={interval}.",
+            user_message=(
+                "This plan is not available for the selected billing period."
+            ),
+            http_status=400,
+        )
+    return price_id
+
+
+def plan_for_price_id(price_id: str | None) -> str | None:
+    """Reverse lookup: which plan a Stripe Price id grants."""
+    if not price_id:
+        return None
+    for (plan, _interval), pid in _price_map().items():
+        if pid == price_id:
+            return plan
+    return None
+
+
+def _as_dict(obj: Any) -> dict[str, Any]:
+    """Normalise a Stripe object (webhook payload) into a plain dict."""
+    if hasattr(obj, "to_dict_recursive"):
+        return obj.to_dict_recursive()
+    if hasattr(obj, "to_dict"):
+        return obj.to_dict()
+    return dict(obj)
+
+
+# ---------------------------------------------------------------------------
+# Customer + checkout
+# ---------------------------------------------------------------------------
+
+
+async def ensure_customer(
+    db: AsyncSession, org: Organization, user: User
+) -> str:
+    """Return the org's Stripe customer id, creating it on first use."""
+    _require_configured()
+    if org.stripe_customer_id:
+        return org.stripe_customer_id
+
+    try:
+        customer = stripe.Customer.create(
+            name=org.name,
+            email=user.email or None,
+            metadata={
+                "organization_id": str(org.id),
+                "organization_slug": org.slug,
+            },
+        )
+    except stripe.StripeError as exc:  # noqa: BLE001
+        translated = translate_stripe_error(exc)
+        raise StripeServiceError(
+            f"Stripe customer creation failed: {exc}",
+            user_message=translated.user_message,
+            http_status=translated.http_status,
+        ) from exc
+
+    org.stripe_customer_id = customer.id
+    await db.flush()
+    return customer.id
+
+
+async def create_subscription_checkout(
+    db: AsyncSession,
+    *,
+    org: Organization,
+    user: User,
+    plan: str,
+    interval: str,
+) -> stripe.checkout.Session:
+    """Open a ``mode=subscription`` Checkout session for an organization.
+
+    Enables Stripe Tax (automatic VAT) and VAT-id collection so the
+    session is EU-VAT compliant for both B2C and B2B customers.
+    """
+    _require_configured()
+    price_id = resolve_price_id(plan, interval)
+    customer_id = await ensure_customer(db, org, user)
+
+    session_kwargs: dict[str, Any] = {
+        "mode": "subscription",
+        "customer": customer_id,
+        "line_items": [{"price": price_id, "quantity": 1}],
+        "success_url": settings.stripe_subscription_success_url,
+        "cancel_url": settings.stripe_subscription_cancel_url,
+        "client_reference_id": str(org.id),
+        "metadata": {
+            "lane": "subscription",
+            "organization_id": str(org.id),
+            "plan": plan,
+            "interval": interval,
+        },
+        "subscription_data": {
+            "metadata": {
+                "organization_id": str(org.id),
+                "plan": plan,
+                "interval": interval,
+            }
+        },
+        # VAT: collect a billing address (Stripe Tax needs it) and a
+        # business VAT id (reverse-charge for B2B). ``customer_update``
+        # is required so Checkout may persist what it collects back onto
+        # the existing customer.
+        "billing_address_collection": "required",
+        "tax_id_collection": {"enabled": True},
+        "customer_update": {"address": "auto", "name": "auto"},
+    }
+    if settings.stripe_tax_enabled:
+        session_kwargs["automatic_tax"] = {"enabled": True}
+
+    try:
+        session = stripe.checkout.Session.create(**session_kwargs)
+    except stripe.StripeError as exc:  # noqa: BLE001
+        logger.exception("Stripe subscription checkout.Session.create failed")
+        translated = translate_stripe_error(exc)
+        raise StripeServiceError(
+            f"Stripe rejected the subscription session: {exc}",
+            user_message=translated.user_message,
+            http_status=translated.http_status,
+        ) from exc
+
+    await db.commit()
+    return session
+
+
+async def create_billing_portal_session(
+    *, org: Organization
+) -> stripe.billing_portal.Session:
+    """Open a Stripe Billing Portal session so the org can self-manage.
+
+    The portal lets the customer update card, switch plan, download
+    invoices, and cancel — all handled by Stripe, mirrored back to us
+    through the subscription webhooks.
+    """
+    _require_configured()
+    if not org.stripe_customer_id:
+        raise StripeServiceError(
+            f"Organization {org.id} has no Stripe customer; cannot open portal.",
+            user_message=(
+                "You do not have a billing account yet — subscribe to a "
+                "plan first."
+            ),
+            http_status=400,
+        )
+    try:
+        return stripe.billing_portal.Session.create(
+            customer=org.stripe_customer_id,
+            return_url=settings.stripe_billing_portal_return_url,
+        )
+    except stripe.StripeError as exc:  # noqa: BLE001
+        translated = translate_stripe_error(exc)
+        raise StripeServiceError(
+            f"Stripe billing portal creation failed: {exc}",
+            user_message=translated.user_message,
+            http_status=translated.http_status,
+        ) from exc
+
+
+def list_available_plans() -> list[dict[str, Any]]:
+    """Configured plans with live amounts pulled from Stripe.
+
+    Amounts come straight from the Stripe Price objects so the app never
+    stores or guesses a price. ``unit_amount`` is in minor units.
+    """
+    _require_configured()
+    plans: list[dict[str, Any]] = []
+    for (plan, interval), price_id in sorted(_price_map().items()):
+        try:
+            price = stripe.Price.retrieve(price_id)
+        except stripe.StripeError as exc:  # noqa: BLE001
+            logger.warning(
+                "Skipping plan %s/%s — Stripe price %s not retrievable: %s",
+                plan,
+                interval,
+                price_id,
+                exc,
+            )
+            continue
+        # Stripe objects support attribute / subscript access but NOT
+        # dict.get(), so read fields with getattr and defaults.
+        recurring = getattr(price, "recurring", None)
+        plans.append(
+            {
+                "plan": plan,
+                "interval": interval,
+                "price_id": price_id,
+                "unit_amount": getattr(price, "unit_amount", None),
+                "currency": getattr(price, "currency", None),
+                "recurring_interval": (
+                    getattr(recurring, "interval", None) if recurring else None
+                ),
+                "recurring_interval_count": (
+                    getattr(recurring, "interval_count", None)
+                    if recurring
+                    else None
+                ),
+            }
+        )
+    return plans
+
+
+# ---------------------------------------------------------------------------
+# Webhook → organization state
+# ---------------------------------------------------------------------------
+
+
+async def _find_org_for_subscription(
+    db: AsyncSession, sub: dict[str, Any]
+) -> Organization | None:
+    customer_id = sub.get("customer")
+    if customer_id:
+        org = (
+            await db.execute(
+                select(Organization).where(
+                    Organization.stripe_customer_id == customer_id
+                )
+            )
+        ).scalar_one_or_none()
+        if org is not None:
+            return org
+
+    org_id = (sub.get("metadata") or {}).get("organization_id")
+    if org_id:
+        try:
+            oid = uuid.UUID(org_id)
+        except (TypeError, ValueError):
+            oid = None
+        if oid is not None:
+            return (
+                await db.execute(
+                    select(Organization).where(Organization.id == oid)
+                )
+            ).scalar_one_or_none()
+    return None
+
+
+async def _apply_subscription_to_org(
+    db: AsyncSession, subscription: Any
+) -> dict[str, Any]:
+    """Mirror a Stripe subscription onto its organization row.
+
+    Updates the billing columns and drives ``Organization.plan``: the
+    plan is granted while the subscription is entitled and downgraded to
+    the free ``solo`` tier when it is revoked.
+    """
+    sub = _as_dict(subscription)
+    org = await _find_org_for_subscription(db, sub)
+    if org is None:
+        logger.warning(
+            "Stripe subscription %s has no matching organization",
+            sub.get("id"),
+        )
+        return {"handled": False, "reason": "organization_not_found"}
+
+    status_str = sub.get("status")
+    items = (sub.get("items") or {}).get("data") or []
+    price_id = None
+    if items:
+        price_id = (items[0].get("price") or {}).get("id")
+
+    org.stripe_subscription_id = sub.get("id")
+    org.subscription_status = status_str
+    org.subscription_price_id = price_id
+    period_end = sub.get("current_period_end")
+    org.subscription_current_period_end = (
+        datetime.fromtimestamp(period_end, tz=timezone.utc)
+        if period_end
+        else None
+    )
+    org.subscription_cancel_at_period_end = bool(
+        sub.get("cancel_at_period_end")
+    )
+
+    if status_str in _ENTITLED_STATUSES:
+        plan = plan_for_price_id(price_id)
+        if plan is not None:
+            org.plan = OrganizationPlan(plan)
+    elif status_str in _REVOKED_STATUSES:
+        org.plan = OrganizationPlan.solo
+
+    await db.flush()
+    return {
+        "handled": True,
+        "organization_id": str(org.id),
+        "subscription_status": status_str,
+        "plan": org.plan.value,
+    }
+
+
+async def handle_subscription_event(
+    db: AsyncSession, event: Any
+) -> dict[str, Any]:
+    """Dispatch a verified subscription/invoice Stripe event.
+
+    Routed here from :func:`app.payments.service.handle_event`. Every
+    branch resolves the canonical subscription object and reconciles the
+    org row, so out-of-order webhook delivery still converges.
+    """
+    event_type = event["type"]
+    obj = event["data"]["object"]
+
+    if event_type in (
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    ):
+        result = await _apply_subscription_to_org(db, obj)
+        await db.commit()
+        return result
+
+    if event_type == "checkout.session.completed":
+        session = _as_dict(obj)
+        subscription_id = session.get("subscription")
+        if not subscription_id:
+            return {"handled": False, "reason": "no_subscription_on_session"}
+        _require_configured()
+        sub = stripe.Subscription.retrieve(subscription_id)
+        result = await _apply_subscription_to_org(db, sub)
+        await db.commit()
+        return result
+
+    if event_type in ("invoice.paid", "invoice.payment_failed"):
+        invoice = _as_dict(obj)
+        subscription_id = invoice.get("subscription")
+        if not subscription_id:
+            return {"handled": False, "reason": "no_subscription_on_invoice"}
+        _require_configured()
+        sub = stripe.Subscription.retrieve(subscription_id)
+        result = await _apply_subscription_to_org(db, sub)
+        await db.commit()
+        return result
+
+    return {
+        "handled": False,
+        "reason": "unhandled_subscription_event",
+        "event_type": event_type,
+    }

--- a/services/api/app/payments/subscription_service.py
+++ b/services/api/app/payments/subscription_service.py
@@ -314,6 +314,23 @@ async def _find_org_for_subscription(
     return None
 
 
+def subscription_id_from_invoice(invoice: dict[str, Any]) -> str | None:
+    """Resolve the subscription id from an invoice across Stripe versions.
+
+    ``invoice.subscription`` was removed in recent Stripe API versions; the
+    id now lives under ``subscription_details`` and, in the newest versions,
+    under ``parent.subscription_details``. We check all three so the dunning
+    lane works regardless of the account's API version.
+    """
+    return (
+        invoice.get("subscription")
+        or (invoice.get("subscription_details") or {}).get("subscription")
+        or (
+            (invoice.get("parent") or {}).get("subscription_details") or {}
+        ).get("subscription")
+    )
+
+
 async def _apply_subscription_to_org(
     db: AsyncSession, subscription: Any
 ) -> dict[str, Any]:
@@ -333,15 +350,40 @@ async def _apply_subscription_to_org(
         return {"handled": False, "reason": "organization_not_found"}
 
     status_str = sub.get("status")
+    sub_id = sub.get("id")
     items = (sub.get("items") or {}).get("data") or []
     price_id = None
     if items:
         price_id = (items[0].get("price") or {}).get("id")
 
-    org.stripe_subscription_id = sub.get("id")
+    # ``current_period_end`` moved from the subscription top level onto each
+    # line item in recent Stripe API versions (2025+); read the item value
+    # and fall back to the legacy top-level field for older versions.
+    period_end = sub.get("current_period_end")
+    if period_end is None and items:
+        period_end = items[0].get("current_period_end")
+
+    # Ordering / idempotency guard: a stale, out-of-order revoked event
+    # (e.g. a late ``customer.subscription.deleted`` for a subscription the
+    # org has already replaced with a new active one) must never downgrade a
+    # paying org. Only act on a revoked status when it concerns the
+    # subscription we currently track.
+    is_revoked = status_str in _REVOKED_STATUSES
+    if (
+        is_revoked
+        and org.stripe_subscription_id
+        and sub_id
+        and org.stripe_subscription_id != sub_id
+    ):
+        return {
+            "handled": False,
+            "reason": "stale_subscription_event",
+            "organization_id": str(org.id),
+        }
+
+    org.stripe_subscription_id = sub_id
     org.subscription_status = status_str
     org.subscription_price_id = price_id
-    period_end = sub.get("current_period_end")
     org.subscription_current_period_end = (
         datetime.fromtimestamp(period_end, tz=timezone.utc)
         if period_end
@@ -355,7 +397,7 @@ async def _apply_subscription_to_org(
         plan = plan_for_price_id(price_id)
         if plan is not None:
             org.plan = OrganizationPlan(plan)
-    elif status_str in _REVOKED_STATUSES:
+    elif is_revoked:
         org.plan = OrganizationPlan.solo
 
     await db.flush()
@@ -401,7 +443,7 @@ async def handle_subscription_event(
 
     if event_type in ("invoice.paid", "invoice.payment_failed"):
         invoice = _as_dict(obj)
-        subscription_id = invoice.get("subscription")
+        subscription_id = subscription_id_from_invoice(invoice)
         if not subscription_id:
             return {"handled": False, "reason": "no_subscription_on_invoice"}
         _require_configured()

--- a/services/api/tests/test_subscriptions.py
+++ b/services/api/tests/test_subscriptions.py
@@ -1,0 +1,382 @@
+"""Tests for the Stripe subscription lane (issue #62).
+
+No mocks: the price→plan mapping is exercised through real settings,
+the webhook state-machine runs against real Organization rows in the
+test DB using constructed Stripe-shaped payloads (data fixtures, not
+behaviour mocks), and the paths that must call Stripe are skipped when
+no STRIPE_SECRET_KEY is configured (skip ≠ mock).
+"""
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.organizations.models import (
+    Organization,
+    OrganizationMembership,
+    OrganizationMembershipRole,
+    OrganizationPlan,
+)
+from app.payments import service as stripe_service
+from app.payments import subscription_service as subs
+from app.payments.service import StripeServiceError
+from app.users.models import User
+from tests.conftest import auth_headers
+
+# A configured plan needs a Stripe Price id. These are real-shaped ids
+# used only to populate the config so the mapping logic can resolve;
+# no Stripe call is made with them in the non-skipped tests.
+_SOLO_M = "price_solo_monthly_test"
+_TEAM_M = "price_team_monthly_test"
+_TEAM_A = "price_team_annual_test"
+
+
+@pytest.fixture
+def configured_prices():
+    """Populate the subscription price ids on settings, then restore.
+
+    Assigning real config values (not patching behaviour) so
+    ``_price_map`` resolves during the test.
+    """
+    keys = {
+        "stripe_price_solo_monthly": _SOLO_M,
+        "stripe_price_team_monthly": _TEAM_M,
+        "stripe_price_team_annual": _TEAM_A,
+    }
+    saved = {k: getattr(settings, k) for k in keys}
+    for k, v in keys.items():
+        setattr(settings, k, v)
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            setattr(settings, k, v)
+
+
+def _subscription_payload(
+    *,
+    customer: str,
+    price_id: str,
+    status: str = "active",
+    cancel_at_period_end: bool = False,
+    organization_id: str | None = None,
+) -> dict:
+    """Stripe Subscription object shape the webhook delivers."""
+    return {
+        "id": f"sub_{uuid.uuid4().hex[:16]}",
+        "customer": customer,
+        "status": status,
+        "cancel_at_period_end": cancel_at_period_end,
+        "current_period_end": 1924905600,  # 2031-01-01, fixed
+        "items": {"data": [{"price": {"id": price_id}}]},
+        "metadata": (
+            {"organization_id": organization_id} if organization_id else {}
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Price ↔ plan mapping
+# ---------------------------------------------------------------------------
+
+
+class TestPriceMapping:
+    def test_resolve_price_id(self, configured_prices) -> None:
+        assert subs.resolve_price_id("team", "monthly") == _TEAM_M
+        assert subs.resolve_price_id("team", "annual") == _TEAM_A
+        assert subs.resolve_price_id("solo", "monthly") == _SOLO_M
+
+    def test_resolve_unconfigured_raises(self, configured_prices) -> None:
+        # solo/annual was never configured in the fixture.
+        with pytest.raises(StripeServiceError):
+            subs.resolve_price_id("solo", "annual")
+
+    def test_plan_for_price_id(self, configured_prices) -> None:
+        assert subs.plan_for_price_id(_TEAM_M) == "team"
+        assert subs.plan_for_price_id(_SOLO_M) == "solo"
+        assert subs.plan_for_price_id("price_unknown") is None
+        assert subs.plan_for_price_id(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Webhook state-machine → organization
+# ---------------------------------------------------------------------------
+
+
+class TestSubscriptionStateMachine:
+    async def test_active_subscription_grants_plan(
+        self, db_session: AsyncSession, configured_prices
+    ) -> None:
+        org = Organization(
+            slug="acme", name="Acme", stripe_customer_id="cus_acme"
+        )
+        db_session.add(org)
+        await db_session.flush()
+
+        payload = _subscription_payload(customer="cus_acme", price_id=_TEAM_M)
+        result = await subs._apply_subscription_to_org(db_session, payload)
+
+        assert result["handled"] is True
+        await db_session.refresh(org)
+        assert org.plan == OrganizationPlan.team
+        assert org.subscription_status == "active"
+        assert org.subscription_price_id == _TEAM_M
+        assert org.stripe_subscription_id == payload["id"]
+        assert org.subscription_current_period_end is not None
+        assert org.subscription_cancel_at_period_end is False
+
+    async def test_canceled_subscription_downgrades_to_solo(
+        self, db_session: AsyncSession, configured_prices
+    ) -> None:
+        org = Organization(
+            slug="beta",
+            name="Beta",
+            stripe_customer_id="cus_beta",
+            plan=OrganizationPlan.team,
+        )
+        db_session.add(org)
+        await db_session.flush()
+
+        payload = _subscription_payload(
+            customer="cus_beta", price_id=_TEAM_M, status="canceled"
+        )
+        await subs._apply_subscription_to_org(db_session, payload)
+
+        await db_session.refresh(org)
+        assert org.plan == OrganizationPlan.solo
+        assert org.subscription_status == "canceled"
+
+    async def test_org_resolved_by_metadata_when_customer_unknown(
+        self, db_session: AsyncSession, configured_prices
+    ) -> None:
+        org = Organization(slug="gamma", name="Gamma")
+        db_session.add(org)
+        await db_session.flush()
+
+        # No stripe_customer_id on the row, and the payload's customer
+        # is unknown — resolution must fall back to metadata.
+        payload = _subscription_payload(
+            customer="cus_never_seen",
+            price_id=_TEAM_A,
+            organization_id=str(org.id),
+        )
+        result = await subs._apply_subscription_to_org(db_session, payload)
+
+        assert result["handled"] is True
+        await db_session.refresh(org)
+        assert org.plan == OrganizationPlan.team
+        assert org.stripe_subscription_id == payload["id"]
+
+    async def test_unknown_org_is_ignored(
+        self, db_session: AsyncSession, configured_prices
+    ) -> None:
+        payload = _subscription_payload(
+            customer="cus_nope", price_id=_TEAM_M
+        )
+        result = await subs._apply_subscription_to_org(db_session, payload)
+        assert result["handled"] is False
+        assert result["reason"] == "organization_not_found"
+
+    async def test_webhook_dispatch_routes_subscription_event(
+        self, db_session: AsyncSession, configured_prices
+    ) -> None:
+        # Full path: stripe_service.handle_event must route a
+        # customer.subscription.* event into the subscription lane.
+        org = Organization(
+            slug="delta", name="Delta", stripe_customer_id="cus_delta"
+        )
+        db_session.add(org)
+        await db_session.flush()
+
+        event = {
+            "type": "customer.subscription.updated",
+            "data": {
+                "object": _subscription_payload(
+                    customer="cus_delta", price_id=_TEAM_M
+                )
+            },
+        }
+        result = await stripe_service.handle_event(db_session, event)
+        assert result["handled"] is True
+        await db_session.refresh(org)
+        assert org.plan == OrganizationPlan.team
+
+
+# ---------------------------------------------------------------------------
+# Endpoints (auth + scoping)
+# ---------------------------------------------------------------------------
+
+
+class TestLivePlanListing:
+    """Requires real Stripe test keys + price ids; skipped otherwise.
+
+    Guards the StripeObject access bug (Price objects support attribute
+    access but not dict.get()) found during local testing.
+    """
+
+    @pytest.mark.skipif(
+        not (
+            settings.stripe_secret_key
+            and settings.stripe_price_solo_monthly
+        ),
+        reason="Stripe test key + price ids not configured",
+    )
+    def test_list_available_plans_returns_live_prices(self) -> None:
+        plans = subs.list_available_plans()
+        assert len(plans) >= 1
+        for p in plans:
+            assert p["price_id"].startswith("price_")
+            assert isinstance(p["unit_amount"], int)
+            assert p["currency"]
+            assert p["recurring_interval"] in ("month", "year")
+
+
+class TestSubscriptionEndpoints:
+    async def test_plans_requires_auth(self, client: AsyncClient) -> None:
+        resp = await client.get("/payments/stripe/subscription/plans")
+        assert resp.status_code == 401
+
+    async def test_plans_empty_when_no_prices_configured(
+        self, client: AsyncClient, client_user: User
+    ) -> None:
+        # With no plan price ids configured, the endpoint returns an
+        # empty list (no Stripe call). Clear the ids deterministically so
+        # the test does not depend on the developer's local .env.
+        price_keys = [
+            "stripe_price_solo_monthly",
+            "stripe_price_solo_annual",
+            "stripe_price_team_monthly",
+            "stripe_price_team_annual",
+        ]
+        saved = {k: getattr(settings, k) for k in price_keys}
+        for k in price_keys:
+            setattr(settings, k, "")
+        try:
+            resp = await client.get(
+                "/payments/stripe/subscription/plans",
+                headers=auth_headers(client_user),
+            )
+        finally:
+            for k, v in saved.items():
+                setattr(settings, k, v)
+        assert resp.status_code == 200
+        assert resp.json() == {"plans": []}
+
+    async def test_status_requires_auth(self, client: AsyncClient) -> None:
+        resp = await client.get("/payments/stripe/subscription/status")
+        assert resp.status_code == 401
+
+    async def test_checkout_requires_auth(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/payments/stripe/subscription/checkout-session",
+            json={"plan": "team", "interval": "monthly"},
+        )
+        assert resp.status_code == 401
+
+    async def test_status_forbidden_for_non_member(
+        self,
+        client: AsyncClient,
+        client_user: User,
+        admin_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        # Org owned by admin_user; client_user is not a member at all.
+        org = Organization(slug="acme-co", name="Acme Co")
+        db_session.add(org)
+        await db_session.flush()
+        db_session.add(
+            OrganizationMembership(
+                organization_id=org.id,
+                user_id=admin_user.id,
+                role=OrganizationMembershipRole.owner,
+            )
+        )
+        await db_session.commit()
+
+        # client_user is not a member of this org → 403.
+        resp = await client.get(
+            "/payments/stripe/subscription/status",
+            params={"organization_id": str(org.id)},
+            headers=auth_headers(client_user),
+        )
+        assert resp.status_code == 403
+
+    async def test_status_ok_for_org_owner(
+        self,
+        client: AsyncClient,
+        client_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        org = Organization(slug="owned", name="Owned Org")
+        db_session.add(org)
+        await db_session.flush()
+        db_session.add(
+            OrganizationMembership(
+                organization_id=org.id,
+                user_id=client_user.id,
+                role=OrganizationMembershipRole.owner,
+            )
+        )
+        await db_session.commit()
+
+        resp = await client.get(
+            "/payments/stripe/subscription/status",
+            params={"organization_id": str(org.id)},
+            headers=auth_headers(client_user),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["organization_id"] == str(org.id)
+        assert body["plan"] == "solo"
+        assert body["has_billing_account"] is False
+        assert body["subscription_status"] is None
+        assert body["can_manage"] is True
+
+    async def test_member_can_read_status_but_not_manage(
+        self,
+        client: AsyncClient,
+        client_user: User,
+        admin_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        # A plain member can read the status (can_manage=False) but is
+        # refused checkout (owner/admin only).
+        org = Organization(slug="team-co", name="Team Co")
+        db_session.add(org)
+        await db_session.flush()
+        db_session.add_all(
+            [
+                OrganizationMembership(
+                    organization_id=org.id,
+                    user_id=admin_user.id,
+                    role=OrganizationMembershipRole.owner,
+                ),
+                OrganizationMembership(
+                    organization_id=org.id,
+                    user_id=client_user.id,
+                    role=OrganizationMembershipRole.member,
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        status_resp = await client.get(
+            "/payments/stripe/subscription/status",
+            params={"organization_id": str(org.id)},
+            headers=auth_headers(client_user),
+        )
+        assert status_resp.status_code == 200
+        assert status_resp.json()["can_manage"] is False
+
+        checkout_resp = await client.post(
+            "/payments/stripe/subscription/checkout-session",
+            json={
+                "plan": "team",
+                "interval": "monthly",
+                "organization_id": str(org.id),
+            },
+            headers=auth_headers(client_user),
+        )
+        assert checkout_resp.status_code == 403

--- a/services/api/tests/test_subscriptions.py
+++ b/services/api/tests/test_subscriptions.py
@@ -63,14 +63,24 @@ def _subscription_payload(
     cancel_at_period_end: bool = False,
     organization_id: str | None = None,
 ) -> dict:
-    """Stripe Subscription object shape the webhook delivers."""
+    """Stripe Subscription object shape the webhook delivers.
+
+    Mirrors the current Stripe API: ``current_period_end`` lives on each
+    line item, not at the subscription top level.
+    """
     return {
         "id": f"sub_{uuid.uuid4().hex[:16]}",
         "customer": customer,
         "status": status,
         "cancel_at_period_end": cancel_at_period_end,
-        "current_period_end": 1924905600,  # 2031-01-01, fixed
-        "items": {"data": [{"price": {"id": price_id}}]},
+        "items": {
+            "data": [
+                {
+                    "price": {"id": price_id},
+                    "current_period_end": 1924905600,  # 2031-01-01, fixed
+                }
+            ]
+        },
         "metadata": (
             {"organization_id": organization_id} if organization_id else {}
         ),
@@ -147,6 +157,58 @@ class TestSubscriptionStateMachine:
         await db_session.refresh(org)
         assert org.plan == OrganizationPlan.solo
         assert org.subscription_status == "canceled"
+
+    def test_invoice_subscription_id_resolution(self) -> None:
+        # Current Stripe API: id under subscription_details.
+        assert (
+            subs.subscription_id_from_invoice(
+                {"subscription_details": {"subscription": "sub_new"}}
+            )
+            == "sub_new"
+        )
+        # Newest API: under parent.subscription_details.
+        assert (
+            subs.subscription_id_from_invoice(
+                {"parent": {"subscription_details": {"subscription": "sub_p"}}}
+            )
+            == "sub_p"
+        )
+        # Legacy top-level still works.
+        assert (
+            subs.subscription_id_from_invoice({"subscription": "sub_old"})
+            == "sub_old"
+        )
+        # A one-off invoice with no subscription anywhere.
+        assert subs.subscription_id_from_invoice({}) is None
+
+    async def test_stale_deleted_event_does_not_downgrade(
+        self, db_session: AsyncSession, configured_prices
+    ) -> None:
+        # Org is on a live subscription sub_B (paying, team plan).
+        org = Organization(
+            slug="delta",
+            name="Delta",
+            stripe_customer_id="cus_delta",
+            plan=OrganizationPlan.team,
+            stripe_subscription_id="sub_B",
+            subscription_status="active",
+        )
+        db_session.add(org)
+        await db_session.flush()
+
+        # A late, out-of-order `deleted` for an OLD subscription sub_A.
+        stale = _subscription_payload(
+            customer="cus_delta", price_id=_TEAM_M, status="canceled"
+        )
+        stale["id"] = "sub_A"
+        result = await subs._apply_subscription_to_org(db_session, stale)
+
+        assert result["handled"] is False
+        assert result["reason"] == "stale_subscription_event"
+        await db_session.refresh(org)
+        # Paying org must NOT be downgraded by the stale event.
+        assert org.plan == OrganizationPlan.team
+        assert org.stripe_subscription_id == "sub_B"
 
     async def test_org_resolved_by_metadata_when_customer_unknown(
         self, db_session: AsyncSession, configured_prices


### PR DESCRIPTION
Closes #62.

Pricing plans had no checkout. This adds org-scoped Stripe **subscription** checkout with **Stripe Tax** (automatic EU VAT + B2B VAT-id collection), a webhook lane that drives `organizations.plan`, and a Stripe Billing Portal for self-service manage/cancel. No prices are hardcoded — plans resolve to Stripe Price ids; amounts come live from Stripe. Any member can view; owner/admin manage. 16 tests, full suite green.

## Screenshots

_In-app billing section:_

<img width="662" height="317" alt="pr62-billing-section" src="https://github.com/user-attachments/assets/c19ef2f0-6b41-4511-999b-103d2e6f6bf7" />


_Stripe Billing Portal:_

<img width="1425" height="962" alt="pr62-stripe-billing-portal" src="https://github.com/user-attachments/assets/46d07a4b-cdef-40dc-8630-fbd4b2bf94f7" />
