### PR TITLE
feat(rag): OCR fallback for scanned PDFs (#66)

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libpq-dev curl ca-certificates gnupg \
+        tesseract-ocr \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*

--- a/services/api/app/ai/rag/ocr.py
+++ b/services/api/app/ai/rag/ocr.py
@@ -1,0 +1,96 @@
+"""OCR fallback for scanned PDFs (issue #66).
+
+When a PDF page carries no text layer (a scanned filing), pypdf's
+``extract_text`` returns nothing and the page never makes it into the
+RAG index. This module renders such pages with PyMuPDF and runs
+Tesseract over the image so the text becomes searchable.
+
+OCR is local (no third party) — confidential filings never leave the
+server. It is best-effort: if the ``tesseract`` binary is not installed
+(or OCR is disabled in config), :func:`ocr_available` returns False and
+callers fall back to text-layer extraction only.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import tempfile
+from functools import lru_cache
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _tesseract_on_path() -> bool:
+    return shutil.which("tesseract") is not None
+
+
+def ocr_available() -> bool:
+    """True when OCR is enabled in config and usable on this host."""
+    if not settings.ocr_enabled:
+        return False
+    try:
+        import pytesseract  # noqa: F401
+    except ImportError:
+        return False
+    return _tesseract_on_path()
+
+
+def ocr_pdf_pages(
+    file_path: str, page_indices: list[int] | None = None
+) -> dict[int, str]:
+    """OCR the given PDF pages; return ``{page_index: text}`` for hits.
+
+    Renders each page to an image with PyMuPDF at ``settings.ocr_dpi`` and
+    runs Tesseract. Pages that yield no text are omitted. Raises only on a
+    catastrophic open failure; per-page errors are logged and skipped so
+    one bad page never sinks the whole document.
+    """
+    import fitz  # PyMuPDF
+    import pytesseract
+
+    results: dict[int, str] = {}
+    doc = fitz.open(file_path)
+    try:
+        indices = (
+            page_indices
+            if page_indices is not None
+            else list(range(doc.page_count))
+        )
+        for index in indices:
+            if index < 0 or index >= doc.page_count:
+                continue
+            try:
+                page = doc.load_page(index)
+                pix = page.get_pixmap(dpi=settings.ocr_dpi)
+                # Pass a rendered PNG file PATH to Tesseract rather than a
+                # PIL image object: some Pillow builds make pytesseract
+                # misread the image stream and raise UnicodeDecodeError.
+                tmp = tempfile.NamedTemporaryFile(
+                    suffix=".png", delete=False
+                )
+                try:
+                    tmp.write(pix.tobytes("png"))
+                    tmp.close()
+                    text = pytesseract.image_to_string(
+                        tmp.name, lang=settings.ocr_languages
+                    )
+                finally:
+                    try:
+                        os.unlink(tmp.name)
+                    except OSError:
+                        pass
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "OCR failed on page %d of %s", index, file_path
+                )
+                continue
+            cleaned = (text or "").replace("\x00", "").strip()
+            if cleaned:
+                results[index] = cleaned
+    finally:
+        doc.close()
+    return results

--- a/services/api/app/ai/rag/service.py
+++ b/services/api/app/ai/rag/service.py
@@ -1,5 +1,6 @@
 """RAG pipeline: text extraction, chunking, indexing, search, and augmented chat."""
 
+import asyncio
 import json
 import logging
 import math
@@ -23,16 +24,42 @@ def _read_text_file(file_path: str) -> str:
 
 
 def _read_pdf_pages(file_path: str) -> list[str]:
-    """Read a PDF and return a list of per-page text strings."""
+    """Read a PDF and return a list of per-page text strings.
+
+    Pages with a text layer are read with pypdf. Pages WITHOUT one (a
+    scanned filing) are recovered via Tesseract OCR when it is available
+    (issue #66), so scanned documents still make it into the RAG index.
+    """
     from pypdf import PdfReader
 
+    from app.ai.rag import ocr
+
     reader = PdfReader(file_path)
-    pages: list[str] = []
-    for page in reader.pages:
+    per_page: list[str] = []
+    missing: list[int] = []
+    for index, page in enumerate(reader.pages):
         text = (page.extract_text() or "").replace("\x00", "")
-        if text.strip():
-            pages.append(text)
-    return pages
+        per_page.append(text)
+        if not text.strip():
+            missing.append(index)
+
+    # OCR only the pages that yielded no text layer.
+    if missing and ocr.ocr_available():
+        try:
+            ocr_texts = ocr.ocr_pdf_pages(file_path, page_indices=missing)
+            for index, text in ocr_texts.items():
+                per_page[index] = text
+            if ocr_texts:
+                logger.info(
+                    "OCR recovered %d/%d text-less page(s) in %s",
+                    len(ocr_texts),
+                    len(missing),
+                    file_path,
+                )
+        except Exception:  # noqa: BLE001
+            logger.warning("OCR fallback failed for %s", file_path)
+
+    return [text for text in per_page if text.strip()]
 
 
 async def extract_text_from_file(file_path: str) -> str:
@@ -53,7 +80,8 @@ async def extract_text_from_file(file_path: str) -> str:
 
     if lower_path.endswith(".pdf"):
         try:
-            pages = _read_pdf_pages(file_path)
+            # Off the event loop: pypdf + OCR are blocking CPU work.
+            pages = await asyncio.to_thread(_read_pdf_pages, file_path)
             return "\n".join(pages)
         except Exception:
             logger.warning("Failed to extract text from PDF: %s", file_path)
@@ -71,7 +99,7 @@ async def extract_pdf_pages(file_path: str) -> list[str]:
     if not file_path.lower().endswith(".pdf"):
         return []
     try:
-        return _read_pdf_pages(file_path)
+        return await asyncio.to_thread(_read_pdf_pages, file_path)
     except Exception:
         logger.warning("Failed to extract PDF pages: %s", file_path)
         return []

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -87,6 +87,15 @@ class Settings(BaseSettings):
     euipo_base_url: str = "https://api-sandbox.euipo.europa.eu"
     euipo_auth_url: str = "https://auth-sandbox.euipo.europa.eu/oidc/accessToken"
 
+    # OCR fallback for scanned PDFs (issue #66). When a PDF page has no
+    # text layer, the RAG extractor renders it and runs Tesseract. Needs
+    # the system ``tesseract`` binary; if it is absent, OCR is skipped and
+    # text-layer extraction still works. ``ocr_languages`` is a Tesseract
+    # lang spec (e.g. "eng" or "eng+tur").
+    ocr_enabled: bool = True
+    ocr_languages: str = "eng"
+    ocr_dpi: int = 200
+
     # Redis
     redis_url: str = "redis://localhost:6379/0"
 

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -21,6 +21,10 @@ dependencies = [
     "pypdf>=4.0.0",
     "pymupdf>=1.24.0",
     "pynacl>=1.5.0",
+    # OCR fallback for scanned (no text-layer) PDFs — issue #66.
+    # Requires the system `tesseract` binary (installed in the Dockerfile).
+    "pytesseract>=0.3.10",
+    "pillow>=10.0.0",
     "base58>=2.1.1",
     "solana>=0.34.0",
     "solders>=0.21.0",

--- a/services/api/tests/test_ocr.py
+++ b/services/api/tests/test_ocr.py
@@ -1,0 +1,115 @@
+"""Tests for the OCR fallback on scanned PDFs (issue #66).
+
+No mocks: real PDFs are generated (one with a text layer, one image-only
+"scanned" page) and run through the real extraction path. The actual
+Tesseract OCR assertion is skipped when the binary is not installed
+(skip != mock); the OCR-disabled and text-layer paths are deterministic
+and always run.
+"""
+import io
+
+import pytest
+
+from app.ai.rag import ocr
+from app.ai.rag.service import _read_pdf_pages, extract_text_from_file
+from app.config import settings
+
+_SCANNED_TEXT = "SCANNED OCR TEXT 12345"
+
+
+def _make_text_layer_pdf(path: str) -> None:
+    """A PDF whose page carries a real text layer (no OCR needed)."""
+    import fitz
+
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Hello text layer world", fontsize=14)
+    doc.save(path)
+    doc.close()
+
+
+def _make_scanned_pdf(path: str) -> None:
+    """A PDF whose only content is a rasterised image of text.
+
+    pypdf's extract_text returns nothing for this — it needs OCR.
+    """
+    import fitz
+    from PIL import Image, ImageDraw, ImageFont
+
+    image = Image.new("RGB", (900, 250), "white")
+    draw = ImageDraw.Draw(image)
+    try:
+        font = ImageFont.load_default(size=48)
+    except TypeError:  # older Pillow without size kwarg
+        font = ImageFont.load_default()
+    draw.text((30, 90), _SCANNED_TEXT, fill="black", font=font)
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+
+    doc = fitz.open()
+    page = doc.new_page(width=900, height=250)
+    page.insert_image(fitz.Rect(0, 0, 900, 250), stream=buf.getvalue())
+    doc.save(path)
+    doc.close()
+
+
+class TestOcrAvailability:
+    def test_disabled_in_config_means_unavailable(self) -> None:
+        saved = settings.ocr_enabled
+        settings.ocr_enabled = False
+        try:
+            assert ocr.ocr_available() is False
+        finally:
+            settings.ocr_enabled = saved
+
+
+class TestTextLayerExtraction:
+    async def test_text_layer_pdf_extracted_without_ocr(self, tmp_path) -> None:
+        pdf = str(tmp_path / "text.pdf")
+        _make_text_layer_pdf(pdf)
+        text = await extract_text_from_file(pdf)
+        assert "text layer world" in text.lower()
+
+    def test_scanned_pdf_has_no_text_layer(self, tmp_path) -> None:
+        # Sanity: the generated scanned PDF really has no text layer, so
+        # OCR is the only way to recover it.
+        from pypdf import PdfReader
+
+        pdf = str(tmp_path / "scan_probe.pdf")
+        _make_scanned_pdf(pdf)
+        reader = PdfReader(pdf)
+        raw = "".join((p.extract_text() or "") for p in reader.pages)
+        assert raw.strip() == ""
+
+
+class TestScannedPdfOcrDisabled:
+    async def test_no_ocr_when_disabled(self, tmp_path) -> None:
+        # With OCR disabled, a scanned PDF yields no extractable text.
+        pdf = str(tmp_path / "scan.pdf")
+        _make_scanned_pdf(pdf)
+        saved = settings.ocr_enabled
+        settings.ocr_enabled = False
+        try:
+            assert _read_pdf_pages(pdf) == []
+            assert (await extract_text_from_file(pdf)).strip() == ""
+        finally:
+            settings.ocr_enabled = saved
+
+
+@pytest.mark.skipif(
+    not ocr.ocr_available(),
+    reason="Tesseract binary not installed (real OCR call)",
+)
+class TestScannedPdfOcr:
+    async def test_ocr_recovers_scanned_text(self, tmp_path) -> None:
+        pdf = str(tmp_path / "scan.pdf")
+        _make_scanned_pdf(pdf)
+        text = await extract_text_from_file(pdf)
+        assert "SCANNED" in text.upper()
+
+    def test_ocr_pdf_pages_direct(self, tmp_path) -> None:
+        pdf = str(tmp_path / "scan2.pdf")
+        _make_scanned_pdf(pdf)
+        result = ocr.ocr_pdf_pages(pdf, page_indices=[0])
+        assert 0 in result
+        assert "SCANNED" in result[0].upper()


### PR DESCRIPTION
Closes #66.

Document RAG only indexed **text-layer** PDFs — scanned filings produced no text and never entered the index. This adds a **local Tesseract OCR fallback**: when a PDF page has no text layer, the extractor renders it with PyMuPDF and OCRs the image, so scanned documents become searchable. The OCR runs **on-server (no third party)** so confidential filings never leave the host, and it is **fail-open** — with no `tesseract` binary, OCR is skipped and text-layer extraction is unchanged.

## What changed
- `app/ai/rag/ocr.py` — `ocr_available()` (config + binary check) and `ocr_pdf_pages()` (render via PyMuPDF, OCR via Tesseract).
- `_read_pdf_pages` OCRs only the text-less pages; PDF extraction now runs off the event loop (`asyncio.to_thread`) since OCR is CPU-bound. The existing `index_document` (`POST /ai/index/{document_id}`) benefits transparently.
- deps: `pytesseract` + `pillow`; Dockerfile installs `tesseract-ocr`; config `ocr_enabled` / `ocr_languages` / `ocr_dpi`.

No frontend / no migration — this is a transparent extraction-layer improvement.

## Proof (live pipeline, real Tesseract)
```
1) pypdf text-layer extraction : ''   <- empty (scanned)
2) OCR fallback (live pipeline): 'CONFIDENTIAL TRADEMARK AFFIDAVIT 2026'
3) result: scanned PDF is now searchable -> PASS
```

6 tests (real Tesseract, no mocks): scanned-PDF recovery, text-layer regression, OCR-disabled path, availability. Full backend suite: **507 passed**.