### PR TITLE
feat(auth): TOTP two-factor authentication for email + wallet login (#56)

### DIFF
--- a/dashboard/src/app/dashboard/profile/page.tsx
+++ b/dashboard/src/app/dashboard/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import api, { extractErrorMessage } from "@/lib/api";
+import TwoFactorSettings from "@/components/TwoFactorSettings";
 
 interface MeUser {
   id: string;
@@ -597,6 +598,9 @@ export default function ProfilePage() {
           )}
         </div>
       </section>
+
+      {/* Two-factor authentication */}
+      <TwoFactorSettings onChanged={fetchAll} />
 
       {/* Filings timeline */}
       <section>

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -45,8 +45,34 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  // Second-factor step: set once the backend answers a correct password
+  // with `mfa_required`. We hold the short-lived challenge token and
+  // collect a TOTP (or recovery) code before any tokens are issued.
+  const [mfaToken, setMfaToken] = useState<string | null>(null);
+  const [mfaCode, setMfaCode] = useState("");
 
   const activeOption = ROLE_OPTIONS.find((r) => r.key === selectedRole)!;
+
+  // Shared completion path for password-only and 2FA logins: enforce the
+  // selected role matches the account, then persist tokens.
+  function finishLogin(accessToken: string, refreshToken?: string): void {
+    const payload = JSON.parse(atob(accessToken.split(".")[1]));
+    if (payload.role !== selectedRole) {
+      setError(
+        `This account is registered as ${ROLE_LABELS[payload.role] || payload.role}. Please select the correct login type.`
+      );
+      return;
+    }
+    setToken(accessToken, refreshToken);
+    router.push("/dashboard");
+  }
+
+  function readError(err: unknown, fallback: string): string {
+    return (
+      (err as { response?: { data?: { detail?: string } } })?.response?.data
+        ?.detail ?? fallback
+    );
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -55,26 +81,43 @@ export default function LoginPage() {
 
     try {
       const res = await api.post("/auth/login", { email, password });
-      const token = res.data.access_token;
 
-      const payload = JSON.parse(atob(token.split(".")[1]));
-      if (payload.role !== selectedRole) {
-        setError(
-          `This account is registered as ${ROLE_LABELS[payload.role] || payload.role}. Please select the correct login type.`
-        );
+      if (res.data.mfa_required) {
+        setMfaToken(res.data.mfa_token);
+        setMfaCode("");
         return;
       }
 
-      setToken(token, res.data.refresh_token);
-      router.push("/dashboard");
+      finishLogin(res.data.access_token, res.data.refresh_token);
     } catch (err: unknown) {
-      const message =
-        (err as { response?: { data?: { detail?: string } } })?.response?.data
-          ?.detail ?? "Login failed. Please try again.";
-      setError(message);
+      setError(readError(err, "Login failed. Please try again."));
     } finally {
       setLoading(false);
     }
+  }
+
+  async function handleMfaSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const res = await api.post("/auth/login/mfa", {
+        mfa_token: mfaToken,
+        code: mfaCode.trim(),
+      });
+      finishLogin(res.data.access_token, res.data.refresh_token);
+    } catch (err: unknown) {
+      setError(readError(err, "Verification failed. Please try again."));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function cancelMfa() {
+    setMfaToken(null);
+    setMfaCode("");
+    setError("");
   }
 
   return (
@@ -158,7 +201,7 @@ export default function LoginPage() {
           </div>
 
           <h2 className="mb-4 text-center text-base font-medium text-[color:var(--color-espresso)]">
-            {activeOption.label} Access
+            {mfaToken ? "Two-Factor Verification" : `${activeOption.label} Access`}
           </h2>
 
           {error && (
@@ -170,6 +213,49 @@ export default function LoginPage() {
             </div>
           )}
 
+          {mfaToken ? (
+            <form onSubmit={handleMfaSubmit} className="space-y-4">
+              <p className="text-sm text-[color:var(--color-muted)]">
+                Enter the 6-digit code from your authenticator app. Lost your
+                device? Enter one of your recovery codes instead.
+              </p>
+              <div>
+                <label
+                  htmlFor="mfa-code"
+                  className="block text-xs font-semibold uppercase tracking-wider text-[color:var(--color-muted)]"
+                >
+                  Authentication code
+                </label>
+                <input
+                  id="mfa-code"
+                  type="text"
+                  inputMode="text"
+                  autoComplete="one-time-code"
+                  autoFocus
+                  required
+                  value={mfaCode}
+                  onChange={(e) => setMfaCode(e.target.value)}
+                  className="rwa-input mt-1.5 w-full tracking-widest"
+                  placeholder="123 456"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={loading}
+                className="rwa-btn-primary w-full"
+              >
+                {loading ? "Verifying..." : "Verify & Sign In"}
+              </button>
+              <button
+                type="button"
+                onClick={cancelMfa}
+                className="w-full text-center text-xs text-[color:var(--color-muted)] hover:text-[color:var(--color-bronze)]"
+              >
+                ← Back to login
+              </button>
+            </form>
+          ) : (
+          <>
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label
@@ -256,6 +342,8 @@ export default function LoginPage() {
               Register
             </Link>
           </p>
+          </>
+          )}
         </div>
 
         <p className="mt-6 text-center text-[11px] text-[color:var(--color-muted)]">

--- a/dashboard/src/components/TwoFactorSettings.tsx
+++ b/dashboard/src/components/TwoFactorSettings.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import api, { extractErrorMessage } from "@/lib/api";
+
+interface TwoFactorStatus {
+  enabled: boolean;
+  required: boolean;
+  recovery_codes_remaining: number;
+}
+
+interface EnrollData {
+  secret: string;
+  otpauth_uri: string;
+  qr_data_url: string;
+}
+
+interface TwoFactorSettingsProps {
+  /** Called after enable/disable so the parent can refresh /auth/me. */
+  onChanged?: () => void;
+}
+
+type Phase = "loading" | "idle" | "enrolling" | "showing_recovery";
+
+export default function TwoFactorSettings({ onChanged }: TwoFactorSettingsProps) {
+  const [status, setStatus] = useState<TwoFactorStatus | null>(null);
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [enroll, setEnroll] = useState<EnrollData | null>(null);
+  const [code, setCode] = useState("");
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [disabling, setDisabling] = useState(false);
+  const [disableCode, setDisableCode] = useState("");
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const res = await api.get<TwoFactorStatus>("/auth/2fa/status");
+      setStatus(res.data);
+      setPhase((prev) => (prev === "showing_recovery" ? prev : "idle"));
+    } catch (err) {
+      setError(extractErrorMessage(err, "Could not load two-factor status."));
+      setPhase("idle");
+    }
+  }, []);
+
+  useEffect(() => {
+    loadStatus();
+  }, [loadStatus]);
+
+  async function startEnrollment() {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await api.post<EnrollData>("/auth/2fa/enroll");
+      setEnroll(res.data);
+      setCode("");
+      setPhase("enrolling");
+    } catch (err) {
+      setError(extractErrorMessage(err, "Could not start enrollment."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function confirmEnable() {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await api.post<{ recovery_codes: string[] }>(
+        "/auth/2fa/enable",
+        { code: code.trim() }
+      );
+      setRecoveryCodes(res.data.recovery_codes);
+      setEnroll(null);
+      setCode("");
+      setPhase("showing_recovery");
+      await loadStatus();
+      onChanged?.();
+    } catch (err) {
+      setError(extractErrorMessage(err, "Invalid code. Please try again."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function disable() {
+    setError(null);
+    setBusy(true);
+    try {
+      await api.post("/auth/2fa/disable", { code: disableCode.trim() });
+      setDisabling(false);
+      setDisableCode("");
+      await loadStatus();
+      onChanged?.();
+    } catch (err) {
+      setError(extractErrorMessage(err, "Invalid code. Please try again."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function cancelEnrollment() {
+    setEnroll(null);
+    setCode("");
+    setError(null);
+    setPhase("idle");
+  }
+
+  function finishRecovery() {
+    setRecoveryCodes([]);
+    setPhase("idle");
+  }
+
+  const heading = (
+    <div className="flex items-center justify-between">
+      <h3 className="text-base font-semibold text-[color:var(--color-ink)]">
+        Two-Factor Authentication
+      </h3>
+      {status?.enabled ? (
+        <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-semibold text-green-800">
+          Enabled
+        </span>
+      ) : (
+        <span className="rounded-full bg-[color:var(--color-sand)] px-2.5 py-0.5 text-xs font-semibold text-[color:var(--color-muted)]">
+          Disabled
+        </span>
+      )}
+    </div>
+  );
+
+  return (
+    <section className="rounded-xl border border-[color:var(--color-stone)] bg-white p-6">
+      <div className="space-y-4">
+        {heading}
+
+        <p className="text-sm text-[color:var(--color-muted)]">
+          Protect your account with a time-based one-time password (TOTP) from
+          an authenticator app such as Google Authenticator, 1Password, or Authy.
+        </p>
+
+        {status?.required && !status.enabled && (
+          <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+            Two-factor authentication is required for admin accounts. Please set
+            it up to secure your account.
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800"
+          >
+            {error}
+          </div>
+        )}
+
+        {phase === "loading" && (
+          <p className="text-sm text-[color:var(--color-muted)]">Loading…</p>
+        )}
+
+        {/* Already enabled — offer disable + recovery count */}
+        {phase === "idle" && status?.enabled && (
+          <div className="space-y-3">
+            <p className="text-sm text-[color:var(--color-ink)]">
+              {status.recovery_codes_remaining} recovery code
+              {status.recovery_codes_remaining === 1 ? "" : "s"} remaining.
+            </p>
+            {!disabling ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setDisabling(true);
+                  setError(null);
+                }}
+                className="rounded-lg border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50"
+              >
+                Disable 2FA
+              </button>
+            ) : (
+              <div className="space-y-2">
+                <label
+                  htmlFor="disable-code"
+                  className="block text-xs font-semibold uppercase tracking-wider text-[color:var(--color-muted)]"
+                >
+                  Enter a current code or recovery code to confirm
+                </label>
+                <input
+                  id="disable-code"
+                  type="text"
+                  inputMode="text"
+                  autoComplete="one-time-code"
+                  value={disableCode}
+                  onChange={(e) => setDisableCode(e.target.value)}
+                  className="rwa-input w-full"
+                  placeholder="123 456"
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={busy || !disableCode.trim()}
+                    onClick={disable}
+                    className="rounded-lg border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 disabled:opacity-50"
+                  >
+                    {busy ? "Disabling…" : "Confirm Disable"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDisabling(false);
+                      setDisableCode("");
+                      setError(null);
+                    }}
+                    className="rounded-lg border border-[color:var(--color-stone)] px-4 py-2 text-sm font-semibold text-[color:var(--color-muted)] hover:bg-[color:var(--color-sand)]"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Not enabled, not yet enrolling */}
+        {phase === "idle" && !status?.enabled && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={startEnrollment}
+            className="rwa-btn-primary"
+          >
+            {busy ? "Preparing…" : "Enable 2FA"}
+          </button>
+        )}
+
+        {/* Enrollment: scan QR + confirm with a code */}
+        {phase === "enrolling" && enroll && (
+          <div className="space-y-4">
+            <ol className="list-decimal space-y-2 pl-5 text-sm text-[color:var(--color-ink)]">
+              <li>Scan this QR code with your authenticator app.</li>
+              <li>Enter the 6-digit code it generates to confirm.</li>
+            </ol>
+            <div className="flex flex-col items-center gap-3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={enroll.qr_data_url}
+                alt="Two-factor QR code"
+                width={180}
+                height={180}
+                className="rounded-lg border border-[color:var(--color-stone)] bg-white p-2"
+              />
+              <details className="w-full text-center">
+                <summary className="cursor-pointer text-xs text-[color:var(--color-muted)]">
+                  Can&apos;t scan? Enter this key manually
+                </summary>
+                <code className="mt-2 block break-all rounded bg-[color:var(--color-sand)] px-3 py-2 text-xs text-[color:var(--color-ink)]">
+                  {enroll.secret}
+                </code>
+              </details>
+            </div>
+            <div>
+              <label
+                htmlFor="enable-code"
+                className="block text-xs font-semibold uppercase tracking-wider text-[color:var(--color-muted)]"
+              >
+                Authentication code
+              </label>
+              <input
+                id="enable-code"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                className="rwa-input mt-1.5 w-full tracking-widest"
+                placeholder="123 456"
+              />
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                disabled={busy || !code.trim()}
+                onClick={confirmEnable}
+                className="rwa-btn-primary disabled:opacity-50"
+              >
+                {busy ? "Verifying…" : "Verify & Enable"}
+              </button>
+              <button
+                type="button"
+                onClick={cancelEnrollment}
+                className="rounded-lg border border-[color:var(--color-stone)] px-4 py-2 text-sm font-semibold text-[color:var(--color-muted)] hover:bg-[color:var(--color-sand)]"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Recovery codes shown once */}
+        {phase === "showing_recovery" && (
+          <div className="space-y-3">
+            <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+              Save these recovery codes somewhere safe. Each can be used once if
+              you lose access to your authenticator. They will not be shown again.
+            </div>
+            <ul className="grid grid-cols-2 gap-2">
+              {recoveryCodes.map((rc) => (
+                <li
+                  key={rc}
+                  className="rounded bg-[color:var(--color-sand)] px-3 py-2 text-center font-mono text-sm text-[color:var(--color-ink)]"
+                >
+                  {rc}
+                </li>
+              ))}
+            </ul>
+            <button
+              type="button"
+              onClick={finishRecovery}
+              className="rwa-btn-primary"
+            >
+              I&apos;ve saved my recovery codes
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/components/WalletSignInButton.tsx
+++ b/dashboard/src/components/WalletSignInButton.tsx
@@ -15,19 +15,29 @@ interface NonceResponse {
   expires_at: string;
 }
 
+interface VerifyUser {
+  id: string;
+  wallet_address: string | null;
+  public_handle: string | null;
+  role: string;
+  auth_method: string;
+  email: string | null;
+  full_name: string;
+}
+
 interface VerifyResponse {
+  access_token: string | null;
+  refresh_token: string | null;
+  token_type: string;
+  mfa_required?: boolean;
+  mfa_token?: string | null;
+  user: VerifyUser;
+}
+
+interface MfaTokenResponse {
   access_token: string;
   refresh_token: string;
   token_type: string;
-  user: {
-    id: string;
-    wallet_address: string | null;
-    public_handle: string | null;
-    role: string;
-    auth_method: string;
-    email: string | null;
-    full_name: string;
-  };
 }
 
 type Status =
@@ -36,13 +46,14 @@ type Status =
   | { kind: "requesting_nonce" }
   | { kind: "awaiting_signature" }
   | { kind: "verifying" }
+  | { kind: "mfa"; mfaToken: string; user: VerifyUser }
   | { kind: "error"; message: string };
 
 interface WalletSignInButtonProps {
   label?: string;
   role?: "client";
   fullName?: string;
-  onSuccess?: (user: VerifyResponse["user"]) => void;
+  onSuccess?: (user: VerifyUser) => void;
   className?: string;
 }
 
@@ -59,12 +70,26 @@ export function WalletSignInButton({
   const { setVisible } = useWalletModal();
   const [status, setStatus] = useState<Status>({ kind: "idle" });
   const [mounted, setMounted] = useState(false);
+  const [mfaCode, setMfaCode] = useState("");
+  const [mfaBusy, setMfaBusy] = useState(false);
   const inFlightRef = useRef(false);
   const initiatedRef = useRef(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  const finishSuccess = useCallback(
+    (user: VerifyUser) => {
+      setStatus({ kind: "idle" });
+      if (onSuccess) {
+        onSuccess(user);
+        return;
+      }
+      router.push("/dashboard");
+    },
+    [onSuccess, router]
+  );
 
   const runSignInFlow = useCallback(async () => {
     if (inFlightRef.current) return;
@@ -111,14 +136,21 @@ export function WalletSignInButton({
         verifyPayload
       );
 
-      setToken(verifyRes.data.access_token, verifyRes.data.refresh_token);
-      setStatus({ kind: "idle" });
-
-      if (onSuccess) {
-        onSuccess(verifyRes.data.user);
+      if (verifyRes.data.mfa_required && verifyRes.data.mfa_token) {
+        // 2FA account: pause for a code before tokens are issued.
+        setMfaCode("");
+        setStatus({
+          kind: "mfa",
+          mfaToken: verifyRes.data.mfa_token,
+          user: verifyRes.data.user,
+        });
         return;
       }
-      router.push("/dashboard");
+
+      if (verifyRes.data.access_token) {
+        setToken(verifyRes.data.access_token, verifyRes.data.refresh_token ?? undefined);
+      }
+      finishSuccess(verifyRes.data.user);
     } catch (err: unknown) {
       const detail =
         (err as { response?: { data?: { detail?: string } } })?.response?.data
@@ -129,7 +161,28 @@ export function WalletSignInButton({
     } finally {
       inFlightRef.current = false;
     }
-  }, [publicKey, signMessage, router, onSuccess, role, fullName]);
+  }, [publicKey, signMessage, role, fullName, finishSuccess]);
+
+  async function handleMfaSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (status.kind !== "mfa") return;
+    setMfaBusy(true);
+    try {
+      const res = await api.post<MfaTokenResponse>("/auth/login/mfa", {
+        mfa_token: status.mfaToken,
+        code: mfaCode.trim(),
+      });
+      setToken(res.data.access_token, res.data.refresh_token);
+      finishSuccess(status.user);
+    } catch (err: unknown) {
+      const detail =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? "Verification failed. Please try again.";
+      setStatus({ kind: "error", message: detail });
+    } finally {
+      setMfaBusy(false);
+    }
+  }
 
   useEffect(() => {
     if (!connected || !publicKey || !initiatedRef.current) return;
@@ -191,6 +244,45 @@ export function WalletSignInButton({
       }
     }
     setStatus({ kind: "idle" });
+  }
+
+  if (status.kind === "mfa") {
+    return (
+      <form onSubmit={handleMfaSubmit} className="w-full space-y-2">
+        <p className="text-xs text-[color:var(--color-dusk-gray)]">
+          Two-factor authentication is enabled. Enter the 6-digit code from your
+          authenticator app, or a recovery code.
+        </p>
+        <input
+          type="text"
+          inputMode="text"
+          autoComplete="one-time-code"
+          autoFocus
+          required
+          value={mfaCode}
+          onChange={(e) => setMfaCode(e.target.value)}
+          className="rwa-input w-full tracking-widest"
+          placeholder="123 456"
+        />
+        <button
+          type="submit"
+          disabled={mfaBusy || !mfaCode.trim()}
+          className="flex w-full items-center justify-center gap-2 rounded-full border border-[color:var(--color-accent)] bg-[color:var(--color-accent)] px-4 py-2.5 text-sm font-medium text-[color:var(--color-paper-white)] transition-all hover:bg-[color:var(--color-accent-hover)] hover:border-[color:var(--color-accent-hover)] disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {mfaBusy ? "Verifying…" : "Verify & Continue"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setStatus({ kind: "idle" });
+            setMfaCode("");
+          }}
+          className="w-full text-center text-xs text-[color:var(--color-dusk-gray)] hover:text-[color:var(--color-accent)] hover:underline"
+        >
+          Cancel
+        </button>
+      </form>
+    );
   }
 
   return (

--- a/services/api/alembic/versions/c3f1a9b27e64_add_user_totp_2fa.py
+++ b/services/api/alembic/versions/c3f1a9b27e64_add_user_totp_2fa.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "c3f1a9b27e64"
-down_revision = "d4a5b6c7e8f9"
+down_revision = "98ee72c0f678"
 branch_labels = None
 depends_on = None
 

--- a/services/api/alembic/versions/c3f1a9b27e64_add_user_totp_2fa.py
+++ b/services/api/alembic/versions/c3f1a9b27e64_add_user_totp_2fa.py
@@ -1,0 +1,45 @@
+"""add TOTP two-factor columns to users
+
+Adds the storage for RFC 6238 TOTP two-factor authentication:
+``totp_secret`` (base32 secret encrypted at rest), ``totp_enabled``
+(flips true once the user proves possession with a valid code) and
+``totp_recovery_codes`` (JSON array of bcrypt-hashed single-use codes).
+
+Revision ID: c3f1a9b27e64
+Revises: d4a5b6c7e8f9
+Create Date: 2026-06-06
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "c3f1a9b27e64"
+down_revision = "d4a5b6c7e8f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("totp_secret", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "totp_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column("totp_recovery_codes", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "totp_recovery_codes")
+    op.drop_column("users", "totp_enabled")
+    op.drop_column("users", "totp_secret")

--- a/services/api/app/auth/router.py
+++ b/services/api/app/auth/router.py
@@ -14,10 +14,17 @@ from app.auth.email_verification import (
 )
 from app.auth.schemas import (
     LoginRequest,
+    LoginResponse,
+    MfaLoginRequest,
     PublicRegisterRequest,
     RefreshRequest,
     RegisterRequest,
     TokenResponse,
+    TwoFactorDisableRequest,
+    TwoFactorEnableRequest,
+    TwoFactorEnableResponse,
+    TwoFactorEnrollResponse,
+    TwoFactorStatusResponse,
     UserResponse,
     VerifyCodeRequest,
 )
@@ -27,7 +34,14 @@ from app.auth.service import (
     get_user_by_email,
     get_user_by_id,
 )
-from app.auth.utils import create_access_token, create_refresh_token, decode_token
+from app.auth import totp_service
+from app.auth.totp_service import TotpError
+from app.auth.utils import (
+    create_access_token,
+    create_mfa_token,
+    create_refresh_token,
+    decode_token,
+)
 from app.cases.guest_linking import link_guest_cases
 from app.database import get_db
 from app.users.models import User, UserRole
@@ -191,16 +205,73 @@ async def register_admin(
     return user
 
 
-@router.post("/login", response_model=TokenResponse)
+@router.post("/login", response_model=LoginResponse)
 async def login(
     data: LoginRequest,
     db: AsyncSession = Depends(get_db),
-) -> TokenResponse:
+) -> LoginResponse:
     user = await authenticate_user(db, data.email, data.password)
     if user is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
+        )
+
+    if user.totp_enabled:
+        # Password is correct but the account is 2FA-protected: hand back
+        # a short-lived challenge token instead of access tokens. The
+        # client completes the second factor at /auth/login/mfa.
+        return LoginResponse(
+            mfa_required=True,
+            mfa_token=create_mfa_token(str(user.id)),
+        )
+
+    return LoginResponse(
+        access_token=create_access_token(str(user.id), user.role.value),
+        refresh_token=create_refresh_token(str(user.id)),
+    )
+
+
+@router.post("/login/mfa", response_model=TokenResponse)
+async def login_mfa(
+    data: MfaLoginRequest,
+    db: AsyncSession = Depends(get_db),
+) -> TokenResponse:
+    """Complete a 2FA login by exchanging the challenge token + code."""
+
+    try:
+        payload = decode_token(data.mfa_token)
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired authentication session",
+        )
+
+    if payload.get("type") != "mfa":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token type",
+        )
+
+    try:
+        user_id = uuid.UUID(payload["sub"])
+    except (KeyError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+        )
+
+    user = await get_user_by_id(db, user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found or inactive",
+        )
+
+    if not await totp_service.verify_second_factor(db, user, data.code):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication code",
         )
 
     return TokenResponse(
@@ -254,3 +325,70 @@ async def get_me(
     current_user: User = Depends(get_current_user),
 ) -> User:
     return current_user
+
+
+@router.get("/2fa/status", response_model=TwoFactorStatusResponse)
+async def two_factor_status(
+    current_user: User = Depends(get_current_user),
+) -> TwoFactorStatusResponse:
+    return TwoFactorStatusResponse(
+        enabled=current_user.totp_enabled,
+        required=current_user.mfa_setup_required,
+        recovery_codes_remaining=totp_service.recovery_codes_remaining(current_user),
+    )
+
+
+@router.post("/2fa/enroll", response_model=TwoFactorEnrollResponse)
+async def two_factor_enroll(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TwoFactorEnrollResponse:
+    """Start enrollment: mint a secret and return its QR / otpauth URI."""
+
+    try:
+        result = await totp_service.begin_enrollment(db, current_user)
+    except TotpError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        )
+    return TwoFactorEnrollResponse(
+        secret=result.secret,
+        otpauth_uri=result.otpauth_uri,
+        qr_data_url=result.qr_data_url,
+    )
+
+
+@router.post("/2fa/enable", response_model=TwoFactorEnableResponse)
+async def two_factor_enable(
+    data: TwoFactorEnableRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> TwoFactorEnableResponse:
+    """Confirm possession of the secret and turn 2FA on."""
+
+    try:
+        recovery_codes = await totp_service.enable(db, current_user, data.code)
+    except TotpError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+    return TwoFactorEnableResponse(recovery_codes=recovery_codes)
+
+
+@router.post("/2fa/disable", status_code=status.HTTP_204_NO_CONTENT)
+async def two_factor_disable(
+    data: TwoFactorDisableRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Turn 2FA off after proving possession (TOTP or recovery code)."""
+
+    try:
+        await totp_service.disable(db, current_user, data.code)
+    except TotpError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )

--- a/services/api/app/auth/schemas.py
+++ b/services/api/app/auth/schemas.py
@@ -24,6 +24,52 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
+class LoginResponse(BaseModel):
+    """Login result.
+
+    When the account has 2FA disabled this carries the token pair
+    directly. When 2FA is enabled, ``access_token``/``refresh_token``
+    stay null and ``mfa_required`` is true with a short-lived
+    ``mfa_token`` the client exchanges at /auth/login/mfa.
+    """
+
+    access_token: str | None = None
+    refresh_token: str | None = None
+    token_type: str = "bearer"
+    mfa_required: bool = False
+    mfa_token: str | None = None
+
+
+class MfaLoginRequest(BaseModel):
+    mfa_token: str
+    code: str = Field(min_length=4, max_length=32)
+
+
+class TwoFactorStatusResponse(BaseModel):
+    enabled: bool
+    required: bool
+    recovery_codes_remaining: int
+
+
+class TwoFactorEnrollResponse(BaseModel):
+    secret: str
+    otpauth_uri: str
+    qr_data_url: str
+
+
+class TwoFactorEnableRequest(BaseModel):
+    code: str = Field(min_length=6, max_length=10)
+
+
+class TwoFactorEnableResponse(BaseModel):
+    enabled: bool = True
+    recovery_codes: list[str]
+
+
+class TwoFactorDisableRequest(BaseModel):
+    code: str = Field(min_length=4, max_length=32)
+
+
 class RefreshRequest(BaseModel):
     refresh_token: str
 
@@ -79,6 +125,8 @@ class UserResponse(BaseModel):
     wallet_address: str | None = None
     public_handle: str | None = None
     auth_method: str = "email"
+    totp_enabled: bool = False
+    mfa_setup_required: bool = False
     created_at: datetime
     updated_at: datetime
 
@@ -105,7 +153,17 @@ class WalletVerifyRequest(BaseModel):
 
 
 class WalletVerifyResponse(BaseModel):
-    access_token: str
-    refresh_token: str
+    """Wallet sign-in result.
+
+    Mirrors :class:`LoginResponse`: when the resolved account has 2FA
+    enabled, the token pair stays null and ``mfa_required`` is true with
+    a short-lived ``mfa_token`` exchanged at /auth/login/mfa. ``user`` is
+    always present so the client can run its role check either way.
+    """
+
+    access_token: str | None = None
+    refresh_token: str | None = None
     token_type: str = "bearer"
+    mfa_required: bool = False
+    mfa_token: str | None = None
     user: UserResponse

--- a/services/api/app/auth/totp.py
+++ b/services/api/app/auth/totp.py
@@ -1,0 +1,176 @@
+"""TOTP (RFC 6238) two-factor authentication primitives.
+
+The shared secret is stored encrypted at rest. The encryption key is
+derived deterministically from ``settings.jwt_secret`` via HKDF-SHA256,
+so no additional secret has to be provisioned: rotating ``jwt_secret``
+invalidates both sessions and stored TOTP secrets together, which is the
+desired behaviour. The derived key never leaves this module.
+
+Recovery codes let an admin who loses their authenticator device regain
+access. They are generated once at enable time, shown to the user a
+single time, and persisted only as bcrypt hashes — the same one-way
+treatment as passwords.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import secrets
+
+import pyotp
+import qrcode
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.auth.utils import pwd_context
+from app.config import settings
+
+ISSUER = "Etornie"
+
+# Number of recovery codes minted at enable time.
+RECOVERY_CODE_COUNT = 10
+# Bytes of entropy per recovery code before base32 encoding.
+_RECOVERY_CODE_BYTES = 5
+
+# Accept codes from the adjacent 30s window on each side to tolerate
+# clock drift between the server and the authenticator app.
+_VALID_WINDOW = 1
+
+
+def _fernet() -> Fernet:
+    """Build a Fernet instance from a key derived off ``jwt_secret``."""
+
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=b"etornie.totp.secret.v1",
+        info=b"totp-secret-encryption",
+    )
+    raw = hkdf.derive(settings.jwt_secret.encode("utf-8"))
+    return Fernet(base64.urlsafe_b64encode(raw))
+
+
+def generate_secret() -> str:
+    """Return a fresh base32 TOTP secret."""
+
+    return pyotp.random_base32()
+
+
+def encrypt_secret(secret: str) -> str:
+    """Encrypt a base32 secret for storage."""
+
+    return _fernet().encrypt(secret.encode("utf-8")).decode("utf-8")
+
+
+def decrypt_secret(token: str) -> str:
+    """Decrypt a stored secret. Raises ``InvalidToken`` if tampered."""
+
+    return _fernet().decrypt(token.encode("utf-8")).decode("utf-8")
+
+
+def provisioning_uri(secret: str, account_name: str) -> str:
+    """Build the ``otpauth://`` URI an authenticator app consumes."""
+
+    return pyotp.TOTP(secret).provisioning_uri(
+        name=account_name,
+        issuer_name=ISSUER,
+    )
+
+
+def qr_data_url(uri: str) -> str:
+    """Render a provisioning URI to a base64 PNG ``data:`` URL."""
+
+    img = qrcode.make(uri)
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def verify_code(secret: str, code: str) -> bool:
+    """Validate a 6-digit TOTP code against the secret."""
+
+    cleaned = code.strip().replace(" ", "")
+    if not cleaned.isdigit():
+        return False
+    return pyotp.TOTP(secret).verify(cleaned, valid_window=_VALID_WINDOW)
+
+
+def generate_recovery_codes() -> list[str]:
+    """Return a fresh batch of human-friendly recovery codes."""
+
+    codes: list[str] = []
+    for _ in range(RECOVERY_CODE_COUNT):
+        raw = base64.b32encode(secrets.token_bytes(_RECOVERY_CODE_BYTES))
+        token = raw.decode("ascii").rstrip("=")
+        codes.append(f"{token[:4]}-{token[4:]}")
+    return codes
+
+
+def hash_recovery_codes(codes: list[str]) -> str:
+    """Hash a batch of recovery codes into a JSON-serialised store."""
+
+    hashes_ = [pwd_context.hash(_normalize_recovery(code)) for code in codes]
+    return json.dumps(hashes_)
+
+
+def _normalize_recovery(code: str) -> str:
+    return code.strip().upper().replace("-", "").replace(" ", "")
+
+
+def consume_recovery_code(stored: str | None, code: str) -> str | None:
+    """Verify a recovery code against the stored hashes.
+
+    Returns the updated JSON store (with the used hash removed) on a
+    match, or ``None`` if the code does not match any stored hash. The
+    caller persists the returned store so each recovery code is
+    single-use.
+    """
+
+    if not stored:
+        return None
+    try:
+        hashes_: list[str] = json.loads(stored)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    candidate = _normalize_recovery(code)
+    if not candidate:
+        return None
+
+    for index, hashed in enumerate(hashes_):
+        if pwd_context.verify(candidate, hashed):
+            remaining = hashes_[:index] + hashes_[index + 1 :]
+            return json.dumps(remaining)
+    return None
+
+
+def recovery_codes_remaining(stored: str | None) -> int:
+    """Count how many unused recovery codes remain."""
+
+    if not stored:
+        return 0
+    try:
+        return len(json.loads(stored))
+    except (json.JSONDecodeError, TypeError):
+        return 0
+
+
+__all__ = [
+    "ISSUER",
+    "RECOVERY_CODE_COUNT",
+    "InvalidToken",
+    "consume_recovery_code",
+    "decrypt_secret",
+    "encrypt_secret",
+    "generate_recovery_codes",
+    "generate_secret",
+    "hash_recovery_codes",
+    "provisioning_uri",
+    "qr_data_url",
+    "recovery_codes_remaining",
+    "verify_code",
+]

--- a/services/api/app/auth/totp_service.py
+++ b/services/api/app/auth/totp_service.py
@@ -1,0 +1,117 @@
+"""Persistence-side orchestration for TOTP two-factor authentication.
+
+Thin layer over :mod:`app.auth.totp` that mutates the ``User`` row:
+enroll (stash an encrypted pending secret), enable (verify possession and
+mint recovery codes), disable, and second-factor verification used by the
+login challenge. All functions ``flush`` so the caller's transaction sees
+the change; commit stays with the request-scoped session dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import totp
+from app.users.models import User
+
+
+class TotpError(Exception):
+    """Raised for invalid 2FA state transitions (bad code, not enrolled)."""
+
+
+@dataclass(frozen=True)
+class EnrollResult:
+    secret: str
+    otpauth_uri: str
+    qr_data_url: str
+
+
+async def begin_enrollment(db: AsyncSession, user: User) -> EnrollResult:
+    """Generate and stash a fresh secret without enabling 2FA yet.
+
+    Re-enrolling before enabling simply rotates the pending secret. If
+    2FA is already enabled, the caller must disable it first — we refuse
+    to silently overwrite a live secret.
+    """
+
+    if user.totp_enabled:
+        raise TotpError("Two-factor authentication is already enabled")
+
+    secret = totp.generate_secret()
+    user.totp_secret = totp.encrypt_secret(secret)
+    await db.flush()
+
+    account = user.email or user.public_handle or str(user.id)
+    uri = totp.provisioning_uri(secret, account)
+    return EnrollResult(
+        secret=secret,
+        otpauth_uri=uri,
+        qr_data_url=totp.qr_data_url(uri),
+    )
+
+
+async def enable(db: AsyncSession, user: User, code: str) -> list[str]:
+    """Verify the pending secret with ``code`` and turn 2FA on.
+
+    Returns the freshly minted plaintext recovery codes — shown to the
+    user exactly once; only their hashes are persisted.
+    """
+
+    if user.totp_enabled:
+        raise TotpError("Two-factor authentication is already enabled")
+    if not user.totp_secret:
+        raise TotpError("Start enrollment before enabling two-factor authentication")
+
+    secret = totp.decrypt_secret(user.totp_secret)
+    if not totp.verify_code(secret, code):
+        raise TotpError("Invalid authentication code")
+
+    recovery_codes = totp.generate_recovery_codes()
+    user.totp_recovery_codes = totp.hash_recovery_codes(recovery_codes)
+    user.totp_enabled = True
+    await db.flush()
+    return recovery_codes
+
+
+async def disable(db: AsyncSession, user: User, code: str) -> None:
+    """Turn 2FA off after proving possession (TOTP or recovery code)."""
+
+    if not user.totp_enabled:
+        raise TotpError("Two-factor authentication is not enabled")
+
+    if not await verify_second_factor(db, user, code):
+        raise TotpError("Invalid authentication code")
+
+    user.totp_enabled = False
+    user.totp_secret = None
+    user.totp_recovery_codes = None
+    await db.flush()
+
+
+async def verify_second_factor(db: AsyncSession, user: User, code: str) -> bool:
+    """Accept either a valid TOTP code or an unused recovery code.
+
+    A consumed recovery code is removed from the stored set so it cannot
+    be reused.
+    """
+
+    if not user.totp_enabled or not user.totp_secret:
+        return False
+
+    secret = totp.decrypt_secret(user.totp_secret)
+    if totp.verify_code(secret, code):
+        return True
+
+    updated = totp.consume_recovery_code(user.totp_recovery_codes, code)
+    if updated is not None:
+        user.totp_recovery_codes = updated
+        await db.flush()
+        return True
+
+    return False
+
+
+def recovery_codes_remaining(user: User) -> int:
+    return totp.recovery_codes_remaining(user.totp_recovery_codes)

--- a/services/api/app/auth/utils.py
+++ b/services/api/app/auth/utils.py
@@ -29,6 +29,24 @@ def create_access_token(subject: str, role: str) -> str:
     return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
 
 
+# A short-lived token issued after a correct password when the account
+# has 2FA enabled. It only authorises the second-factor step
+# (/auth/login/mfa) — it is NOT an access token and grants no API access.
+MFA_TOKEN_EXPIRE_MINUTES = 5
+
+
+def create_mfa_token(subject: str) -> str:
+    expire = datetime.now(timezone.utc) + timedelta(
+        minutes=MFA_TOKEN_EXPIRE_MINUTES
+    )
+    payload = {
+        "sub": subject,
+        "type": "mfa",
+        "exp": expire,
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+
 def create_refresh_token(subject: str) -> str:
     expire = datetime.now(timezone.utc) + timedelta(
         days=settings.refresh_token_expire_days

--- a/services/api/app/auth/wallet_router.py
+++ b/services/api/app/auth/wallet_router.py
@@ -14,7 +14,11 @@ from app.auth.schemas import (
     WalletVerifyResponse,
     UserResponse,
 )
-from app.auth.utils import create_access_token, create_refresh_token
+from app.auth.utils import (
+    create_access_token,
+    create_mfa_token,
+    create_refresh_token,
+)
 from app.auth.wallet_service import (
     AdminRoleForbidden,
     HandleGenerationFailed,
@@ -133,6 +137,17 @@ async def verify_wallet_signature(
             logger.warning("wallet guest case linking failed: %s", exc)
 
     subject = pick_jwt_subject(user)
+
+    if user.totp_enabled:
+        # 2FA-protected account: a valid signature is the first factor;
+        # hand back a challenge token instead of access tokens. The
+        # client completes the second factor at /auth/login/mfa.
+        return WalletVerifyResponse(
+            mfa_required=True,
+            mfa_token=create_mfa_token(subject),
+            user=UserResponse.model_validate(user),
+        )
+
     return WalletVerifyResponse(
         access_token=create_access_token(subject, user.role.value),
         refresh_token=create_refresh_token(subject),

--- a/services/api/app/users/models.py
+++ b/services/api/app/users/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     ForeignKey,
     LargeBinary,
     String,
+    Text,
     func,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -113,6 +114,18 @@ class User(Base):
         LargeBinary, nullable=True, deferred=True
     )
 
+    # Two-factor authentication (TOTP, RFC 6238). ``totp_secret`` holds
+    # the base32 shared secret encrypted at rest (see app/auth/totp.py);
+    # it is populated at enrollment and only honoured once
+    # ``totp_enabled`` flips true after the user proves possession with a
+    # valid code. ``totp_recovery_codes`` is a JSON array of bcrypt
+    # hashes — single-use fallbacks if the authenticator device is lost.
+    totp_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
+    totp_enabled: Mapped[bool] = mapped_column(
+        nullable=False, default=False, server_default="false"
+    )
+    totp_recovery_codes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
@@ -142,3 +155,14 @@ class User(Base):
         back_populates="uploaded_by_user",
         foreign_keys="Document.uploaded_by",
     )
+
+    @property
+    def mfa_setup_required(self) -> bool:
+        """Admins must hold 2FA; surface a setup nudge until they do.
+
+        Login still succeeds for an admin without 2FA (otherwise there
+        is no authenticated session in which to enroll) — the frontend
+        gates the rest of the app behind enrollment when this is true.
+        """
+
+        return self.role == UserRole.admin and not self.totp_enabled

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "openpyxl>=3.1.0",
     "stripe>=11.0.0",
     "sentry-sdk[fastapi]>=2.0.0",
+    "pyotp>=2.9.0",
+    "qrcode[pil]>=7.4.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Implements RFC 6238 **TOTP two-factor authentication** (Closes #56). 2FA is available to all users and surfaced as **required for admin accounts** (grace enrollment — login still succeeds so the admin can enroll, and the UI nudges them until they do).

Works for **both** sign-in methods:
- **Email + password** (`/auth/login`)
- **Solana wallet** (`/auth/wallet/verify`)

When 2FA is on, the first factor (password or wallet signature) returns an `mfa_required` challenge + a short-lived `mfa_token` instead of access tokens; the client completes the second factor at `/auth/login/mfa` with a TOTP code **or** a single-use recovery code.

## Backend (`services/api`)

- **`app/auth/totp.py`** — TOTP primitives. The shared secret is **encrypted at rest** with Fernet, whose key is derived from `jwt_secret` via HKDF-SHA256 (no new secret to provision; rotating `jwt_secret` invalidates stored secrets too). Provisioning URI, QR PNG (data URL), code verification (±1 window for clock drift), and **single-use, bcrypt-hashed recovery codes**.
- **`app/auth/totp_service.py`** — enroll / enable / disable / second-factor verification (accepts TOTP or an unused recovery code, which is then consumed).
- **`User` model** — `totp_secret` (encrypted), `totp_enabled`, `totp_recovery_codes`; migration **`c3f1a9b27e64`** (chains off `d4a5b6c7e8f9`). `mfa_setup_required` property drives the admin nudge.
- **Endpoints** — `GET /auth/2fa/status`, `POST /auth/2fa/{enroll,enable,disable}`, `POST /auth/login/mfa`. Login and wallet-verify responses gained optional token fields + `mfa_required`/`mfa_token`.
- **Deps** — `pyotp`, `qrcode[pil]`.

## Frontend (`dashboard`)

- **Login page** — second-factor code step after a correct password.
- **`WalletSignInButton`** — second-factor code step after a valid signature.
- **`TwoFactorSettings`** component on the **Profile** page — QR enrollment, enable, one-time recovery-code display, and disable.

## Verification

End-to-end against the running API (real TOTP codes via `pyotp`, real ed25519 wallet signatures via `solders`), temp accounts cleaned up afterwards:

**Email flow** — login (no 2FA) → enroll → enable (10 recovery codes) → login now returns `mfa_required` → wrong code `401` → correct TOTP issues tokens → recovery-code login works → reused recovery code `401` (single-use, 9 remain) → disable restores plain login. ✓

**Wallet flow** — new wallet login (no 2FA) → enable 2FA → wallet login now returns `mfa_required` (no tokens) → `/auth/login/mfa` with TOTP issues tokens → recovery code works → wrong code `401`. ✓

`tsc --noEmit` clean.

## Screenshots

**Profile — Two-Factor Authentication section / enabled state**

<img width="1391" height="207" alt="2fa" src="https://github.com/user-attachments/assets/607151cd-0ee1-4b1b-94e6-7b512d63f774" />

**Enrollment — scan QR + enter code**

<img width="1391" height="589" alt="qr" src="https://github.com/user-attachments/assets/7097efc9-0ada-4987-b757-aeb629781646" />

**Login — second-factor code step**

<img width="511" height="719" alt="login2fa" src="https://github.com/user-attachments/assets/e14cde57-253f-4eb8-a613-fc114fe02d4f" />

## Notes

- Local DB sat on feature-branch migrations not yet in `main` (`98ee72c0f678`), so `alembic upgrade` couldn't resolve that chain locally; the `totp_*` columns were applied with DDL identical to the migration's `upgrade()`. The migration file chains cleanly off `main`'s head and runs on a clean/main DB.
