### PR TITLE
docs(adr): ADR folder with the first 5 architecture decisions (#68)

### DIFF
--- a/docs/adr/0000-adr-template.md
+++ b/docs/adr/0000-adr-template.md
@@ -1,0 +1,23 @@
+# ADR-NNNN: <short decision title>
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD
+- **Deciders:** <who made the call>
+
+## Context
+
+What is the problem or force that requires a decision? Capture the
+constraints, the alternatives considered, and anything a newcomer would
+need to understand the trade-off. Be honest about the downsides of the
+chosen path.
+
+## Decision
+
+The decision, stated in active voice: "We will …". Reference the code,
+programs, or services that implement it where helpful.
+
+## Consequences
+
+What becomes easier and what becomes harder as a result. Include
+operational impacts (deploys, keys, migrations), security implications,
+and any follow-up work this creates or unblocks.

--- a/docs/adr/0001-onchain-case-attestation-on-solana.md
+++ b/docs/adr/0001-onchain-case-attestation-on-solana.md
@@ -1,0 +1,51 @@
+# ADR-0001: On-chain case attestation on Solana via sponsored transactions
+
+- **Status:** Accepted
+- **Date:** 2026-06-05 (documenting an established decision)
+- **Deciders:** Etornie engineering
+
+## Context
+
+Etornie's core value proposition is a tamper-evident record that an IP
+matter (a case) exists, who owns it, and what has happened to it. A
+centralised database row alone cannot prove to a third party that the
+record was not altered after the fact.
+
+We needed an immutable, independently verifiable anchor for each case
+without (a) asking non-crypto clients to fund gas, or (b) custodying
+client private keys. The platform already targets Solana for its low
+fees and fast finality.
+
+Alternatives considered: a private/permissioned ledger (no independent
+verifiability), hashing into a public L1 like Ethereum (higher fees,
+slower), or skipping on-chain entirely (loses the trust guarantee).
+
+## Decision
+
+We will attest each case on Solana using a dedicated Anchor program
+(`programs/etornie-attestation`, program id `CpLYWQn39xw1Qei1fqcDF8NkJGiJsME2dKpAfzkN1T2X`,
+devnet today) and a **sponsored, co-signed** transaction model:
+
+- The backend builds a partially-prepared attestation transaction
+  (`prepare_case_attestation`) and returns it to the frontend.
+- The client signs it with their own wallet (Phantom); the **operator
+  keypair co-signs** as fee payer and submits it
+  (`finalize_sponsored_attestation_tx`).
+- Case lifecycle events are recorded the same way (`update_case_attestation`),
+  and the resulting tx signature + PDA are stored on the case row.
+
+The operator key is loaded from `solana_operator_key_path` or, on
+filesystem-less hosts, the inline `solana_operator_key_json`.
+
+## Consequences
+
+- Clients get a verifiable on-chain record without paying gas or
+  surrendering keys; the operator sponsors fees.
+- The operator keypair is sensitive — it co-signs every attestation.
+  It must be treated as a secret and is a natural future target for
+  multisig hardening (see issue #17, Squads upgrade authority).
+- On-chain data is **immutable**: anything attested cannot later be
+  redacted, which has privacy implications captured in the data-export
+  / erasure work (GDPR). Only non-personal hashes/ids belong on-chain.
+- Devnet today; promoting to mainnet requires a verifiable build
+  pipeline and key custody review before launch.

--- a/docs/adr/0002-zero-knowledge-compliance-proofs.md
+++ b/docs/adr/0002-zero-knowledge-compliance-proofs.md
@@ -1,0 +1,49 @@
+# ADR-0002: Zero-knowledge compliance proofs for paid filings
+
+- **Status:** Accepted
+- **Date:** 2026-06-05 (documenting an established decision)
+- **Deciders:** Etornie engineering
+
+## Context
+
+When a filing is paid for and auto-submitted, we want to prove on-chain
+that the payment was bound to a specific, compliant filing request —
+without publishing the client's private filing details (mark text, Nice
+classes, applicant) on a public ledger. We need *verifiable compliance*
+and *privacy* at the same time.
+
+A plain on-chain record of the filing payload would leak confidential
+client data. A purely off-chain claim would not be independently
+verifiable.
+
+## Decision
+
+We will generate a **Groth16 zero-knowledge proof** per paid filing and
+verify it on-chain with a dedicated Anchor verifier program
+(`programs/etornie-zk-verifier`, id `GCnpSrJ1W8SXPZ94FbYy4xs5kNZEAQuiDD7Nqk4nwSk5`).
+
+- A canonical `query_hash` binds the filing (draft id, mark, Nice
+  classes, platform) and the payment id; a secret derived from the
+  operator key + payment id makes the commitment reproducible and
+  replay-resistant (`app/compliance/service.py`).
+- Proof generation shells out to a Node prover
+  (`services/api/scripts/prove_compliance.mjs`) sharing the same circuit WASM/zkey as
+  the frontend (`circuits/`), returning the proof in the on-chain byte
+  layout the verifier expects.
+- One `ComplianceArtifact` row is persisted per `PaymentIntent`
+  (idempotent), then `verify_compliance_proof` is submitted on-chain.
+
+Paid filings **require** a real compliance proof + on-chain verification;
+this is not optional for the agent payment path.
+
+## Consequences
+
+- Confidential filing details stay off-chain; only the proof and
+  commitments are public — privacy and verifiability together.
+- Adds a Node prover dependency and a multi-step pipeline (prove →
+  persist → on-chain verify) with its own failure modes; artifacts
+  record `failed` status with the error so the operator can inspect
+  without re-running from logs.
+- The verifier program and circuit verifying key must stay in lockstep;
+  changing the circuit requires redeploying the verifier and re-pinning
+  the VK.

--- a/docs/adr/0003-two-tier-role-model.md
+++ b/docs/adr/0003-two-tier-role-model.md
@@ -1,0 +1,38 @@
+# ADR-0003: Two-tier role model (retire the lawyer layer)
+
+- **Status:** Accepted
+- **Date:** 2026-05-02
+- **Deciders:** Etornie engineering
+- **Reference:** [docs/REMOVED_LAWYER_LAYER.md](../REMOVED_LAWYER_LAYER.md)
+
+## Context
+
+The system originally carried three system-level roles: `admin`,
+`lawyer`, and `client`. In practice the `lawyer` tier added permission
+complexity (a parallel authorization path on nearly every case route)
+without a distinct product need — operators were acting as admins and
+the lawyer capabilities had collapsed into the operator role.
+
+## Decision
+
+We will run a **two-tier system role model**: `admin` (the platform
+operator) and `client` (the case owner). The historical `lawyer` value
+still exists in the Postgres `user_role` enum for legacy rows, but
+nothing in the runtime path emits or accepts it; legacy `lawyer` rows
+are treated as `client`.
+
+Per-case access is therefore simple (`app/cases/router.py:_can_access_case`):
+an `admin` can reach any case; every other user can reach only the case
+they are bound to as `client_id`. Multi-tenant scoping lives separately
+in the `organization_membership` role (`owner`/`admin`/`member`), which
+is independent of the system role.
+
+## Consequences
+
+- Authorization checks across case, document, and note routes collapse
+  to "admin or owner", which is far easier to reason about and audit.
+- Organisation-level roles (owner/admin/member) handle team permissions,
+  keeping system roles minimal.
+- The retired `lawyer` enum value is intentionally left in the database
+  to avoid a destructive enum migration; code must keep tolerating it on
+  read. New 2FA/MFA work (issue #56) targets the `admin` role.

--- a/docs/adr/0004-agent-orchestrator-model.md
+++ b/docs/adr/0004-agent-orchestrator-model.md
@@ -1,0 +1,43 @@
+# ADR-0004: Agent orchestrator LLM = Llama-3.3-70B-Instruct-Turbo
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Deciders:** Etornie engineering
+- **Reference:** code comment in [`app/config.py`](../../services/api/app/config.py)
+
+## Context
+
+EtornieGPT's agent orchestrator is a chat-first surface that drives a
+multi-tool filing flow. It needs reliable **structured tool-calling**
+and sub-10s latency per turn. We evaluated several models on Together
+AI against a realistic ~16-tool prompt.
+
+Findings:
+- `moonshotai/Kimi-K2.5` — reasoning model, 60–180s per turn. Too slow
+  for an interactive agent.
+- `openai/gpt-oss-120b` — its "harmony" channels leak as plain text on
+  Together's serving: the model emits `assistant…commentary
+  to=functions.X json{…}` as message *content* instead of structured
+  `tool_calls`, then hallucinates the tool result. Unusable as the
+  primary agent today.
+- `meta-llama/Llama-3.3-70B-Instruct-Turbo` — Meta-native function
+  calling, ~3–6s on tool-using turns, no harmony leaks.
+
+## Decision
+
+We will use `meta-llama/Llama-3.3-70B-Instruct-Turbo` as the agent
+orchestrator (`together_agent_model`) and session-title model. Vision
+document intake uses a separate model
+(`meta-llama/Llama-4-Scout-17B-16E-Instruct`) because the orchestrator
+model is text-only. RAG embeddings use
+`intfloat/multilingual-e5-large-instruct`.
+
+## Consequences
+
+- Reliable structured tool-calls and acceptable latency for the
+  interactive flow.
+- Model choice is config-driven (`together_*` settings), so swapping is
+  a config change — but any candidate must be re-validated on a
+  tool-heavy prompt for harmony-style leakage before adoption.
+- We are coupled to Together AI's serving behaviour; the gpt-oss leak is
+  a serving-side issue to re-check if we reconsider that model.

--- a/docs/adr/0005-dual-payment-rails.md
+++ b/docs/adr/0005-dual-payment-rails.md
@@ -1,0 +1,41 @@
+# ADR-0005: Dual payment rails — x402 (crypto) + Stripe (card)
+
+- **Status:** Accepted
+- **Date:** 2026-06-05 (documenting an established decision)
+- **Deciders:** Etornie engineering
+
+## Context
+
+Etornie serves both crypto-native users (who hold a Solana wallet) and
+conventional clients (who pay by card). Filing fees and platform fees
+must be collectable from both audiences, and crypto-native flows want
+on-chain, programmatic settlement rather than a redirect to a card
+checkout.
+
+## Decision
+
+We will run **two parallel payment rails**, both converging on the same
+domain model (`PaymentIntent` with a `provider` discriminator):
+
+- **x402 (crypto):** wallet-signed, on-chain payments for the agent and
+  EtornieGPT flows (e.g. `etorniegpt_payment_vault`, the UKIPO Solana
+  filing-fee vault). Paired with the ZK compliance proof of ADR-0002.
+- **Stripe (card):** hosted Checkout for fiat. The entire `/payments/stripe/*`
+  surface fails closed when `stripe_secret_key` is empty. Stripe webhooks
+  are signature-verified and drive the `PaymentIntent` state machine;
+  refunds and EUIPO auto-submit hang off the confirmed state.
+
+All money conversion (Decimal ↔ Stripe minor units) and the
+event→state mapping live in `app/payments/service.py`; routers and tools
+never call `stripe.*` directly.
+
+## Consequences
+
+- One `PaymentIntent` table + status machine serves both rails, so
+  refunds, the admin panel, and reporting work uniformly.
+- Each rail is independently disable-able (empty key/vault = fail
+  closed), so a misconfigured provider degrades gracefully instead of
+  erroring.
+- This rail design is the foundation the recurring **subscription**
+  lane extends (org-scoped Stripe subscriptions + EU VAT via Stripe Tax,
+  issue #62), which reuses the same Stripe service + webhook dispatch.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,45 @@
+# Architecture Decision Records (ADRs)
+
+This folder is the single home for Etornie's significant architecture
+decisions. Previously these were scattered across PR descriptions and
+code comments; an ADR captures the **context**, the **decision**, and
+its **consequences** in one durable place so future contributors can
+understand *why* the system is the way it is.
+
+## What is an ADR?
+
+A short, immutable document describing one architecturally significant
+decision. Once accepted, an ADR is not edited — if a decision changes,
+write a new ADR that **supersedes** the old one (and link both ways).
+
+See Michael Nygard's original article:
+<https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions>
+
+## When to write one
+
+Write an ADR when a choice is expensive to reverse or shapes the system:
+a new external dependency, a security/compliance model, an on-chain
+program design, a data-model change with wide blast radius, or a
+platform/runtime decision.
+
+You do **not** need an ADR for routine feature work, bug fixes, or
+choices that are cheap to change later.
+
+## How to add one
+
+1. Copy [`0000-adr-template.md`](./0000-adr-template.md) to
+   `NNNN-short-title.md`, where `NNNN` is the next zero-padded number.
+2. Fill in Status, Context, Decision, Consequences.
+3. Open it as **Proposed**; flip to **Accepted** when merged. Use
+   **Superseded by ADR-XXXX** when a later decision replaces it.
+4. Add a row to the index below.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](./0001-onchain-case-attestation-on-solana.md) | On-chain case attestation on Solana via sponsored transactions | Accepted |
+| [0002](./0002-zero-knowledge-compliance-proofs.md) | Zero-knowledge compliance proofs for paid filings | Accepted |
+| [0003](./0003-two-tier-role-model.md) | Two-tier role model (retire the lawyer layer) | Accepted |
+| [0004](./0004-agent-orchestrator-model.md) | Agent orchestrator LLM = Llama-3.3-70B-Instruct-Turbo | Accepted |
+| [0005](./0005-dual-payment-rails.md) | Dual payment rails: x402 (crypto) + Stripe (card) | Accepted |


### PR DESCRIPTION
Closes #68.

Architecture decisions were scattered across PR descriptions and code comments. This centralises them under `docs/adr/` with a process README + a template, and records the first five — each documenting a **real, existing** decision (program ids, model names, file references and dates verified against the codebase).

## Contents
- `README.md` — what an ADR is, when to write one, how to add/supersede, and an index.
- `0000-adr-template.md` — copy-to-start template.
- **0001** On-chain case attestation on Solana (sponsored, operator co-sign).
- **0002** Zero-knowledge (Groth16) compliance proofs for paid filings.
- **0003** Two-tier role model (retire the lawyer layer).
- **0004** Agent orchestrator LLM = Llama-3.3-70B-Instruct-Turbo (why, vs gpt-oss/Kimi).
- **0005** Dual payment rails: x402 (crypto) + Stripe (card).

Docs-only — no code, migrations, or runtime changes. Review renders cleanly on GitHub (index links are relative and resolve).