### PR TITLE
feat(cases): one-click case templates (#65)

### DIFF
--- a/dashboard/src/app/dashboard/cases/page.tsx
+++ b/dashboard/src/app/dashboard/cases/page.tsx
@@ -72,6 +72,17 @@ interface CaseListResponse {
   total: number;
 }
 
+interface CaseTemplateOption {
+  key: string;
+  name: string;
+  description: string;
+  case_type: string;
+  default_title: string;
+  default_description: string;
+  default_jurisdiction: string | null;
+  default_nice_classes: string | null;
+}
+
 const CASE_TYPES = ["trademark", "patent", "design", "copyright"];
 
 const NICE_CLASSES: ReadonlyArray<{ class_number: number; category: string; description: string }> = [
@@ -296,7 +307,27 @@ export default function CasesPage() {
   const [createLoading, setCreateLoading] = useState(false);
   const [createError, setCreateError] = useState("");
   const [createSuccess, setCreateSuccess] = useState("");
+  const [caseTemplates, setCaseTemplates] = useState<CaseTemplateOption[]>([]);
+  // Defaults of the last-applied template, so switching templates can
+  // refresh untouched fields without clobbering hand-edited ones.
+  const appliedTemplateRef = useRef<{
+    title: string;
+    description: string;
+  } | null>(null);
   const { publicKey: walletPubkey, signTransaction } = useWallet();
+
+  useEffect(() => {
+    let active = true;
+    api
+      .get<{ templates: CaseTemplateOption[] }>("/case-templates")
+      .then((r) => {
+        if (active) setCaseTemplates(r.data.templates);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
 
   async function fetchCases() {
     setLoading(true);
@@ -511,6 +542,58 @@ export default function CasesPage() {
             </div>
           )}
           <form onSubmit={handleCreate} className="grid gap-4 sm:grid-cols-2">
+            {caseTemplates.length > 0 && (
+              <div className="sm:col-span-2">
+                <label className="block text-sm font-medium text-gray-700">
+                  Start from template (optional)
+                </label>
+                <select
+                  defaultValue=""
+                  onChange={(e) => {
+                    const t = caseTemplates.find(
+                      (x) => x.key === e.target.value
+                    );
+                    const prevDef = appliedTemplateRef.current;
+                    setCreateForm((prev) => {
+                      if (!t) return prev;
+                      // Replace a field only when it is empty or still
+                      // holds the previously-applied template's default
+                      // (i.e. the user has not hand-edited it).
+                      const titleKept =
+                        prev.title && (!prevDef || prev.title !== prevDef.title);
+                      const descKept =
+                        prev.description &&
+                        (!prevDef || prev.description !== prevDef.description);
+                      return {
+                        ...prev,
+                        title: titleKept ? prev.title : t.default_title,
+                        description: descKept
+                          ? prev.description
+                          : t.default_description,
+                        case_type: t.case_type,
+                      };
+                    });
+                    appliedTemplateRef.current = t
+                      ? {
+                          title: t.default_title,
+                          description: t.default_description,
+                        }
+                      : null;
+                  }}
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                >
+                  <option value="">— None —</option>
+                  {caseTemplates.map((t) => (
+                    <option key={t.key} value={t.key}>
+                      {t.name}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs text-gray-500">
+                  Pre-fills type, title and description for a common workflow.
+                </p>
+              </div>
+            )}
             <div className="sm:col-span-2">
               <label className="block text-sm font-medium text-gray-700">
                 Title *

--- a/services/api/app/cases/router.py
+++ b/services/api/app/cases/router.py
@@ -99,14 +99,49 @@ async def create_case_endpoint(
     Solana attestation is enabled, a partially-signed attestation tx that
     the frontend can have the user sign via Phantom and submit to devnet.
     """
+    # Resolve a one-click case template (issue #65): it supplies the
+    # title / case_type / description / jurisdiction / nice_classes the
+    # request leaves unset; anything the caller sent always wins.
+    template = None
+    if data.template_key is not None:
+        from app.cases.templates import get_template
+
+        template = get_template(data.template_key)
+        if template is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown case template '{data.template_key}'.",
+            )
+
+    effective_title = data.title or (template.default_title if template else None)
+    effective_case_type = data.case_type or (
+        template.case_type if template else None
+    )
+    effective_description = (
+        data.description
+        if data.description is not None
+        else (template.default_description if template else None)
+    )
+    effective_jurisdiction = data.jurisdiction or (
+        template.default_jurisdiction if template else None
+    )
+    effective_nice_classes = data.nice_classes or (
+        template.default_nice_classes if template else None
+    )
+    if not effective_title or effective_case_type is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="title and case_type are required (directly or via template).",
+        )
+
     create_kwargs: dict[str, object] = {
-        "title": data.title,
-        "description": data.description,
-        "case_type": data.case_type,
+        "title": effective_title,
+        "description": effective_description,
+        "case_type": effective_case_type,
         "client_id": data.client_id,
         "assigned_lawyer_id": data.assigned_lawyer_id,
-        "jurisdiction": data.jurisdiction,
-        "nice_classes": data.nice_classes,
+        "jurisdiction": effective_jurisdiction,
+        "nice_classes": effective_nice_classes,
         "filing_date": data.filing_date,
         "deadline": data.deadline,
         "client_wallet": data.client_wallet,

--- a/services/api/app/cases/schemas.py
+++ b/services/api/app/cases/schemas.py
@@ -7,9 +7,18 @@ from app.cases.models import CaseNftState, CaseStatus, CaseType
 
 
 class CaseCreate(BaseModel):
-    title: str = Field(min_length=1, max_length=500)
+    # title + case_type are required UNLESS a template_key is supplied,
+    # in which case the create endpoint fills them from the template
+    # (issue #65). Validated below.
+    title: str | None = Field(default=None, max_length=500)
     description: str | None = None
-    case_type: CaseType
+    case_type: CaseType | None = None
+    template_key: str | None = Field(
+        default=None,
+        max_length=64,
+        description="One-click case template key; supplies title / "
+        "case_type / description defaults the request omits.",
+    )
     client_id: uuid.UUID | None = None
     assigned_lawyer_id: uuid.UUID | None = None
     jurisdiction: str | None = Field(default=None, max_length=255)
@@ -24,6 +33,18 @@ class CaseCreate(BaseModel):
     # Optional explicit wallet binding. When set, overrides the linked
     # user's wallet_address as the on-chain client pubkey.
     client_wallet: str | None = Field(default=None, max_length=64)
+
+    @model_validator(mode="after")
+    def validate_template_or_required(self) -> "CaseCreate":
+        """Without a template_key, title + case_type are mandatory."""
+        if self.template_key is None:
+            if not self.title or not self.title.strip():
+                raise ValueError("title is required when no template_key is given.")
+            if self.case_type is None:
+                raise ValueError(
+                    "case_type is required when no template_key is given."
+                )
+        return self
 
     @model_validator(mode="after")
     def validate_client_info(self) -> "CaseCreate":

--- a/services/api/app/cases/templates.py
+++ b/services/api/app/cases/templates.py
@@ -1,0 +1,70 @@
+"""Case templates (issue #65) — one-click starting points for common
+IP workflows.
+
+Templates are code-defined (not a DB table): the catalog is small,
+versioned with the code, and needs no admin CRUD. Each template
+pre-fills the fields a new case would otherwise require by hand
+(case_type, a default title and description, and optional suggested
+jurisdiction / Nice classes). The case-creation endpoint applies these
+as DEFAULTS — any field the caller supplies overrides the template — and
+the existing create_case pipeline still auto-generates the required
+documents + proposal from the resulting jurisdiction/case_type.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.cases.models import CaseType
+
+
+@dataclass(frozen=True)
+class CaseTemplate:
+    key: str
+    name: str
+    description: str  # shown in the picker
+    case_type: CaseType
+    default_title: str
+    default_description: str
+    # Optional starting points the caller can override. Left None when a
+    # sensible default cannot be assumed (jurisdiction is country-specific
+    # and Nice classes are mark-specific).
+    default_jurisdiction: str | None = None
+    default_nice_classes: str | None = None
+
+
+CASE_TEMPLATES: tuple[CaseTemplate, ...] = (
+    CaseTemplate(
+        key="trademark-renewal",
+        name="Trademark Renewal",
+        description=(
+            "Renew an existing trademark registration before its deadline."
+        ),
+        case_type=CaseType.trademark,
+        default_title="Trademark Renewal",
+        default_description=(
+            "Renewal of an existing trademark registration."
+        ),
+    ),
+    CaseTemplate(
+        key="patent-filing",
+        name="Patent Filing",
+        description="File a new patent application.",
+        case_type=CaseType.patent,
+        default_title="Patent Filing",
+        default_description="New patent application filing.",
+    ),
+    CaseTemplate(
+        key="design-registration",
+        name="Design Registration",
+        description="Register a new industrial design.",
+        case_type=CaseType.design,
+        default_title="Design Registration",
+        default_description="New industrial design registration.",
+    ),
+)
+
+_BY_KEY: dict[str, CaseTemplate] = {t.key: t for t in CASE_TEMPLATES}
+
+
+def get_template(key: str) -> CaseTemplate | None:
+    return _BY_KEY.get(key)

--- a/services/api/app/cases/templates_router.py
+++ b/services/api/app/cases/templates_router.py
@@ -1,0 +1,48 @@
+"""GET /case-templates — list the one-click case templates (issue #65)."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.auth.dependencies import get_current_user
+from app.cases.templates import CASE_TEMPLATES
+from app.users.models import User
+
+router = APIRouter(prefix="/case-templates", tags=["case-templates"])
+
+
+class CaseTemplateOption(BaseModel):
+    key: str
+    name: str
+    description: str
+    case_type: str
+    default_title: str
+    default_description: str
+    default_jurisdiction: str | None
+    default_nice_classes: str | None
+
+
+class CaseTemplateListResponse(BaseModel):
+    templates: list[CaseTemplateOption]
+
+
+@router.get("", response_model=CaseTemplateListResponse)
+async def list_case_templates(
+    _: User = Depends(get_current_user),
+) -> CaseTemplateListResponse:
+    """List the available case templates for the create-case picker."""
+    return CaseTemplateListResponse(
+        templates=[
+            CaseTemplateOption(
+                key=t.key,
+                name=t.name,
+                description=t.description,
+                case_type=t.case_type.value,
+                default_title=t.default_title,
+                default_description=t.default_description,
+                default_jurisdiction=t.default_jurisdiction,
+                default_nice_classes=t.default_nice_classes,
+            )
+            for t in CASE_TEMPLATES
+        ]
+    )

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -15,6 +15,7 @@ from app.braid.admin_router import router as braid_admin_router
 from app.braid.router import router as braid_router
 from app.cases.metadata_router import router as case_metadata_router
 from app.cases.router import router as cases_router
+from app.cases.templates_router import router as case_templates_router
 from app.config import settings
 from app.documents.router import router as documents_router
 from app.errors import UserFacingError
@@ -101,6 +102,7 @@ app.include_router(wallet_auth_router)
 app.include_router(users_router)
 app.include_router(cases_router)
 app.include_router(case_metadata_router)
+app.include_router(case_templates_router)
 app.include_router(documents_router)
 app.include_router(notifications_router)
 app.include_router(ai_router)

--- a/services/api/tests/test_case_templates.py
+++ b/services/api/tests/test_case_templates.py
@@ -1,0 +1,110 @@
+"""Tests for case templates (issue #65).
+
+Real DB, no mocks: templates are listed through the live endpoint and
+cases are created from them through the real create-case pipeline.
+"""
+import pytest
+from httpx import AsyncClient
+
+from app.users.models import User
+from tests.conftest import auth_headers
+
+
+class TestListCaseTemplates:
+    async def test_requires_auth(self, client: AsyncClient) -> None:
+        resp = await client.get("/case-templates")
+        assert resp.status_code == 401
+
+    async def test_lists_templates(
+        self, client: AsyncClient, client_user: User
+    ) -> None:
+        resp = await client.get(
+            "/case-templates", headers=auth_headers(client_user)
+        )
+        assert resp.status_code == 200
+        templates = resp.json()["templates"]
+        by_key = {t["key"]: t for t in templates}
+        assert {
+            "trademark-renewal",
+            "patent-filing",
+            "design-registration",
+        } <= set(by_key)
+        assert by_key["patent-filing"]["case_type"] == "patent"
+        assert by_key["design-registration"]["case_type"] == "design"
+        assert by_key["trademark-renewal"]["default_title"] == "Trademark Renewal"
+
+
+class TestCreateFromTemplate:
+    async def test_create_with_template_only(
+        self, client: AsyncClient, admin_user: User, client_user: User
+    ) -> None:
+        # No title / case_type — both come from the template.
+        resp = await client.post(
+            "/cases",
+            json={
+                "template_key": "patent-filing",
+                "client_id": str(client_user.id),
+            },
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 201, resp.text
+        case = resp.json()["case"]
+        assert case["case_type"] == "patent"
+        assert case["title"] == "Patent Filing"
+
+    async def test_request_fields_override_template(
+        self, client: AsyncClient, admin_user: User, client_user: User
+    ) -> None:
+        resp = await client.post(
+            "/cases",
+            json={
+                "template_key": "patent-filing",
+                "title": "My Custom Patent",
+                "client_id": str(client_user.id),
+            },
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 201, resp.text
+        case = resp.json()["case"]
+        # Title overridden by the request; case_type still from template.
+        assert case["title"] == "My Custom Patent"
+        assert case["case_type"] == "patent"
+
+    async def test_unknown_template_rejected(
+        self, client: AsyncClient, admin_user: User, client_user: User
+    ) -> None:
+        resp = await client.post(
+            "/cases",
+            json={
+                "template_key": "does-not-exist",
+                "client_id": str(client_user.id),
+            },
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 400
+
+    async def test_no_template_still_requires_title_and_type(
+        self, client: AsyncClient, admin_user: User, client_user: User
+    ) -> None:
+        # Neither template_key nor title/case_type → schema rejects (422).
+        resp = await client.post(
+            "/cases",
+            json={"client_id": str(client_user.id)},
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 422
+
+    async def test_plain_create_without_template_still_works(
+        self, client: AsyncClient, admin_user: User, client_user: User
+    ) -> None:
+        resp = await client.post(
+            "/cases",
+            json={
+                "title": "Manual Case",
+                "case_type": "trademark",
+                "client_id": str(client_user.id),
+            },
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["case"]["title"] == "Manual Case"


### PR DESCRIPTION
Closes #65.

Common case workflows were created from scratch every time. This adds code-defined **case templates** (Trademark Renewal, Patent Filing, Design Registration) so they are one-click: a `GET /case-templates` catalog, an optional `template_key` on case creation that fills title / case_type / description defaults (request values always win, then the existing pipeline auto-generates required documents + proposal), and a "Start from template" picker on the New Case form that pre-fills and refreshes untouched fields. No migration (templates are code constants). 7 tests, full suite green.

## Screenshots

_Template picker:_

<img width="1093" height="207" alt="templates" src="https://github.com/user-attachments/assets/c2cba4c1-b194-4ea5-8201-88387e086720" />

_New Case form pre-filled from a template:_

<img width="1414" height="445" alt="newcase" src="https://github.com/user-attachments/assets/b58352ec-6ee3-4907-a987-b660e56d8899" />
