### PR TITLE
feat(esign): Yousign e-signature for case documents (#63)

### DIFF
--- a/dashboard/src/app/dashboard/cases/[id]/page.tsx
+++ b/dashboard/src/app/dashboard/cases/[id]/page.tsx
@@ -207,6 +207,22 @@ interface DocumentItem {
   created_at: string;
 }
 
+interface SignatureRequestItem {
+  id: string;
+  case_id: string;
+  source_document_id: string | null;
+  signed_document_id: string | null;
+  signer_email: string;
+  signer_name: string;
+  subject: string;
+  provider: string;
+  status: string;
+  signing_url: string | null;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 interface RequiredDocument {
   id: string;
   case_id: string;
@@ -246,6 +262,10 @@ export default function CaseDetailPage({
   const [notes, setNotes] = useState<CaseNote[]>([]);
   const [documents, setDocuments] = useState<DocumentItem[]>([]);
   const [requiredDocs, setRequiredDocs] = useState<RequiredDocument[]>([]);
+  const [signatureRequests, setSignatureRequests] = useState<
+    SignatureRequestItem[]
+  >([]);
+  const [sendingSignDocId, setSendingSignDocId] = useState<string | null>(null);
   const [proposals, setProposals] = useState<ProposalItem[]>([]);
   const [userRole, setUserRole] = useState<string>("");
   const [loading, setLoading] = useState(true);
@@ -340,6 +360,17 @@ export default function CaseDetailPage({
     }
   }, [id]);
 
+  const fetchSignatureRequests = useCallback(async () => {
+    try {
+      const res = await api.get<{
+        signature_requests: SignatureRequestItem[];
+      }>(`/esign/signature-requests`, { params: { case_id: id } });
+      setSignatureRequests(res.data.signature_requests);
+    } catch {
+      // e-signature may be disabled (no provider key) — ignore silently.
+    }
+  }, [id]);
+
   const fetchProposals = useCallback(async () => {
     try {
       const res = await api.get<{ proposals: ProposalItem[]; total: number }>(
@@ -375,6 +406,17 @@ export default function CaseDetailPage({
         setDocuments(docsRes.data.documents);
         setRequiredDocs(reqDocsRes.data.required_documents);
         setProposals(proposalsRes.data.proposals);
+        // E-signature requests load independently and tolerate being
+        // disabled (no provider key) — never block case load on them.
+        api
+          .get<{ signature_requests: SignatureRequestItem[] }>(
+            `/esign/signature-requests`,
+            { params: { case_id: id } }
+          )
+          .then((r) => {
+            if (!cancelled) setSignatureRequests(r.data.signature_requests);
+          })
+          .catch(() => {});
       } catch {
         if (!cancelled) setError("Failed to load case details.");
       } finally {
@@ -642,6 +684,26 @@ export default function CaseDetailPage({
       setDocSuccess("");
     } finally {
       setProvingDocId(null);
+    }
+  }
+
+  async function handleSendForSignature(doc: DocumentItem) {
+    setSendingSignDocId(doc.id);
+    setDocError("");
+    setDocSuccess("");
+    try {
+      await api.post(`/esign/signature-requests`, {
+        case_id: id,
+        document_id: doc.id,
+      });
+      setDocSuccess("Document sent for signature.");
+      await fetchSignatureRequests();
+    } catch (err: unknown) {
+      setDocError(
+        extractErrorMessage(err, "Failed to send document for signature.")
+      );
+    } finally {
+      setSendingSignDocId(null);
     }
   }
 
@@ -1825,6 +1887,13 @@ export default function CaseDetailPage({
             ) : (
               documents.map((doc) => {
                 const docStatusConfig = DOC_STATUS_CONFIG[doc.status] ?? DOC_STATUS_CONFIG.uploaded;
+                const sigReq = signatureRequests.find(
+                  (s) => s.source_document_id === doc.id
+                );
+                const isPdf =
+                  (doc.file_type ?? "").includes("pdf") ||
+                  doc.filename.toLowerCase().endsWith(".pdf");
+                const isCancelledDoc = doc.status === "cancelled";
                 return (
                   <div
                     key={doc.id}
@@ -1910,6 +1979,53 @@ export default function CaseDetailPage({
                                     : "Prove ownership"}
                                 </button>
                               )}
+                            {/* E-signature: send for signature, or show status */}
+                            {sigReq ? (
+                              <span
+                                className="inline-flex items-center gap-1 text-xs"
+                                title={sigReq.error ?? sigReq.subject}
+                              >
+                                <span
+                                  className={`rounded px-1.5 py-0.5 font-medium ${
+                                    sigReq.status === "signed"
+                                      ? "bg-emerald-100 text-emerald-700"
+                                      : sigReq.status === "ongoing"
+                                        ? "bg-amber-100 text-amber-700"
+                                        : sigReq.status === "error"
+                                          ? "bg-red-100 text-red-700"
+                                          : "bg-gray-100 text-gray-600"
+                                  }`}
+                                >
+                                  e-sign: {sigReq.status}
+                                </span>
+                                {sigReq.status === "ongoing" &&
+                                sigReq.signing_url ? (
+                                  <a
+                                    href={sigReq.signing_url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-blue-600 hover:underline"
+                                  >
+                                    Open signing link
+                                  </a>
+                                ) : null}
+                              </span>
+                            ) : (
+                              isPdf &&
+                              !isCancelledDoc && (
+                                <button
+                                  type="button"
+                                  onClick={() => handleSendForSignature(doc)}
+                                  disabled={sendingSignDocId === doc.id}
+                                  className="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                                  title="Send this PDF to the client for e-signature (Yousign)"
+                                >
+                                  {sendingSignDocId === doc.id
+                                    ? "Sending…"
+                                    : "Send for signature"}
+                                </button>
+                              )
+                            )}
                             <button
                               type="button"
                               onClick={async () => {

--- a/services/api/alembic/versions/914ad2096e71_add_signature_requests.py
+++ b/services/api/alembic/versions/914ad2096e71_add_signature_requests.py
@@ -1,0 +1,111 @@
+"""add signature_requests table (e-signature, issue #63)
+
+Tracks documents sent to a signer through an external e-signature
+provider (Yousign). Links the source PDF, the signer, the provider's
+correlation ids, and the resulting signed PDF document.
+
+Revision ID: 914ad2096e71
+Revises: d4a5b6c7e8f9
+Create Date: 2026-06-03
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "914ad2096e71"
+down_revision = "d4a5b6c7e8f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    signature_provider = sa.Enum("yousign", name="signature_provider")
+    signature_status = sa.Enum(
+        "draft",
+        "ongoing",
+        "signed",
+        "declined",
+        "expired",
+        "cancelled",
+        "error",
+        name="signature_request_status",
+    )
+
+    op.create_table(
+        "signature_requests",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("case_id", sa.Uuid(), nullable=False),
+        sa.Column("source_document_id", sa.Uuid(), nullable=True),
+        sa.Column("signed_document_id", sa.Uuid(), nullable=True),
+        sa.Column("signer_user_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "provider",
+            signature_provider,
+            nullable=False,
+            server_default="yousign",
+        ),
+        sa.Column(
+            "status",
+            signature_status,
+            nullable=False,
+            server_default="draft",
+        ),
+        sa.Column("provider_request_id", sa.String(length=128), nullable=True),
+        sa.Column("provider_document_id", sa.String(length=128), nullable=True),
+        sa.Column("provider_signer_id", sa.String(length=128), nullable=True),
+        sa.Column("signer_email", sa.String(length=255), nullable=False),
+        sa.Column("signer_name", sa.String(length=255), nullable=False),
+        sa.Column("signing_url", sa.String(length=1000), nullable=True),
+        sa.Column("subject", sa.String(length=255), nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["case_id"], ["cases.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["source_document_id"], ["documents.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["signed_document_id"], ["documents.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["signer_user_id"], ["users.id"], ondelete="CASCADE"
+        ),
+    )
+    op.create_index(
+        "ix_signature_requests_case_id", "signature_requests", ["case_id"]
+    )
+    op.create_index(
+        "ix_signature_requests_provider_request_id",
+        "signature_requests",
+        ["provider_request_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_signature_requests_provider_request_id",
+        table_name="signature_requests",
+    )
+    op.drop_index(
+        "ix_signature_requests_case_id", table_name="signature_requests"
+    )
+    op.drop_table("signature_requests")
+    sa.Enum(name="signature_request_status").drop(op.get_bind())
+    sa.Enum(name="signature_provider").drop(op.get_bind())

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -171,5 +171,14 @@ class Settings(BaseSettings):
     )
     stripe_cancel_url: str = "http://localhost:3000/payments/cancelled"
 
+    # Yousign e-signature (issue #63). Empty ``yousign_api_key`` disables
+    # the entire /esign/* surface (fail-closed). The sandbox base URL is
+    # the default; switch to https://api.yousign.app/v3 for production.
+    # ``yousign_webhook_secret`` verifies the X-Yousign-Signature-256
+    # header (HMAC-SHA256); empty value makes the webhook fail closed.
+    yousign_api_key: str = ""
+    yousign_base_url: str = "https://api-sandbox.yousign.app/v3"
+    yousign_webhook_secret: str = ""
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/services/api/app/esign/models.py
+++ b/services/api/app/esign/models.py
@@ -1,0 +1,106 @@
+"""E-signature models (issue #63).
+
+A ``SignatureRequest`` tracks one document sent to one signer (the case
+client) through an external provider (Yousign today). It links the
+source PDF document, the signer, the provider's request id, and — once
+signed — the stored signed PDF document. The status mirrors the
+provider's lifecycle so the UI can show progress without a round-trip.
+"""
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class SignatureRequestStatus(str, enum.Enum):
+    draft = "draft"          # created locally, not yet sent to provider
+    ongoing = "ongoing"      # sent; awaiting the signer
+    signed = "signed"        # completed; signed PDF stored
+    declined = "declined"    # signer refused
+    expired = "expired"      # provider expiry reached
+    cancelled = "cancelled"  # cancelled before completion
+    error = "error"          # provider/integration failure
+
+
+class SignatureProvider(str, enum.Enum):
+    yousign = "yousign"
+
+
+class SignatureRequest(Base):
+    __tablename__ = "signature_requests"
+
+    case_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("cases.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # The PDF being signed. SET NULL on delete so a cancelled source
+    # document does not cascade-delete the signature audit trail.
+    source_document_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("documents.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # The resulting signed PDF, stored as its own Document once the
+    # provider reports completion.
+    signed_document_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("documents.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    signer_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    provider: Mapped[SignatureProvider] = mapped_column(
+        Enum(SignatureProvider, name="signature_provider"),
+        nullable=False,
+        default=SignatureProvider.yousign,
+        server_default=SignatureProvider.yousign.value,
+    )
+    status: Mapped[SignatureRequestStatus] = mapped_column(
+        Enum(SignatureRequestStatus, name="signature_request_status"),
+        nullable=False,
+        default=SignatureRequestStatus.draft,
+        server_default=SignatureRequestStatus.draft.value,
+    )
+
+    # Provider correlation ids (Yousign signature_request / document /
+    # signer). Nullable until the provider calls return.
+    provider_request_id: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, index=True
+    )
+    provider_document_id: Mapped[str | None] = mapped_column(
+        String(128), nullable=True
+    )
+    provider_signer_id: Mapped[str | None] = mapped_column(
+        String(128), nullable=True
+    )
+
+    signer_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    signer_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Hosted signing link the signer opens (also emailed by the provider).
+    signing_url: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    # Free-text title shown in the provider dashboard + signer email.
+    subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    source_document = relationship(
+        "Document", foreign_keys=[source_document_id]
+    )
+    signed_document = relationship(
+        "Document", foreign_keys=[signed_document_id]
+    )

--- a/services/api/app/esign/router.py
+++ b/services/api/app/esign/router.py
@@ -1,0 +1,192 @@
+"""FastAPI endpoints for e-signature (issue #63).
+
+- POST /esign/signature-requests        — send a case document to its
+                                           client for e-signature (auth).
+- GET  /esign/signature-requests        — list a case's requests (auth).
+- GET  /esign/signature-requests/{id}   — read one request (auth).
+- POST /esign/webhook                    — Yousign-signed event receiver.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_user
+from app.cases.models import Case
+from app.database import get_db
+from app.documents.models import Document
+from app.esign import service as esign_service
+from app.esign import yousign_client
+from app.esign.models import SignatureRequest
+from app.esign.schemas import (
+    CreateSignatureRequestBody,
+    SignatureRequestListResponse,
+    SignatureRequestResponse,
+)
+from app.esign.yousign_client import EsignError
+from app.users.models import User, UserRole
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/esign", tags=["esign"])
+
+
+def _can_access_case(user: User, case: Case) -> bool:
+    """Admins (operators) and the bound client may act on a case."""
+    return user.role == UserRole.admin or user.id == case.client_id
+
+
+def _to_response(row: SignatureRequest) -> SignatureRequestResponse:
+    return SignatureRequestResponse(
+        id=row.id,
+        case_id=row.case_id,
+        source_document_id=row.source_document_id,
+        signed_document_id=row.signed_document_id,
+        signer_email=row.signer_email,
+        signer_name=row.signer_name,
+        subject=row.subject,
+        provider=row.provider.value,
+        status=row.status.value,
+        signing_url=row.signing_url,
+        error=row.error,
+        created_at=row.created_at.isoformat(),
+        updated_at=row.updated_at.isoformat(),
+    )
+
+
+@router.post(
+    "/signature-requests",
+    response_model=SignatureRequestResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_signature_request(
+    body: CreateSignatureRequestBody,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SignatureRequestResponse:
+    """Send a case document to the case client for e-signature."""
+    case = (
+        await db.execute(select(Case).where(Case.id == body.case_id))
+    ).scalar_one_or_none()
+    if case is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Case not found")
+    if not _can_access_case(current_user, case):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "You do not have access to this case"
+        )
+    if case.client_id is None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "This case has no bound client to sign as.",
+        )
+
+    document = (
+        await db.execute(
+            select(Document).where(Document.id == body.document_id)
+        )
+    ).scalar_one_or_none()
+    if document is None or document.case_id != case.id:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, "Document not found on this case"
+        )
+
+    signer = (
+        await db.execute(select(User).where(User.id == case.client_id))
+    ).scalar_one_or_none()
+    if signer is None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, "Case client account not found."
+        )
+
+    try:
+        row = await esign_service.create_signature_request_for_document(
+            db, case=case, document=document, signer=signer, subject=body.subject
+        )
+    except EsignError as exc:
+        await db.commit()  # persist the error row before surfacing
+        raise HTTPException(status_code=exc.http_status, detail=exc.user_message)
+
+    await db.commit()
+    await db.refresh(row)
+    return _to_response(row)
+
+
+@router.get(
+    "/signature-requests",
+    response_model=SignatureRequestListResponse,
+)
+async def list_signature_requests(
+    case_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SignatureRequestListResponse:
+    """List signature requests for a case the caller can access."""
+    case = (
+        await db.execute(select(Case).where(Case.id == case_id))
+    ).scalar_one_or_none()
+    if case is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Case not found")
+    if not _can_access_case(current_user, case):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "You do not have access to this case"
+        )
+    rows = await esign_service.list_for_case(db, case_id)
+    return SignatureRequestListResponse(
+        signature_requests=[_to_response(r) for r in rows]
+    )
+
+
+@router.get(
+    "/signature-requests/{request_id}",
+    response_model=SignatureRequestResponse,
+)
+async def get_signature_request(
+    request_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> SignatureRequestResponse:
+    row = await esign_service.get_request(db, request_id)
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Request not found")
+    case = (
+        await db.execute(select(Case).where(Case.id == row.case_id))
+    ).scalar_one_or_none()
+    if case is None or not _can_access_case(current_user, case):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Request not found")
+    return _to_response(row)
+
+
+@router.post("/webhook", status_code=status.HTTP_200_OK)
+async def yousign_webhook(
+    request: Request,
+    x_yousign_signature_256: str | None = Header(
+        default=None, alias="X-Yousign-Signature-256"
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Receive a Yousign-signed webhook and reconcile the request row.
+
+    The raw body is required for HMAC verification — do not parse JSON
+    before verifying.
+    """
+    payload = await request.body()
+    if not yousign_client.verify_webhook(payload, x_yousign_signature_256):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Yousign webhook signature.",
+        )
+    import json
+
+    try:
+        event = json.loads(payload)
+    except json.JSONDecodeError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Webhook body is not valid JSON.",
+        )
+    result = await esign_service.handle_webhook(db, event)
+    return {"received": True, **result}

--- a/services/api/app/esign/schemas.py
+++ b/services/api/app/esign/schemas.py
@@ -1,0 +1,42 @@
+"""Request / response schemas for the /esign router (issue #63)."""
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CreateSignatureRequestBody(BaseModel):
+    """Send a case document to the case client for e-signature."""
+
+    case_id: uuid.UUID
+    document_id: uuid.UUID = Field(
+        ..., description="The case document (PDF) to be signed."
+    )
+    subject: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Optional title shown in the signer email + dashboard.",
+    )
+
+
+class SignatureRequestResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    case_id: uuid.UUID
+    source_document_id: uuid.UUID | None
+    signed_document_id: uuid.UUID | None
+    signer_email: str
+    signer_name: str
+    subject: str
+    provider: str
+    status: str
+    signing_url: str | None
+    error: str | None
+    created_at: str
+    updated_at: str
+
+
+class SignatureRequestListResponse(BaseModel):
+    signature_requests: list[SignatureRequestResponse]

--- a/services/api/app/esign/service.py
+++ b/services/api/app/esign/service.py
@@ -1,0 +1,271 @@
+"""E-signature service layer (issue #63).
+
+Orchestrates the Yousign provider client and the local
+``SignatureRequest`` rows: turns a stored case PDF into an activated
+signature request, and reconciles provider webhooks back onto the row
+(downloading the signed PDF into a new ``Document`` on completion).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cases.models import Case
+from app.config import settings
+from app.documents.models import Document
+from app.documents.service import create_document
+from app.esign import yousign_client
+from app.esign.models import (
+    SignatureProvider,
+    SignatureRequest,
+    SignatureRequestStatus,
+)
+from app.esign.yousign_client import EsignError
+from app.users.models import User
+
+logger = logging.getLogger(__name__)
+
+
+# Yousign's name fields reject anything outside letters, spaces,
+# hyphens and apostrophes (e.g. underscores or digits in an
+# auto-generated wallet handle like "etornie_CBDjvUkZ"). Replace the
+# rest with spaces before splitting.
+_NAME_DISALLOWED = re.compile(r"[^A-Za-zÀ-ÖØ-öø-ÿ' -]+")
+
+
+def _split_name(full_name: str) -> tuple[str, str]:
+    """Split a display name into provider-safe (first, last).
+
+    Yousign requires both and rejects unauthorized characters; we
+    sanitise to its allowed set and collapse single-token names so the
+    call never fails on a missing or invalid last name.
+    """
+    cleaned = _NAME_DISALLOWED.sub(" ", full_name or "")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    parts = cleaned.split()
+    if not parts:
+        return "Client", "Client"
+    if len(parts) == 1:
+        return parts[0], parts[0]
+    return parts[0], " ".join(parts[1:])
+
+
+async def create_signature_request_for_document(
+    db: AsyncSession,
+    *,
+    case: Case,
+    document: Document,
+    signer: User,
+    subject: str | None = None,
+) -> SignatureRequest:
+    """Send a case document to its client for e-signature via Yousign.
+
+    Reads the stored PDF, creates + activates a Yousign signature
+    request, and persists a ``SignatureRequest`` row. On provider failure
+    the row is saved with ``status=error`` and the error is re-raised.
+    """
+    if not signer.email:
+        raise EsignError(
+            f"Signer {signer.id} has no email; cannot send for signature.",
+            user_message=(
+                "The signer has no email address on file. Add an email "
+                "before sending the document for signature."
+            ),
+            http_status=400,
+        )
+    if document.case_id != case.id:
+        raise EsignError(
+            "Document does not belong to the case.",
+            user_message="This document is not part of the case.",
+            http_status=400,
+        )
+    if not document.file_path or not os.path.isfile(document.file_path):
+        raise EsignError(
+            f"Document {document.id} file is missing on disk.",
+            user_message="The document file could not be found on the server.",
+            http_status=404,
+        )
+
+    first_name, last_name = _split_name(signer.full_name)
+    title = subject or f"Signature required — {document.filename}"
+
+    row = SignatureRequest(
+        case_id=case.id,
+        source_document_id=document.id,
+        signer_user_id=signer.id,
+        provider=SignatureProvider.yousign,
+        status=SignatureRequestStatus.draft,
+        signer_email=signer.email,
+        signer_name=signer.full_name or signer.email,
+        subject=title,
+    )
+    db.add(row)
+    await db.flush()
+
+    try:
+        with open(document.file_path, "rb") as fh:
+            pdf_bytes = fh.read()
+
+        request_id = await yousign_client.create_signature_request(name=title)
+        row.provider_request_id = request_id
+
+        document_id = await yousign_client.upload_document(
+            request_id=request_id,
+            file_bytes=pdf_bytes,
+            filename=document.filename or "document.pdf",
+        )
+        row.provider_document_id = document_id
+
+        signer_id = await yousign_client.add_signer(
+            request_id=request_id,
+            document_id=document_id,
+            first_name=first_name,
+            last_name=last_name,
+            email=signer.email,
+        )
+        row.provider_signer_id = signer_id
+
+        activated = await yousign_client.activate(request_id=request_id)
+        row.signing_url = yousign_client.extract_signature_link(activated)
+        row.status = SignatureRequestStatus.ongoing
+        row.error = None
+    except EsignError as exc:
+        row.status = SignatureRequestStatus.error
+        row.error = str(exc)
+        await db.flush()
+        raise
+
+    await db.flush()
+    return row
+
+
+async def get_request(
+    db: AsyncSession, request_id: uuid.UUID
+) -> SignatureRequest | None:
+    return (
+        await db.execute(
+            select(SignatureRequest).where(SignatureRequest.id == request_id)
+        )
+    ).scalar_one_or_none()
+
+
+async def list_for_case(
+    db: AsyncSession, case_id: uuid.UUID
+) -> list[SignatureRequest]:
+    return list(
+        (
+            await db.execute(
+                select(SignatureRequest)
+                .where(SignatureRequest.case_id == case_id)
+                .order_by(SignatureRequest.created_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Webhook reconciliation
+# ---------------------------------------------------------------------------
+
+# Yousign webhook event_name -> terminal status.
+_TERMINAL_EVENTS = {
+    "signature_request.done": SignatureRequestStatus.signed,
+    "signature_request.declined": SignatureRequestStatus.declined,
+    "signature_request.expired": SignatureRequestStatus.expired,
+}
+
+
+async def _store_signed_document(
+    db: AsyncSession, row: SignatureRequest
+) -> uuid.UUID | None:
+    """Download the signed PDF from Yousign and persist it as a Document."""
+    if not (row.provider_request_id and row.provider_document_id):
+        return None
+    signed_bytes = await yousign_client.download_signed_document(
+        request_id=row.provider_request_id,
+        document_id=row.provider_document_id,
+    )
+    case_dir = os.path.join(settings.upload_dir, str(row.case_id))
+    os.makedirs(case_dir, exist_ok=True)
+    base_name = "document.pdf"
+    if row.source_document_id is not None:
+        src = (
+            await db.execute(
+                select(Document).where(Document.id == row.source_document_id)
+            )
+        ).scalar_one_or_none()
+        if src is not None and src.filename:
+            base_name = src.filename
+    filename = f"signed_{base_name}"
+    file_path = os.path.join(case_dir, f"{uuid.uuid4()}_{filename}")
+    with open(file_path, "wb") as fh:
+        fh.write(signed_bytes)
+
+    signed_doc = await create_document(
+        db,
+        case_id=row.case_id,
+        uploaded_by=row.signer_user_id,
+        filename=filename,
+        file_path=file_path,
+        file_type="application/pdf",
+        file_size=len(signed_bytes),
+        document_type="signed_document",
+    )
+    return signed_doc.id
+
+
+async def handle_webhook(db: AsyncSession, event: dict[str, Any]) -> dict[str, Any]:
+    """Reconcile a verified Yousign webhook event onto its row.
+
+    Idempotent: a redelivered ``done`` event on an already-signed row is
+    a no-op (the signed document is only stored once).
+    """
+    event_name = event.get("event_name")
+    target = _TERMINAL_EVENTS.get(event_name or "")
+    if target is None:
+        return {"handled": False, "reason": "ignored_event", "event": event_name}
+
+    sr = (event.get("data") or {}).get("signature_request") or {}
+    provider_request_id = sr.get("id")
+    if not provider_request_id:
+        return {"handled": False, "reason": "missing_signature_request_id"}
+
+    row = (
+        await db.execute(
+            select(SignatureRequest).where(
+                SignatureRequest.provider_request_id == provider_request_id
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return {"handled": False, "reason": "request_not_found"}
+
+    if row.status == SignatureRequestStatus.signed:
+        return {"handled": True, "reason": "already_signed"}
+
+    if target is SignatureRequestStatus.signed:
+        if row.signed_document_id is None:
+            signed_id = await _store_signed_document(db, row)
+            if signed_id is not None:
+                row.signed_document_id = signed_id
+        row.status = SignatureRequestStatus.signed
+        row.error = None
+    else:
+        row.status = target
+
+    row.updated_at = datetime.now(timezone.utc)
+    await db.commit()
+    return {
+        "handled": True,
+        "signature_request_id": str(row.id),
+        "status": row.status.value,
+    }

--- a/services/api/app/esign/yousign_client.py
+++ b/services/api/app/esign/yousign_client.py
@@ -1,0 +1,237 @@
+"""Yousign API v3 client (e-signature provider, issue #63).
+
+Thin async HTTP layer over the Yousign v3 REST API. Every network call
+to Yousign lives here so the service layer stays provider-agnostic; if a
+second provider is added later only this module is duplicated.
+
+Flow (https://developers.yousign.com):
+  POST /signature_requests                     -> create (draft)
+  POST /signature_requests/{id}/documents      -> upload signable PDF
+  POST /signature_requests/{id}/signers        -> add signer + field
+  POST /signature_requests/{id}/activate       -> send (emails signer)
+  GET  /signature_requests/{id}                -> read status + links
+  GET  /signature_requests/{id}/documents/{doc}/download -> signed PDF
+
+Webhook payloads carry an ``X-Yousign-Signature-256: sha256=<hmac>``
+header verified against the configured webhook secret.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from typing import Any
+
+import httpx
+
+from app.config import settings
+from app.errors import ErrorCategory, UserFacingError
+
+logger = logging.getLogger(__name__)
+
+# Where the signature box is stamped on the PDF. These are layout
+# defaults (points from the lower-left of page 1), not business data —
+# a sensible bottom-left placement that works for affidavit/declaration
+# style documents.
+_FIELD_PAGE = 1
+_FIELD_X = 80
+_FIELD_Y = 80
+_FIELD_WIDTH = 120
+_FIELD_HEIGHT = 50
+
+_TIMEOUT = httpx.Timeout(30.0)
+
+
+class EsignError(UserFacingError):
+    """Domain-level e-signature failure surfaced to the caller."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        user_message: str | None = None,
+        http_status: int = 400,
+    ) -> None:
+        super().__init__(
+            user_message=user_message
+            or "We could not process this signature request. Please try again.",
+            technical_detail=message,
+            category=ErrorCategory.unknown,
+            http_status=http_status,
+        )
+        self.args = (message,)
+
+
+def is_configured() -> bool:
+    return bool(settings.yousign_api_key)
+
+
+def _require_configured() -> None:
+    if not settings.yousign_api_key:
+        raise EsignError(
+            "Yousign is not configured (YOUSIGN_API_KEY is empty).",
+            user_message="E-signature is not available on this server.",
+            http_status=503,
+        )
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {settings.yousign_api_key}"}
+
+
+def _base() -> str:
+    return settings.yousign_base_url.rstrip("/")
+
+
+def _raise_for(resp: httpx.Response, action: str) -> None:
+    if resp.is_success:
+        return
+    body = resp.text[:400]
+    logger.warning("Yousign %s failed %s: %s", action, resp.status_code, body)
+    raise EsignError(
+        f"Yousign {action} failed ({resp.status_code}): {body}",
+        user_message="The e-signature provider rejected the request.",
+        http_status=502,
+    )
+
+
+async def create_signature_request(*, name: str) -> str:
+    """Create a draft signature request; return its provider id."""
+    _require_configured()
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            f"{_base()}/signature_requests",
+            headers=_headers(),
+            json={
+                "name": name,
+                "delivery_mode": "email",
+                "timezone": "Europe/Zurich",
+            },
+        )
+    _raise_for(resp, "create signature request")
+    return resp.json()["id"]
+
+
+async def upload_document(
+    *, request_id: str, file_bytes: bytes, filename: str
+) -> str:
+    """Upload the signable PDF; return the provider document id."""
+    _require_configured()
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            f"{_base()}/signature_requests/{request_id}/documents",
+            headers=_headers(),
+            files={"file": (filename, file_bytes, "application/pdf")},
+            data={"nature": "signable_document"},
+        )
+    _raise_for(resp, "upload document")
+    return resp.json()["id"]
+
+
+async def add_signer(
+    *,
+    request_id: str,
+    document_id: str,
+    first_name: str,
+    last_name: str,
+    email: str,
+    locale: str = "en",
+) -> str:
+    """Add the signer with a signature field; return the signer id."""
+    _require_configured()
+    payload: dict[str, Any] = {
+        "info": {
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": email,
+            "locale": locale,
+        },
+        "signature_level": "electronic_signature",
+        "signature_authentication_mode": "no_otp",
+        "fields": [
+            {
+                "type": "signature",
+                "document_id": document_id,
+                "page": _FIELD_PAGE,
+                "x": _FIELD_X,
+                "y": _FIELD_Y,
+                "width": _FIELD_WIDTH,
+                "height": _FIELD_HEIGHT,
+            }
+        ],
+    }
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            f"{_base()}/signature_requests/{request_id}/signers",
+            headers=_headers(),
+            json=payload,
+        )
+    _raise_for(resp, "add signer")
+    return resp.json()["id"]
+
+
+async def activate(*, request_id: str) -> dict[str, Any]:
+    """Activate (send) the request; return the activated payload."""
+    _require_configured()
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            f"{_base()}/signature_requests/{request_id}/activate",
+            headers=_headers(),
+        )
+    _raise_for(resp, "activate signature request")
+    return resp.json()
+
+
+async def get_signature_request(*, request_id: str) -> dict[str, Any]:
+    _require_configured()
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(
+            f"{_base()}/signature_requests/{request_id}",
+            headers=_headers(),
+        )
+    _raise_for(resp, "get signature request")
+    return resp.json()
+
+
+async def download_signed_document(
+    *, request_id: str, document_id: str
+) -> bytes:
+    """Download the completed (signed) PDF bytes."""
+    _require_configured()
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(
+            f"{_base()}/signature_requests/{request_id}/documents/"
+            f"{document_id}/download",
+            headers=_headers(),
+        )
+    _raise_for(resp, "download signed document")
+    return resp.content
+
+
+def extract_signature_link(activated: dict[str, Any]) -> str | None:
+    """Pull the first signer's hosted signing link from an activate/get
+    payload, tolerating the two shapes Yousign returns."""
+    signers = activated.get("signers") or []
+    if signers and isinstance(signers, list):
+        link = signers[0].get("signature_link")
+        if link:
+            return link
+    return activated.get("signature_link")
+
+
+def verify_webhook(payload: bytes, signature_header: str | None) -> bool:
+    """Verify the ``X-Yousign-Signature-256`` HMAC-SHA256 header.
+
+    Fails closed: returns False when no secret is configured or the
+    header is missing/malformed.
+    """
+    secret = settings.yousign_webhook_secret
+    if not secret or not signature_header:
+        return False
+    expected = (
+        "sha256="
+        + hmac.new(
+            secret.encode("utf-8"), payload, hashlib.sha256
+        ).hexdigest()
+    )
+    return hmac.compare_digest(expected, signature_header.strip())

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -17,6 +17,7 @@ from app.cases.metadata_router import router as case_metadata_router
 from app.cases.router import router as cases_router
 from app.config import settings
 from app.documents.router import router as documents_router
+from app.esign.router import router as esign_router
 from app.errors import UserFacingError
 from app.observability import capture_exception, init_sentry
 from app.security.headers import SecurityHeadersMiddleware
@@ -102,6 +103,7 @@ app.include_router(users_router)
 app.include_router(cases_router)
 app.include_router(case_metadata_router)
 app.include_router(documents_router)
+app.include_router(esign_router)
 app.include_router(notifications_router)
 app.include_router(ai_router)
 app.include_router(required_documents_router)

--- a/services/api/tests/test_esign.py
+++ b/services/api/tests/test_esign.py
@@ -1,0 +1,364 @@
+"""Tests for the e-signature lane (issue #63).
+
+No mocks: webhook HMAC verification uses real hashing, the webhook
+state-machine runs against real SignatureRequest rows in the test DB
+with constructed Yousign-shaped payloads (data fixtures, not behaviour
+mocks), and any path that must call Yousign is skipped when
+YOUSIGN_API_KEY is absent (skip ≠ mock).
+"""
+import hashlib
+import hmac
+import json
+import os
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.esign import service as esign_service
+from app.esign import yousign_client
+from app.esign.models import (
+    SignatureProvider,
+    SignatureRequest,
+    SignatureRequestStatus,
+)
+from app.cases.models import Case
+from app.documents.models import Document
+from app.users.models import User
+from tests.conftest import auth_headers
+
+_SECRET = "whsec_test_esign_secret"
+
+
+@pytest.fixture
+def webhook_secret():
+    saved = settings.yousign_webhook_secret
+    settings.yousign_webhook_secret = _SECRET
+    try:
+        yield _SECRET
+    finally:
+        settings.yousign_webhook_secret = saved
+
+
+def _sign(body: bytes, secret: str = _SECRET) -> str:
+    return "sha256=" + hmac.new(
+        secret.encode(), body, hashlib.sha256
+    ).hexdigest()
+
+
+async def _make_request_row(
+    db: AsyncSession,
+    case: Case,
+    signer: User,
+    *,
+    status: SignatureRequestStatus = SignatureRequestStatus.ongoing,
+    provider_request_id: str = "sr_test_1",
+) -> SignatureRequest:
+    row = SignatureRequest(
+        case_id=case.id,
+        source_document_id=None,
+        signer_user_id=signer.id,
+        provider=SignatureProvider.yousign,
+        status=status,
+        provider_request_id=provider_request_id,
+        provider_document_id="doc_test_1",
+        signer_email=signer.email or "x@example.com",
+        signer_name=signer.full_name or "Client",
+        subject="Sign this",
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Webhook HMAC verification (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookVerification:
+    def test_valid_signature(self, webhook_secret) -> None:
+        body = b'{"event_name":"signature_request.done"}'
+        assert yousign_client.verify_webhook(body, _sign(body)) is True
+
+    def test_tampered_body_fails(self, webhook_secret) -> None:
+        good = _sign(b'{"a":1}')
+        assert yousign_client.verify_webhook(b'{"a":2}', good) is False
+
+    def test_missing_header_fails(self, webhook_secret) -> None:
+        assert yousign_client.verify_webhook(b"{}", None) is False
+
+    def test_no_secret_fails_closed(self) -> None:
+        saved = settings.yousign_webhook_secret
+        settings.yousign_webhook_secret = ""
+        try:
+            body = b"{}"
+            assert yousign_client.verify_webhook(body, _sign(body)) is False
+        finally:
+            settings.yousign_webhook_secret = saved
+
+
+class TestNameSplit:
+    def test_split_name(self) -> None:
+        assert esign_service._split_name("Muhammed Akinci") == (
+            "Muhammed",
+            "Akinci",
+        )
+        assert esign_service._split_name("Cher") == ("Cher", "Cher")
+        assert esign_service._split_name("") == ("Client", "Client")
+        assert esign_service._split_name("A B C") == ("A", "B C")
+
+    def test_split_name_sanitizes_unauthorized_chars(self) -> None:
+        # Yousign rejects underscores/digits; an auto-generated wallet
+        # handle must be cleaned to letters before being sent.
+        assert esign_service._split_name("etornie_CBDjvUkZ") == (
+            "etornie",
+            "CBDjvUkZ",
+        )
+        assert esign_service._split_name("wallet_0x1234") == (
+            "wallet",
+            "x",
+        )
+        # All-unauthorized collapses to the safe fallback.
+        assert esign_service._split_name("___999") == ("Client", "Client")
+
+
+# ---------------------------------------------------------------------------
+# Webhook state-machine (real DB, constructed payloads)
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookStateMachine:
+    async def test_declined_updates_row(
+        self, db_session: AsyncSession, case_fixture: Case, client_user: User
+    ) -> None:
+        row = await _make_request_row(db_session, case_fixture, client_user)
+        event = {
+            "event_name": "signature_request.declined",
+            "data": {"signature_request": {"id": row.provider_request_id}},
+        }
+        result = await esign_service.handle_webhook(db_session, event)
+        assert result["handled"] is True
+        await db_session.refresh(row)
+        assert row.status == SignatureRequestStatus.declined
+
+    async def test_expired_updates_row(
+        self, db_session: AsyncSession, case_fixture: Case, client_user: User
+    ) -> None:
+        row = await _make_request_row(
+            db_session, case_fixture, client_user, provider_request_id="sr_exp"
+        )
+        event = {
+            "event_name": "signature_request.expired",
+            "data": {"signature_request": {"id": "sr_exp"}},
+        }
+        await esign_service.handle_webhook(db_session, event)
+        await db_session.refresh(row)
+        assert row.status == SignatureRequestStatus.expired
+
+    async def test_ignored_event(self, db_session: AsyncSession) -> None:
+        result = await esign_service.handle_webhook(
+            db_session,
+            {"event_name": "signer.notified", "data": {}},
+        )
+        assert result["handled"] is False
+        assert result["reason"] == "ignored_event"
+
+    async def test_unknown_request_ignored(
+        self, db_session: AsyncSession
+    ) -> None:
+        result = await esign_service.handle_webhook(
+            db_session,
+            {
+                "event_name": "signature_request.declined",
+                "data": {"signature_request": {"id": "sr_nope"}},
+            },
+        )
+        assert result["handled"] is False
+        assert result["reason"] == "request_not_found"
+
+    async def test_already_signed_is_noop(
+        self, db_session: AsyncSession, case_fixture: Case, client_user: User
+    ) -> None:
+        row = await _make_request_row(
+            db_session,
+            case_fixture,
+            client_user,
+            status=SignatureRequestStatus.signed,
+            provider_request_id="sr_signed",
+        )
+        result = await esign_service.handle_webhook(
+            db_session,
+            {
+                "event_name": "signature_request.done",
+                "data": {"signature_request": {"id": "sr_signed"}},
+            },
+        )
+        # No Yousign download happens because the row is already signed.
+        assert result["handled"] is True
+        assert result["reason"] == "already_signed"
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestEsignEndpoints:
+    async def test_create_requires_auth(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/esign/signature-requests",
+            json={"case_id": str(uuid.uuid4()), "document_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 401
+
+    async def test_list_requires_auth(self, client: AsyncClient) -> None:
+        resp = await client.get(
+            "/esign/signature-requests",
+            params={"case_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 401
+
+    async def test_webhook_rejects_bad_signature(
+        self, client: AsyncClient, webhook_secret
+    ) -> None:
+        resp = await client.post(
+            "/esign/webhook",
+            content=b'{"event_name":"signature_request.done"}',
+            headers={"X-Yousign-Signature-256": "sha256=deadbeef"},
+        )
+        assert resp.status_code == 401
+
+    async def test_webhook_valid_signature_updates_row(
+        self,
+        client: AsyncClient,
+        db_session: AsyncSession,
+        case_fixture: Case,
+        client_user: User,
+        webhook_secret,
+    ) -> None:
+        row = await _make_request_row(
+            db_session, case_fixture, client_user, provider_request_id="sr_wh"
+        )
+        await db_session.commit()
+        body = json.dumps(
+            {
+                "event_name": "signature_request.declined",
+                "data": {"signature_request": {"id": "sr_wh"}},
+            }
+        ).encode()
+        resp = await client.post(
+            "/esign/webhook",
+            content=body,
+            headers={"X-Yousign-Signature-256": _sign(body)},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "declined"
+
+    async def test_create_unknown_case_404(
+        self, client: AsyncClient, client_user: User
+    ) -> None:
+        resp = await client.post(
+            "/esign/signature-requests",
+            json={"case_id": str(uuid.uuid4()), "document_id": str(uuid.uuid4())},
+            headers=auth_headers(client_user),
+        )
+        assert resp.status_code == 404
+
+    async def test_create_forbidden_for_non_owner(
+        self,
+        client: AsyncClient,
+        case_fixture: Case,
+        second_lawyer_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        # case_fixture client is client_user; second_lawyer_user is a
+        # different client → no access.
+        doc = Document(
+            case_id=case_fixture.id,
+            uploaded_by=case_fixture.client_id,
+            filename="affidavit.pdf",
+            file_path="/tmp/does-not-matter.pdf",
+            file_type="application/pdf",
+            file_size=10,
+        )
+        db_session.add(doc)
+        await db_session.commit()
+        resp = await client.post(
+            "/esign/signature-requests",
+            json={"case_id": str(case_fixture.id), "document_id": str(doc.id)},
+            headers=auth_headers(second_lawyer_user),
+        )
+        assert resp.status_code == 403
+
+    async def test_create_missing_file_404(
+        self,
+        client: AsyncClient,
+        case_fixture: Case,
+        client_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        # Owner access OK, signer has email, but the file is absent on
+        # disk → service refuses before any Yousign call.
+        doc = Document(
+            case_id=case_fixture.id,
+            uploaded_by=client_user.id,
+            filename="missing.pdf",
+            file_path="/tmp/nonexistent-" + uuid.uuid4().hex + ".pdf",
+            file_type="application/pdf",
+            file_size=10,
+        )
+        db_session.add(doc)
+        await db_session.commit()
+        resp = await client.post(
+            "/esign/signature-requests",
+            json={"case_id": str(case_fixture.id), "document_id": str(doc.id)},
+            headers=auth_headers(client_user),
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.skipif(
+    not settings.yousign_api_key,
+    reason="YOUSIGN_API_KEY not configured (live Yousign call)",
+)
+class TestYousignLive:
+    async def test_create_signature_request_live(
+        self,
+        client: AsyncClient,
+        case_fixture: Case,
+        client_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        # Real Yousign sandbox call: upload a real one-page PDF and send.
+        pdf = (
+            b"%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+            b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+            b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 595 842]>>endobj\n"
+            b"trailer<</Root 1 0 R>>\n%%EOF"
+        )
+        case_dir = os.path.join(settings.upload_dir, str(case_fixture.id))
+        os.makedirs(case_dir, exist_ok=True)
+        path = os.path.join(case_dir, f"{uuid.uuid4()}_affidavit.pdf")
+        with open(path, "wb") as fh:
+            fh.write(pdf)
+        doc = Document(
+            case_id=case_fixture.id,
+            uploaded_by=client_user.id,
+            filename="affidavit.pdf",
+            file_path=path,
+            file_type="application/pdf",
+            file_size=len(pdf),
+        )
+        db_session.add(doc)
+        await db_session.commit()
+
+        resp = await client.post(
+            "/esign/signature-requests",
+            json={"case_id": str(case_fixture.id), "document_id": str(doc.id)},
+            headers=auth_headers(client_user),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["status"] == "ongoing"


### PR DESCRIPTION
Closes #63.

Affidavits, declarations and case-close forms needed signatures, but there was no e-signature flow. This adds **Yousign** integration: send a case PDF to the case client for electronic signature, track the lifecycle, and store the signed PDF back on the case. EU/eIDAS provider; no document templates (the existing PDF is sent at runtime). Webhooks are HMAC-SHA256 verified and fail closed; names are sanitised to Yousign's allowed charset. 19 tests, full suite green.

## Screenshots

_Yousign signing screen:_

<img width="1388" height="961" alt="yousign" src="https://github.com/user-attachments/assets/02eda293-5b90-469b-8438-7dadefd29470" />

_Signature invitation email:_

<img width="617" height="592" alt="yousignNotification" src="https://github.com/user-attachments/assets/4467dfc4-87b6-4ef0-adab-36515a52f374" />
