### PR TITLE
docs(solana): Squads multisig upgrade-authority runbook + transfer script (#17)

### DIFF
--- a/docs/runbooks/program-upgrade.md
+++ b/docs/runbooks/program-upgrade.md
@@ -1,0 +1,150 @@
+# Runbook: program upgrade authority via Squads multisig
+
+**Goal:** move the BPF *upgrade authority* of Etornie's three on-chain
+programs from a single deployer keypair to a **3-of-5 Squads multisig**,
+and perform all future upgrades through that multisig. A single key
+holding upgrade authority is a mainnet blocker (issue #17): one
+compromised key could ship a malicious program.
+
+Programs (devnet ids):
+
+| Program | Program id |
+|---------|-----------|
+| `etornie_attestation` | `CpLYWQn39xw1Qei1fqcDF8NkJGiJsME2dKpAfzkN1T2X` |
+| `etornie_ip_token` | `6WrZ6NmuQtfpufrLbk5prQCKuF4isX1JwbrvxGFxT2gF` |
+| `etornie_zk_verifier` | `GCnpSrJ1W8SXPZ94FbYy4xs5kNZEAQuiDD7Nqk4nwSk5` |
+
+> Check the current authority any time: `solana program show <id> --url devnet`.
+> As of writing, all three are owned by the deployer wallet
+> `CBDjvUkZZ6ucrVGrU3vRraasTytha8oVg2NLCxAHE25b`.
+
+> ⚠️ Transferring upgrade authority is **irreversible without the new
+> authority**. If you set it to the wrong address you can no longer
+> upgrade the program. Do devnet first, and double-check the vault PDA.
+
+---
+
+## Prerequisites
+
+- **Squads CLI**: `cargo install squads-multisig-cli`
+  (`squads-multisig-cli --help`).
+- **Solana CLI** ≥ 2.x (`solana --version`).
+- The keypair of the **current** upgrade authority (the deployer wallet
+  above). On devnet this is the deployer wallet, **not** the backend
+  operator key (`services/api/keys/operator.json`).
+- **Five member public keys** for the multisig signers, and a funded
+  fee-payer keypair.
+- (Easy alternative to the CLI: the Squads web app —
+  <https://devnet.squads.so> for devnet.)
+
+---
+
+## Step 1 — Create the 3-of-5 multisig
+
+```bash
+squads-multisig-cli multisig-create \
+  --rpc-url https://api.devnet.solana.com \
+  --keypair <FEE_PAYER_KEYPAIR.json> \
+  --members <MEMBER_1_PUBKEY> <MEMBER_2_PUBKEY> <MEMBER_3_PUBKEY> <MEMBER_4_PUBKEY> <MEMBER_5_PUBKEY> \
+  --threshold 3
+```
+
+> Member permission encoding (propose/vote/execute) is shown by
+> `squads-multisig-cli multisig-create --help`; give each member full
+> permissions unless you intend role separation.
+
+Record the printed **multisig account address** — call it `<MULTISIG>`.
+
+## Step 2 — Find the vault PDA
+
+The upgrade authority must become the multisig's **vault PDA** (vault
+index `0`), *not* the multisig account itself. The vault is the address
+that actually holds assets/authorities.
+
+- In the Squads web app the vault address is shown on the squad's home.
+- Programmatically it is `getVaultPda({ multisigPda: <MULTISIG>, index: 0 })`
+  from `@sqds/multisig`.
+
+Record it as `<VAULT_PDA>`.
+
+## Step 3 — Transfer upgrade authority of all three programs
+
+Use the helper (prompts for confirmation, prints before/after):
+
+```bash
+scripts/transfer-upgrade-authority.sh <VAULT_PDA> <CURRENT_AUTHORITY_KEYPAIR.json> devnet
+```
+
+Equivalent manual command per program (the `--skip-...-signer-check`
+flag is required because a PDA cannot sign):
+
+```bash
+solana program set-upgrade-authority <PROGRAM_ID> \
+  --new-upgrade-authority <VAULT_PDA> \
+  --skip-new-upgrade-authority-signer-check \
+  --keypair <CURRENT_AUTHORITY_KEYPAIR.json> \
+  --url https://api.devnet.solana.com
+```
+
+## Step 4 — Verify
+
+```bash
+for id in CpLYWQn39xw1Qei1fqcDF8NkJGiJsME2dKpAfzkN1T2X \
+          6WrZ6NmuQtfpufrLbk5prQCKuF4isX1JwbrvxGFxT2gF \
+          GCnpSrJ1W8SXPZ94FbYy4xs5kNZEAQuiDD7Nqk4nwSk5; do
+  solana program show "$id" --url https://api.devnet.solana.com | grep -i Authority
+done
+```
+
+Every `Authority` must now equal `<VAULT_PDA>`. ✅ Issue #17 criteria 1 & 2.
+
+---
+
+## Performing a future upgrade (through the multisig)
+
+Once the vault owns upgrade authority, a single key can no longer upgrade
+a program — it takes 3 of 5 approvals.
+
+1. **Build** the new program reproducibly — see
+   [build-reproducibility.md](../build-reproducibility.md). You get
+   `target/deploy/<program>.so`.
+2. **Write a buffer** and hand it to the vault:
+   ```bash
+   solana program write-buffer target/deploy/<program>.so --url <rpc>
+   # -> Buffer: <BUFFER>
+   solana program set-buffer-authority <BUFFER> \
+     --new-buffer-authority <VAULT_PDA> --url <rpc>
+   ```
+3. **Propose the upgrade** as a multisig transaction. Easiest: the Squads
+   web app → the program → **Add upgrade** (enter the program id + buffer).
+   Via CLI, create a vault transaction carrying the BPF Upgradeable Loader
+   `Upgrade` instruction (program, buffer, vault as authority, spill):
+   ```bash
+   squads-multisig-cli vault-transaction-create \
+     --rpc-url <rpc> --keypair <member.json> \
+     --multisig-pubkey <MULTISIG> --transaction-message <...upgrade ix...>
+   ```
+4. **Approve** until the threshold (3) is met:
+   ```bash
+   squads-multisig-cli proposal-vote --action Approve \
+     --rpc-url <rpc> --keypair <member.json> \
+     --multisig-pubkey <MULTISIG> --transaction-index <N>
+   ```
+5. **Execute**:
+   ```bash
+   squads-multisig-cli vault-transaction-execute \
+     --rpc-url <rpc> --keypair <member.json> \
+     --multisig-pubkey <MULTISIG> --transaction-index <N>
+   ```
+
+## Safety & rollback
+
+- **Verify `<VAULT_PDA>` before Step 3.** A wrong address permanently
+  removes your ability to upgrade.
+- Changing the authority back, the threshold, or the member set are all
+  themselves multisig transactions (propose → approve → execute).
+- Keep the member keys on separate machines/people; 3-of-5 means losing
+  up to 2 keys is survivable, and no single key can act alone.
+- Rehearse this entire runbook on **devnet** before mainnet. The mainnet
+  flow is identical — swap `--rpc-url`/`--url` to `https://api.mainnet-beta.solana.com`
+  and use the mainnet program ids.

--- a/scripts/transfer-upgrade-authority.sh
+++ b/scripts/transfer-upgrade-authority.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Transfer the BPF upgrade authority of all three Etornie programs to a new
+# authority — typically a Squads multisig **vault PDA** (issue #17).
+#
+# This is IRREVERSIBLE without the new authority: once the multisig vault
+# owns upgrade authority, only a multisig transaction can change it back.
+# Read docs/runbooks/program-upgrade.md before running.
+#
+# Usage:
+#   scripts/transfer-upgrade-authority.sh <NEW_AUTHORITY> [AUTHORITY_KEYPAIR] [CLUSTER]
+#
+#   NEW_AUTHORITY      Squads vault PDA to receive upgrade authority (required)
+#   AUTHORITY_KEYPAIR  keypair of the CURRENT upgrade authority (default: the
+#                      keypair configured in `solana config`). NOTE: on devnet
+#                      the current authority is the deployer wallet, not the
+#                      backend operator key.
+#   CLUSTER            devnet | mainnet-beta | <rpc-url>  (default: devnet)
+set -euo pipefail
+
+NEW_AUTHORITY="${1:-}"
+AUTHORITY_KEYPAIR="${2:-}"
+CLUSTER="${3:-devnet}"
+
+# program label + program id
+PROGRAMS=(
+  "etornie_attestation:CpLYWQn39xw1Qei1fqcDF8NkJGiJsME2dKpAfzkN1T2X"
+  "etornie_ip_token:6WrZ6NmuQtfpufrLbk5prQCKuF4isX1JwbrvxGFxT2gF"
+  "etornie_zk_verifier:GCnpSrJ1W8SXPZ94FbYy4xs5kNZEAQuiDD7Nqk4nwSk5"
+)
+
+if [ -z "$NEW_AUTHORITY" ]; then
+  echo "usage: $0 <NEW_AUTHORITY_VAULT_PDA> [AUTHORITY_KEYPAIR] [CLUSTER]" >&2
+  exit 1
+fi
+
+case "$CLUSTER" in
+  devnet)       URL="https://api.devnet.solana.com" ;;
+  mainnet-beta) URL="https://api.mainnet-beta.solana.com" ;;
+  *)            URL="$CLUSTER" ;;
+esac
+
+KEYPAIR_ARGS=()
+[ -n "$AUTHORITY_KEYPAIR" ] && KEYPAIR_ARGS=(--keypair "$AUTHORITY_KEYPAIR")
+
+echo "Cluster:        $URL"
+echo "New authority:  $NEW_AUTHORITY  (must be the Squads vault PDA)"
+echo "Programs:"
+for entry in "${PROGRAMS[@]}"; do echo "  - ${entry%%:*} (${entry##*:})"; done
+echo
+echo "This transfers upgrade authority of ALL three programs and is"
+echo "IRREVERSIBLE without the new (multisig) authority. Type 'yes' to proceed:"
+read -r confirm
+[ "$confirm" = "yes" ] || { echo "Aborted."; exit 1; }
+
+for entry in "${PROGRAMS[@]}"; do
+  name="${entry%%:*}"
+  id="${entry##*:}"
+  echo
+  echo "==== $name ($id) ===="
+  echo "before: $(solana program show "$id" --url "$URL" 2>/dev/null | grep -i Authority || echo '?')"
+  solana program set-upgrade-authority "$id" \
+    --new-upgrade-authority "$NEW_AUTHORITY" \
+    --skip-new-upgrade-authority-signer-check \
+    --url "$URL" \
+    "${KEYPAIR_ARGS[@]}"
+  echo "after:  $(solana program show "$id" --url "$URL" 2>/dev/null | grep -i Authority || echo '?')"
+done
+
+echo
+echo "Done. Verify every program's Authority now equals $NEW_AUTHORITY."


