### PR TITLE
docs: curated API documentation beyond Swagger (#70)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,74 @@
+# Etornie API — curated reference
+
+The exhaustive, always-current endpoint reference is the auto-generated
+**OpenAPI / Swagger UI at `/docs`** (and the raw schema at
+`/openapi.json`) on a running backend. These pages do **not** repeat
+every endpoint — they are the *narrative* docs Swagger can't give you:
+the multi-step flows, the auth model, and the conventions that tie the
+surface together.
+
+## Start here
+
+- [Authentication](./authentication.md) — email/password + OTP, the
+  JWT access/refresh model, roles.
+- [Wallet sign-in](./wallet-signing.md) — the ed25519 nonce-challenge
+  flow for Solana wallets.
+- [RAG pipeline](./rag.md) — indexing documents and asking questions
+  about a case (`/ai/*`).
+
+## Base URL
+
+| Environment | Base URL |
+|-------------|----------|
+| Local dev | `http://localhost:8000` |
+
+## Conventions
+
+### Authentication
+
+Most endpoints require a bearer token:
+
+```http
+Authorization: Bearer <access_token>
+```
+
+Obtain one via [Authentication](./authentication.md) or
+[Wallet sign-in](./wallet-signing.md). Access tokens are short-lived;
+refresh them with `POST /auth/refresh` (see Authentication). Lifetimes
+are configurable (`ACCESS_TOKEN_EXPIRE_MINUTES`,
+`REFRESH_TOKEN_EXPIRE_DAYS`).
+
+### Roles
+
+Two system roles: **admin** (platform operator) and **client** (case
+owner). Most write endpoints on `/cases`, `/payments`, etc. are
+admin-only; a client can read/act only on resources they own. See
+[ADR-0003](../adr/0003-two-tier-role-model.md).
+
+### Errors
+
+| Shape | When |
+|-------|------|
+| `{"detail": "..."}` | `HTTPException` (404, 403, 400, …). |
+| `{"detail": [ {loc, msg, type}, … ]}` | `422` request-validation errors. |
+| `{"error": "...", "category": "..."}` | Domain errors (`UserFacingError`) — a safe user message; the technical detail is logged server-side, never returned. |
+
+### Resource surface
+
+Top-level routers (see `/docs` for the full list of operations):
+
+| Prefix | Area |
+|--------|------|
+| `/auth`, `/auth/wallet` | Authentication, wallet sign-in |
+| `/users` | Profile, avatar, timeline, GDPR export |
+| `/cases` | Cases, notes, attestation, NFT claim, export — plus nested document upload/review, renewals, and required-documents |
+| `/ai` | RAG index / search / chat |
+| `/agent`, `/etorniegpt` | EtornieGPT agent sessions + chat + tools |
+| `/payments` | Stripe + x402 payments, webhooks |
+| `/organizations` | Multi-tenant orgs, memberships, invites |
+| `/euipo`, `/ukipo` | IP-office filing integrations |
+| `/zk` | Zero-knowledge ownership proofs |
+| `/notifications`, `/in-app-notifications` | Outbound + in-app notifications |
+
+Document, renewal, and required-document endpoints are nested under
+`/cases` (e.g. `/cases/{id}/documents`); see `/docs` for exact paths.

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,0 +1,99 @@
+# Authentication
+
+Etornie issues a **JWT access + refresh token pair**. Send the access
+token as a bearer header on every authenticated request; mint a fresh
+pair from the refresh token when the access token expires.
+
+```http
+Authorization: Bearer <access_token>
+```
+
+There are two ways in: **email + password** (this page) and
+[**Solana wallet sign-in**](./wallet-signing.md).
+
+## The token model
+
+`POST /auth/login` and the wallet/refresh endpoints all return:
+
+```json
+{
+  "access_token": "<jwt>",
+  "refresh_token": "<jwt>",
+  "token_type": "bearer"
+}
+```
+
+- The **access token** is short-lived and carries the user id + role.
+- The **refresh token** is longer-lived and only used to mint new pairs.
+- Lifetimes are configurable: `ACCESS_TOKEN_EXPIRE_MINUTES`,
+  `REFRESH_TOKEN_EXPIRE_DAYS`.
+
+### Refresh
+
+```http
+POST /auth/refresh
+Content-Type: application/json
+
+{ "refresh_token": "<jwt>" }
+```
+
+Returns a new `{access_token, refresh_token}` pair. The dashboard does
+this automatically on a `401` and replays the original request, so an
+expired access token never logs the user out.
+
+## Email + password registration
+
+There are two registration paths.
+
+### a) Direct register
+
+```http
+POST /auth/register
+Content-Type: application/json
+
+{ "email": "a@b.com", "password": "…", "full_name": "Ada" }
+```
+
+→ `201` with the created user (role `client`).
+
+### b) OTP-verified register (two-step)
+
+For flows that confirm the email first:
+
+1. `POST /auth/register/request` — sends a one-time code (via EmailJS)
+   to the address and stashes the pending signup in Redis.
+2. `POST /auth/register/verify` — submit the code to finalise the
+   account.
+
+Admin accounts are provisioned via `POST /auth/register/admin`
+(operator-only), never by self-service.
+
+## Login
+
+```http
+POST /auth/login
+Content-Type: application/json
+
+{ "email": "a@b.com", "password": "…" }
+```
+
+→ `{access_token, refresh_token, token_type}`. Use the access token on
+subsequent requests.
+
+## Who am I
+
+```http
+GET /auth/me
+Authorization: Bearer <access_token>
+```
+
+→ the current `UserResponse` (id, email, full_name, role,
+wallet_address, public_handle, …). Handy for bootstrapping the UI and
+checking the caller's role.
+
+## Roles
+
+`admin` and `client` only — see
+[ADR-0003](../adr/0003-two-tier-role-model.md). Self-service signup
+(email or wallet) always yields a `client`; admins cannot be created by
+self-elevation.

--- a/docs/api/rag.md
+++ b/docs/api/rag.md
@@ -1,0 +1,92 @@
+# RAG pipeline (`/ai`)
+
+Etornie's document Q&A is a retrieval-augmented-generation (RAG)
+pipeline: case documents are **indexed** into vector embeddings, a
+question is matched against the most relevant chunks, and an LLM answers
+**grounded in those chunks** (with sources). It powers the case
+assistant.
+
+All three operations require an authenticated caller who can access the
+document's case (admin, or the bound client).
+
+## 1. Index a document
+
+```http
+POST /ai/index/{document_id}
+Authorization: Bearer <access_token>
+```
+
+→ `{ "chunks_created": 12 }`
+
+Under the hood (`app/ai/rag/service.py`):
+
+1. **Extract text** from the stored file (PDFs are read page-by-page;
+   `.txt`/`.md` directly).
+2. **Clean + chunk** — PDFs are chunked page-by-page; long pages are
+   split with overlap to stay within the embedding model's token limit.
+3. **Embed** each chunk with Together AI
+   (`intfloat/multilingual-e5-large-instruct`), in batches.
+4. **Store** each chunk + its embedding as a `DocumentChunk` row
+   (Postgres + pgvector).
+
+Re-indexing a document adds fresh chunks; `chunks_created` is `0` when
+there is no extractable text (e.g. an empty or unsupported file).
+
+## 2. Semantic search
+
+```http
+POST /ai/search
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{ "query": "what is the filing deadline?", "case_id": "<uuid>", "top_k": 5 }
+```
+
+Response:
+
+```json
+{
+  "results": [
+    { "content": "…matching chunk text…", "score": 0.83, "document_id": "<uuid>" }
+  ]
+}
+```
+
+- `case_id` (optional) scopes the search to one case's documents.
+- `top_k` (1–50, default 5) caps the number of hits.
+- The top hits are returned with their neighbouring chunks merged in, so
+  a section that spans two chunks comes back whole.
+
+## 3. Ask a question (chat)
+
+```http
+POST /ai/rag/chat
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{ "question": "which documents are still required?", "case_id": "<uuid>" }
+```
+
+Response:
+
+```json
+{
+  "answer": "…grounded answer…",
+  "sources": [
+    { "content": "…chunk used as context…", "score": 0.81, "document_id": "<uuid>" }
+  ]
+}
+```
+
+The endpoint searches the case's indexed chunks, injects the best
+matches as context, and asks the LLM to answer using only that context —
+returning both the `answer` and the `sources` it relied on. If nothing
+relevant is indexed, the assistant says so rather than inventing facts.
+
+## Notes
+
+- Embeddings need `TOGETHER_API_KEY`; without it, indexing/search/chat
+  return errors (the feature is opt-in via config).
+- Indexing is currently an explicit call (`POST /ai/index/{id}`), not
+  automatic on upload — index a document before expecting the assistant
+  to answer from it.

--- a/docs/api/wallet-signing.md
+++ b/docs/api/wallet-signing.md
@@ -1,0 +1,86 @@
+# Wallet sign-in
+
+Users can authenticate with a Solana wallet (Phantom / Solflare) instead
+of a password, using an **ed25519 nonce-challenge**: the server issues a
+one-time message, the wallet signs it, and the server verifies the
+signature and returns a normal JWT pair. The wallet's private key never
+leaves the browser.
+
+Endpoints live under `/auth/wallet`.
+
+## Flow
+
+```
+1. POST /auth/wallet/nonce   { wallet_address }
+        → { wallet_address, nonce, message, expires_at }
+2. Wallet signs `message` (ed25519)   ← in the browser
+3. POST /auth/wallet/verify  { wallet_address, message, signature }
+        → { access_token, refresh_token, token_type, user }
+```
+
+### 1. Request a nonce
+
+```http
+POST /auth/wallet/nonce
+Content-Type: application/json
+
+{ "wallet_address": "<base58 pubkey>" }
+```
+
+Response:
+
+```json
+{
+  "wallet_address": "<base58 pubkey>",
+  "nonce": "<random>",
+  "message": "<the exact string to sign>",
+  "expires_at": "2026-06-05T12:00:00Z"
+}
+```
+
+The `nonce` is **single-use** and stored in Redis with a short TTL, so a
+captured signature cannot be replayed. Always sign the returned
+`message` verbatim.
+
+### 2. Sign the message
+
+In the browser, have the wallet sign `message` (e.g. Phantom's
+`signMessage`) to produce an ed25519 `signature`. This is the only step
+that touches the private key.
+
+### 3. Verify
+
+```http
+POST /auth/wallet/verify
+Content-Type: application/json
+
+{
+  "wallet_address": "<base58 pubkey>",
+  "message": "<the message from step 1>",
+  "signature": "<ed25519 signature>",
+  "full_name": "Ada",        // optional, used on first sign-up
+  "role": "client"            // optional; sign-up is client-only
+}
+```
+
+On success:
+
+```json
+{
+  "access_token": "<jwt>",
+  "refresh_token": "<jwt>",
+  "token_type": "bearer",
+  "user": { "id": "…", "wallet_address": "…", "public_handle": "etornie_ab12cd34", "role": "client" }
+}
+```
+
+- First sign-in **creates** the account (a `client`); later sign-ins log
+  in to the existing one. A `public_handle` like `etornie_<8>` is
+  assigned.
+- Wallet sign-up is restricted to the `client` role — an admin cannot
+  self-elevate through this path.
+- A missing/expired nonce returns `400` ("Nonce missing or expired…") —
+  request a fresh one and retry.
+
+From here, use the `access_token` exactly as in
+[Authentication](./authentication.md), including `POST /auth/refresh`.


### PR DESCRIPTION
Closes #70.

The `/docs` Swagger UI lists every endpoint but not the **multi-step flows** or the conventions that tie the surface together. This adds the narrative API docs under `docs/api/`, covering exactly the areas the issue calls out (auth flow, wallet signing, RAG pipeline).

## Contents
- **`README.md`** — base URL, the `Authorization: Bearer` convention, error-envelope shapes (`detail` / `422` / `{error, category}`), the two-role model, and a router-surface map. Points at `/docs` for the exhaustive per-endpoint reference.
- **`authentication.md`** — email/password + OTP registration, the JWT access/refresh model, `/auth/refresh`, `/auth/me`, roles.
- **`wallet-signing.md`** — the ed25519 nonce-challenge flow (`/auth/wallet/nonce` → sign → `/verify`), single-use Redis nonces, client-only sign-up.
- **`rag.md`** — the `/ai` index → search → chat pipeline (page chunking, `multilingual-e5-large-instruct` embeddings, pgvector, grounded answers with sources).

Endpoints, request/response shapes, the embedding model, the error envelope, and router prefixes are all **verified against the code** (e.g. document endpoints are correctly documented as nested under `/cases`).

Docs only — no code or runtime changes.

> Note: links to `docs/adr/` resolve once the sibling PR #68 merges.