### PR TITLE
docs: developer onboarding guide + env templates (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,12 @@ data lives in `etornie_solana_pgdata`, Redis data in
 - [ ] IP Australia, USPTO filing robots
 - [ ] Programmable licensing and collateralization primitives
 
+## Development
+
+New contributor? See the [developer onboarding guide](docs/onboarding.md)
+to run the backend, dashboard, and (optionally) the Solana programs
+locally. Architecture decisions are recorded as [ADRs](docs/adr/).
+
 ## License
 
 See `LICENSE`.

--- a/dashboard/.env.local.example
+++ b/dashboard/.env.local.example
@@ -1,0 +1,12 @@
+# Etornie dashboard (Next.js) environment.
+# Copy to `.env.local`:  cp dashboard/.env.local.example dashboard/.env.local
+# Only NEXT_PUBLIC_* vars are exposed to the browser.
+
+# Backend API base URL (the FastAPI service).
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Solana cluster used by the wallet/explorer links (optional — defaults
+# to devnet in the code).
+NEXT_PUBLIC_SOLANA_CLUSTER=devnet
+NEXT_PUBLIC_SOLANA_CLUSTER_URL=https://api.devnet.solana.com
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+# ...but DO track the committed example template.
+!.env.local.example
 
 # vercel
 .vercel

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,178 @@
+# Developer onboarding
+
+Get a local Etornie environment running end to end. The repo's top-level
+`README.md` is product-facing; **this** is the guide for contributors.
+
+You can be running the backend + dashboard in ~15 minutes. The Solana
+programs are only needed if you work on the on-chain layer.
+
+---
+
+## 1. What's in the repo
+
+Etornie is a monorepo:
+
+| Path | What it is | Stack |
+|------|------------|-------|
+| `services/api/` | Backend API | Python 3.12, FastAPI, SQLAlchemy (async), Alembic, Postgres + pgvector, Redis |
+| `dashboard/` | Web app | Next.js, React, TypeScript, Tailwind |
+| `programs/` | On-chain programs (`etornie-attestation`, `etornie-ip-token`, `etornie-zk-verifier`) | Rust, Anchor, Solana |
+| `circuits/` | Zero-knowledge circuits | Circom / snarkjs |
+| `services/braid/` | BRAID reasoning agent | — |
+| `docs/` | Docs incl. [ADRs](./adr/) | Markdown |
+
+The two services you'll touch most are `services/api` (backend) and
+`dashboard` (frontend).
+
+---
+
+## 2. Prerequisites
+
+- **Docker** + Docker Compose — for local Postgres (pgvector) and Redis.
+- **Python ≥ 3.12** — backend.
+- **Node.js 20** — dashboard.
+- **(on-chain work only)** Rust, the Solana CLI, and Anchor — see §6.
+
+macOS install hints:
+
+```bash
+brew install python@3.12 node@20
+# Docker Desktop from docker.com
+```
+
+---
+
+## 3. Clone + start the databases
+
+```bash
+git clone https://github.com/wienerlabs/etornie-solana.git
+cd etornie-solana
+
+# Postgres (pgvector) on :5433 and Redis on :6380
+docker compose up -d etornie-solana-db etornie-solana-redis
+```
+
+The compose ports are deliberately non-standard (`5433`, `6380`) so they
+don't clash with a local Postgres/Redis.
+
+---
+
+## 4. Backend (`services/api`)
+
+```bash
+cd services/api
+
+# 4.1 Virtualenv + dependencies (editable install + dev/test extras)
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+
+# 4.2 Environment — the defaults already point at the compose DB/Redis
+cp .env.example .env
+
+# 4.3 Apply migrations
+alembic upgrade head
+
+# 4.4 Run (http://localhost:8000, OpenAPI docs at /docs)
+uvicorn app.main:app --reload --port 8000
+```
+
+Only three settings are strictly required (the rest fail closed when
+empty): `DATABASE_URL`, `JWT_SECRET`, `CORS_ORIGINS`. The provided
+`.env.example` sets sensible local values for all three.
+
+Sanity check: open <http://localhost:8000/health> → `{"status":"ok"}`,
+and <http://localhost:8000/docs> for the interactive API.
+
+---
+
+## 5. Dashboard (`dashboard`)
+
+```bash
+cd dashboard
+npm install
+cp .env.local.example .env.local   # points at http://localhost:8000
+npm run dev                        # http://localhost:3000
+```
+
+> Next.js may warn about multiple lockfiles — the dashboard uses npm
+> (`package-lock.json`); it's harmless.
+
+---
+
+## 6. Solana programs (on-chain work only)
+
+Skip this unless you're changing the Anchor programs or circuits.
+
+Pinned toolchain (see `.github/workflows/anchor.yml`):
+**Solana CLI `3.0.15`**, **Anchor `0.31.1`** (via `avm`).
+
+```bash
+# Solana CLI
+sh -c "$(curl -sSfL https://release.anza.xyz/v3.0.15/install)"
+
+# Anchor via avm
+cargo install --git https://github.com/coral-xyz/anchor avm --locked --force
+avm install 0.31.1 && avm use 0.31.1
+
+# Target devnet + a funded keypair (devnet faucet)
+solana config set --url devnet
+solana-keygen new -o services/api/keys/operator.json   # operator keypair
+solana airdrop 2 "$(solana-keygen pubkey services/api/keys/operator.json)"
+
+# Build / test the programs
+anchor build
+anchor test
+```
+
+If the faucet rate-limits, retry or use <https://faucet.solana.com>.
+Program ids are pinned in `Anchor.toml`.
+
+---
+
+## 7. Running the tests
+
+**Backend** (needs Redis from §3 running; the test DB is in-memory
+SQLite, so Postgres is not required for tests):
+
+```bash
+cd services/api
+source .venv/bin/activate
+pytest                 # whole suite
+pytest tests/test_cases.py -v        # one file
+pytest -k bulk_import                # by keyword
+```
+
+Some tests `skip` when an external key is absent (e.g. live Stripe /
+Yousign / Tesseract) — that's expected, not a failure.
+
+**Dashboard:**
+
+```bash
+cd dashboard
+npm test               # vitest
+npm run lint           # eslint
+```
+
+---
+
+## 8. Day-to-day
+
+- Backend auto-reloads with `--reload`; the dashboard hot-reloads.
+- After editing models, create a migration:
+  `alembic revision -m "..."` then `alembic upgrade head`.
+- New env var? Add it to `app/config.py` **and** `.env.example`.
+- Architecture decisions are recorded as [ADRs](./adr/).
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Backend won't boot / pydantic error | `.env` missing or `DATABASE_URL`/`JWT_SECRET`/`CORS_ORIGINS` unset — `cp .env.example .env`. |
+| `connection refused` to DB/Redis | `docker compose up -d etornie-solana-db etornie-solana-redis`. |
+| `alembic upgrade` can't find a revision | Your DB is ahead of the branch (e.g. after testing another branch). Use a fresh DB volume: `docker compose down -v` then up + `alembic upgrade head`. |
+| Tests error on Redis | Redis must be running on `:6380` (§3). |
+| Dashboard 401s then redirects to /login | Backend not running on `:8000` or `NEXT_PUBLIC_API_URL` wrong. |
+| Port already in use (5433/6380/8000/3000) | Stop the conflicting process or change the port. |

--- a/services/api/.env.example
+++ b/services/api/.env.example
@@ -1,0 +1,67 @@
+# Etornie backend (services/api) environment.
+# Copy to `.env` and fill in. The defaults below work out of the box
+# with the bundled docker-compose Postgres + Redis. Optional third-party
+# keys can stay empty — the features that need them fail closed and the
+# rest of the app keeps working.
+#
+#   cp services/api/.env.example services/api/.env
+
+# ── Required ──────────────────────────────────────────────────────────
+# Postgres DSN (asyncpg driver). Matches docker-compose (host port 5433).
+DATABASE_URL=postgresql+asyncpg://etornie_solana:etornie_solana_dev@localhost:5433/etornie_solana
+# Change this to any random string for local dev.
+JWT_SECRET=dev-change-me-to-a-random-secret
+# JSON array of allowed browser origins (the dashboard runs on :3000).
+CORS_ORIGINS=["http://localhost:3000"]
+
+# ── Core (sensible local defaults) ────────────────────────────────────
+REDIS_URL=redis://localhost:6380/0
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=7
+UPLOAD_DIR=./uploads
+DEBUG=false
+ENVIRONMENT=development
+API_PUBLIC_URL=http://localhost:8000
+
+# ── AI (optional — RAG / EtornieGPT degrade without these) ────────────
+TOGETHER_API_KEY=
+GROQ_API_KEY=
+
+# ── Solana (devnet defaults) ──────────────────────────────────────────
+SOLANA_CLUSTER_URL=https://api.devnet.solana.com
+# Operator keypair: a path to a JSON keypair file, OR inline JSON bytes
+# (SOLANA_OPERATOR_KEY_JSON) for filesystem-less hosts. Generate one with
+#   solana-keygen new -o services/api/keys/operator.json
+SOLANA_OPERATOR_KEY_PATH=keys/operator.json
+SOLANA_OPERATOR_KEY_JSON=
+SOLANA_ATTESTATION_ENABLED=true
+SOLANA_NFT_ENABLED=true
+SOLANA_ZK_VERIFIER_ENABLED=true
+
+# ── Stripe (optional — card payments; empty disables /payments/stripe/*)
+STRIPE_PUBLISHABLE_KEY=
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_API_VERSION=2024-12-18.acacia
+
+# ── EUIPO sandbox (optional — trademark filing) ───────────────────────
+EUIPO_API_KEY=
+EUIPO_API_SECRET=
+EUIPO_BASE_URL=https://api-sandbox.euipo.europa.eu
+EUIPO_AUTH_URL=https://auth-sandbox.euipo.europa.eu/oidc/accessToken
+
+# ── Notifications (optional — WhatsApp / EmailJS) ─────────────────────
+WHATSAPP_API_TOKEN=
+WHATSAPP_PHONE_NUMBER_ID=
+WHATSAPP_BUSINESS_ACCOUNT_ID=
+EMAILJS_PUBLIC_KEY=
+EMAILJS_PRIVATE_KEY=
+EMAILJS_SERVICE_ID=
+EMAILJS_TEMPLATE_ID=
+
+# ── BRAID agent internal auth (optional — empty disables /braid/*) ────
+BRAID_INTERNAL_TOKEN=
+
+# ── Sentry (optional) ─────────────────────────────────────────────────
+SENTRY_DSN=


### PR DESCRIPTION
Closes #69.

New contributors lost time because the top-level README is product-facing and there were no env templates. This adds a contributor-focused onboarding guide and the missing `.env` examples — backend + dashboard run in ~15 minutes.

## Contents
- **`docs/onboarding.md`** — monorepo layout; prerequisites; start Postgres + Redis via compose; backend (venv → `.env` → `alembic upgrade head` → uvicorn); dashboard (`npm install` → `.env.local` → `npm run dev`); Solana programs + **devnet faucet** (pinned **Solana 3.0.15 / Anchor 0.31.1** from CI); running backend (pytest) + dashboard (vitest) tests; and a troubleshooting table.
- **`services/api/.env.example`** — copy-to-run template. The three required settings (`DATABASE_URL`, `JWT_SECRET`, `CORS_ORIGINS`) ship with working local defaults; everything else fails closed when empty. Verified it constructs a valid `Settings` (a fresh `cp .env.example .env` boots).
- **`dashboard/.env.local.example`** (+ a `.gitignore` exception so the template tracks while real `.env*` stays ignored).
- **README** — a short Development pointer to the guide + ADRs.

Covers the issue's four asks: **local env**, **devnet**, **faucet**, **tests**. Docs/config only — no code or runtime changes.

> Note: the guide links to `docs/adr/`, which lands with its sibling PR #68 (issue #68); the link resolves on `main` once both merge.