### PR DESCRIPTION
Addresses #17.

Program upgrade authority is currently a **single deployer keypair** — a mainnet blocker: one compromised key could ship a malicious program. This delivers everything to move it to a **3-of-5 Squads multisig**, and (per the agreed split) the irreversible on-chain transfer is executed by the operator who holds the current authority key and chooses the 5 members.

## What's here
- **`docs/runbooks/program-upgrade.md`** (acceptance criterion 3) — create the 3-of-5 multisig (`squads-multisig-cli multisig-create`), find the **vault PDA**, transfer all three programs' upgrade authority to it, and perform future upgrades through the multisig (`write-buffer` → `set-buffer-authority` → propose → 3 approvals → execute). Plus safety/rollback + mainnet notes.
- **`scripts/transfer-upgrade-authority.sh`** — transfers upgrade authority of all three programs to a given vault PDA, with a confirmation prompt and before/after verification.

## Why a runbook + script (not executed here)
The current upgrade authority keypair is **not** in this repo, and the transfer is irreversible + a security decision (who are the 5 members?). So criteria 1 & 2 are operator-run via this runbook; criterion 3 is delivered.

## Proof / verification (devnet, today)
All three programs are deployed and owned by a **single** key — the exact problem this fixes:
```
$ solana program show CpLYWQn39xw1Qei1fqcDF8NkJGiJsME2dKpAfzkN1T2X --url devnet
Authority: CBDjvUkZZ6ucrVGrU3vRraasTytha8oVg2NLCxAHE25b      # etornie_attestation
$ solana program show 6WrZ6NmuQtfpufrLbk5prQCKuF4isX1JwbrvxGFxT2gF --url devnet
Authority: CBDjvUkZZ6ucrVGrU3vRraasTytha8oVg2NLCxAHE25b      # etornie_ip_token
$ solana program show GCnpSrJ1W8SXPZ94FbYy4xs5kNZEAQuiDD7Nqk4nwSk5 --url devnet
Authority: CBDjvUkZZ6ucrVGrU3vRraasTytha8oVg2NLCxAHE25b      # etornie_zk_verifier
```

Transfer-to-PDA flag confirmed in the local Solana CLI (2.3.0):
```
$ solana program set-upgrade-authority --help
  --skip-new-upgrade-authority-signer-check
      Set this flag if you don't want the new authority to sign the set-upgrade-authority transaction.
```

Squads CLI commands (`multisig-create`, `vault-transaction-create`, `proposal-vote --action Approve`, `vault-transaction-execute`) are taken from the official Squads v4 docs. Helper script passes `bash -n` and its usage guard.

After the operator runs the runbook on devnet, criteria 1 & 2 are verified by re-running the `solana program show` commands above — every `Authority` should equal the multisig **vault PDA**.

Docs/script only — no app code, no frontend, no runtime change.