### PR TITLE
feat(compliance): GDPR Article 17 right to erasure + retention policy (#61)

### DIFF
--- a/dashboard/src/app/dashboard/profile/page.tsx
+++ b/dashboard/src/app/dashboard/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import api, { extractErrorMessage } from "@/lib/api";
+import DataErasureSection from "@/components/DataErasureSection";
 
 interface MeUser {
   id: string;
@@ -776,6 +777,9 @@ export default function ProfilePage() {
           </ul>
         )}
       </section>
+
+      {/* Right to erasure (GDPR Article 17) — danger zone, kept last */}
+      <DataErasureSection authMethod={me.auth_method} />
     </div>
   );
 }

--- a/dashboard/src/components/DataErasureSection.tsx
+++ b/dashboard/src/components/DataErasureSection.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import api, { extractErrorMessage } from "@/lib/api";
+import { removeToken } from "@/lib/auth";
+
+interface BlockingCase {
+  id: string;
+  case_number: string | null;
+  title: string | null;
+  status: string;
+}
+
+interface ErasureSummary {
+  deleted_rows: Record<string, number>;
+  deleted_files: number;
+  retained_tables: string[];
+}
+
+interface DataErasureSectionProps {
+  /** Auth method of the current user — drives whether a password is required. */
+  authMethod: string;
+}
+
+const CONFIRM_PHRASE = "DELETE MY DATA";
+
+export default function DataErasureSection({ authMethod }: DataErasureSectionProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [phrase, setPhrase] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [blockers, setBlockers] = useState<BlockingCase[] | null>(null);
+  const [done, setDone] = useState<ErasureSummary | null>(null);
+
+  const needsPassword = authMethod !== "wallet";
+  const canSubmit =
+    phrase.trim().toUpperCase() === CONFIRM_PHRASE &&
+    (!needsPassword || password.length > 0) &&
+    !busy;
+
+  async function submit() {
+    setError(null);
+    setBlockers(null);
+    setBusy(true);
+    try {
+      const res = await api.post<ErasureSummary>("/users/me/erase", {
+        password: needsPassword ? password : null,
+      });
+      setDone(res.data);
+      // The account no longer exists in a usable form — drop tokens and
+      // send the user to the login page after they read the summary.
+      removeToken();
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response
+        ?.status;
+      const detail = (
+        err as { response?: { data?: { detail?: unknown } } }
+      )?.response?.data?.detail;
+      if (
+        status === 409 &&
+        detail &&
+        typeof detail === "object" &&
+        "blocking_cases" in detail
+      ) {
+        setBlockers(
+          (detail as { blocking_cases: BlockingCase[] }).blocking_cases
+        );
+      } else {
+        setError(extractErrorMessage(err, "Could not erase your data."));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (done) {
+    const total = Object.values(done.deleted_rows).reduce((a, b) => a + b, 0);
+    return (
+      <section className="rounded-xl border border-red-300 bg-red-50 p-6">
+        <h3 className="text-base font-semibold text-red-900">
+          Your data has been erased
+        </h3>
+        <p className="mt-2 text-sm text-red-800">
+          {total} record{total === 1 ? "" : "s"} and {done.deleted_files} file
+          {done.deleted_files === 1 ? "" : "s"} were deleted. Records kept under
+          legal-retention obligations (financial, on-chain, audit) were
+          anonymised. Your account is now closed.
+        </p>
+        <button
+          type="button"
+          onClick={() => router.replace("/login")}
+          className="rwa-btn-primary mt-4"
+        >
+          Return to sign in
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border border-red-300 bg-white p-6">
+      <h3 className="text-base font-semibold text-red-900">
+        Erase my data (GDPR Article 17)
+      </h3>
+      <p className="mt-2 text-sm text-[color:var(--color-muted)]">
+        Permanently delete your personal data and close your account. This is
+        irreversible. Records we are legally required to keep (payment/financial
+        records, on-chain attestations, audit logs) are anonymised rather than
+        deleted. You cannot erase your data while you have cases in active legal
+        proceedings.
+      </p>
+
+      {blockers && (
+        <div className="mt-4 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+          <p className="font-semibold">
+            Erasure is blocked by {blockers.length} active case
+            {blockers.length === 1 ? "" : "s"}:
+          </p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {blockers.map((c) => (
+              <li key={c.id}>
+                {c.case_number ? `${c.case_number} — ` : ""}
+                {c.title ?? "Untitled case"}{" "}
+                <span className="text-amber-700">({c.status})</span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-2">
+            These must be closed before your data can be erased.
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-4 rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800"
+        >
+          {error}
+        </div>
+      )}
+
+      {!open ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="mt-4 rounded-lg border border-red-400 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50"
+        >
+          Erase my data…
+        </button>
+      ) : (
+        <div className="mt-4 space-y-3">
+          <div>
+            <label
+              htmlFor="erase-phrase"
+              className="block text-xs font-semibold uppercase tracking-wider text-[color:var(--color-muted)]"
+            >
+              Type <span className="font-mono text-red-700">{CONFIRM_PHRASE}</span> to confirm
+            </label>
+            <input
+              id="erase-phrase"
+              type="text"
+              autoComplete="off"
+              value={phrase}
+              onChange={(e) => setPhrase(e.target.value)}
+              className="rwa-input mt-1.5 w-full"
+              placeholder={CONFIRM_PHRASE}
+            />
+          </div>
+
+          {needsPassword && (
+            <div>
+              <label
+                htmlFor="erase-password"
+                className="block text-xs font-semibold uppercase tracking-wider text-[color:var(--color-muted)]"
+              >
+                Confirm your password
+              </label>
+              <input
+                id="erase-password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="rwa-input mt-1.5 w-full"
+                placeholder="••••••••"
+              />
+            </div>
+          )}
+
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={!canSubmit}
+              onClick={submit}
+              className="rounded-lg border border-red-500 bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy ? "Erasing…" : "Permanently erase my data"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                setPhrase("");
+                setPassword("");
+                setError(null);
+              }}
+              className="rounded-lg border border-[color:var(--color-stone)] px-4 py-2 text-sm font-semibold text-[color:var(--color-muted)] hover:bg-[color:var(--color-sand)]"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/docs/compliance/data-retention-and-erasure.md
+++ b/docs/compliance/data-retention-and-erasure.md
@@ -1,0 +1,110 @@
+# Data Retention & Right to Erasure (GDPR Article 17)
+
+This document is the human-readable companion to the code in
+`services/api/app/compliance/retention.py` (policy) and
+`erasure.py` (execution). It is intended for legal review
+(this is a `needs-lawyer` deliverable). The code is the source of
+truth; this page explains the reasoning.
+
+## Scope
+
+A data subject (or an admin on their behalf) can request erasure of
+their personal data. Etornie processes the request by **anonymising the
+subject's account and selectively deleting personal data**, while
+**retaining records covered by a GDPR Art. 17(3) exception**.
+
+Erasure is **irreversible**.
+
+## Erasure blockers — active legal proceedings (Art. 17(3)(e))
+
+Erasure is **refused** while the subject has any case in an active
+legal proceeding. A case is "active" when its status is one of:
+
+- `open`
+- `in_progress`
+- `under_review`
+
+(`closed` is the only non-blocking status.)
+
+The API returns **HTTP 409** with the list of blocking cases. The
+subject can re-request erasure once those cases are closed. This
+implements Art. 17(3)(e) — retention for the establishment, exercise,
+or defence of legal claims.
+
+## What is deleted vs retained
+
+Every user-scoped table in the Article-20 data export
+(`app/compliance/data_export.py`) is classified. The two modules are
+kept in lock-step.
+
+### Deleted (physical removal, including on-disk files)
+
+Pure personal data with no overriding retention basis:
+
+| Data | Reason |
+|------|--------|
+| EtornieGPT chat messages | Conversational personal data |
+| AI agent messages | Assistant conversation content |
+| Agent uploads (+ files on disk) | User working files |
+| Case notes authored by the subject | Free-text personal data |
+| In-app notifications | Delivered to the subject |
+| Notifications created by the subject | — |
+| Proposals authored by the subject | — |
+| BRAID calibration feedback | Tied to the subject |
+| Organisation memberships | Severs org links |
+
+The subject's avatar bytes (in-DB) and any legacy avatar file on disk
+are also removed.
+
+### Anonymised (the subject's `users` row)
+
+The row is **tombstoned**: `email`, `full_name`, `phone`,
+`wallet_address`, `public_handle`, `notification_email`, and avatar
+fields are overwritten; `is_active` is set to `false`; `erased_at` and
+`erasure_reason` are stamped.
+
+To satisfy the `ck_users_authenticatable` CHECK constraint without
+storing personal data, `email` becomes a synthetic
+`erased-<uuid>@deleted.etornie.invalid` and the password is replaced
+with a fresh, unknowable random hash. The account can never
+authenticate (it is also deactivated).
+
+Every retained row keeps pointing at this anonymised user id, so no
+identifying data survives in them.
+
+### Retained (Art. 17(3) exception)
+
+| Data | Basis |
+|------|-------|
+| Payment intents | **Financial record** — statutory retention (CH CO 958f / EU VAT, ~10 years) |
+| Case drafts, filing attempts | Backing financial / official IP-office filing records |
+| Cases, case events | IP legal records, frequently **on-chain attested** (immutable) |
+| Documents | Evidence attached to retained IP cases (Art. 17(3)(e)) |
+| Audit logs | Security/compliance audit trail — legal obligation |
+| Organisation invites | Invite history retained; the subject's FKs are nulled |
+
+> **On-chain data.** Solana attestations, NFT mints and compliance
+> records are immutable and cannot be deleted. Erasure removes the
+> off-chain personal data that links a human to those records; the
+> on-chain artefacts themselves remain by design.
+
+## Triggers
+
+- **Self-service** — `POST /users/me/erase`. Accounts with a password
+  must re-authenticate (password in the request body); wallet-only
+  accounts confirm via the typed confirmation in the UI. The subject
+  can only erase themselves.
+- **Admin** — `POST /users/{user_id}/erase` with a `reason`. For
+  processing GDPR requests received out-of-band.
+
+Both paths run the identical retention policy and return a summary of
+deleted-row counts, deleted files, and retained tables, or a 409 with
+blocking cases.
+
+## Open items for legal review
+
+- Confirm the financial-record retention period and jurisdiction basis
+  (currently documented as CH CO 958f / EU VAT ~10y).
+- Confirm whether documents attached to **closed** cases should be
+  deleted or retained (currently retained as case evidence).
+- Confirm the active-proceeding status set is complete.

--- a/services/api/alembic/versions/e7b2d4f1a9c3_add_user_erasure_columns.py
+++ b/services/api/alembic/versions/e7b2d4f1a9c3_add_user_erasure_columns.py
@@ -1,0 +1,33 @@
+"""add GDPR erasure tombstone columns to users
+
+Adds ``erased_at`` (set when the user row has been anonymised under
+GDPR Article 17) and ``erasure_reason`` (audit note of who/why).
+
+Revision ID: e7b2d4f1a9c3
+Revises: d4a5b6c7e8f9
+Create Date: 2026-06-06
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "e7b2d4f1a9c3"
+down_revision = "d4a5b6c7e8f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("erased_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("erasure_reason", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "erasure_reason")
+    op.drop_column("users", "erased_at")

--- a/services/api/alembic/versions/e7b2d4f1a9c3_add_user_erasure_columns.py
+++ b/services/api/alembic/versions/e7b2d4f1a9c3_add_user_erasure_columns.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "e7b2d4f1a9c3"
-down_revision = "d4a5b6c7e8f9"
+down_revision = "c3f1a9b27e64"
 branch_labels = None
 depends_on = None
 

--- a/services/api/app/compliance/erasure.py
+++ b/services/api/app/compliance/erasure.py
@@ -1,0 +1,205 @@
+"""GDPR Article 17 right-to-erasure execution.
+
+Applies the disposition declared in :mod:`app.compliance.retention`:
+
+1. Refuse if the subject has a case in an active legal proceeding
+   (Art. 17(3)(e)) — the caller gets the blocking cases back.
+2. Physically delete the ``DELETE`` tables (and any backing files on
+   disk).
+3. Tombstone the ``users`` row so every ``RETAIN`` row that still
+   references the user id becomes pseudonymous, and null the invite FKs.
+
+Everything runs on the caller's session inside one transaction; the
+request-scoped session dependency commits. The function is idempotent:
+erasing an already-erased user is a no-op that returns a zero summary.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agent.models import AgentMessage, AgentSession, AgentUpload
+from app.auth.utils import hash_password
+from app.braid.models import BraidCalibrationEvent
+from app.cases.models import Case, CaseNote
+from app.compliance import retention
+from app.config import settings
+from app.etorniegpt.models import ChatMessage
+from app.in_app_notifications.models import InAppNotification
+from app.notifications.models import Notification
+from app.organizations.models import OrganizationInvite, OrganizationMembership
+from app.proposals.models import Proposal
+from app.users.models import User
+
+logger = logging.getLogger(__name__)
+
+
+class ErasureBlocked(Exception):
+    """Raised when active legal proceedings forbid erasure."""
+
+    def __init__(self, blockers: list[Case]) -> None:
+        self.blockers = blockers
+        super().__init__(
+            f"{len(blockers)} active case(s) block erasure"
+        )
+
+
+@dataclass
+class ErasureSummary:
+    user_id: uuid.UUID
+    erased_at: datetime
+    deleted_rows: dict[str, int] = field(default_factory=dict)
+    deleted_files: int = 0
+    retained_tables: list[str] = field(default_factory=list)
+    anonymised: bool = False
+
+
+async def _delete_count(db: AsyncSession, stmt) -> int:
+    result = await db.execute(stmt)
+    return int(result.rowcount or 0)
+
+
+def _remove_file(raw_path: str) -> bool:
+    """Best-effort unlink of an on-disk file. Returns True if removed."""
+
+    candidates = [Path(raw_path)]
+    if not Path(raw_path).is_absolute():
+        candidates.append(Path(settings.upload_dir) / raw_path)
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                candidate.unlink()
+                return True
+        except OSError as exc:  # pragma: no cover - filesystem edge
+            logger.warning("erasure: could not unlink %s: %s", candidate, exc)
+    return False
+
+
+async def erase_user(
+    db: AsyncSession,
+    user: User,
+    *,
+    reason: str,
+) -> ErasureSummary:
+    """Execute Article-17 erasure for ``user``.
+
+    Raises :class:`ErasureBlocked` if an active proceeding forbids it.
+    """
+
+    if user.erased_at is not None:
+        # Idempotent: already a tombstone.
+        return ErasureSummary(
+            user_id=user.id,
+            erased_at=user.erased_at,
+            anonymised=True,
+        )
+
+    blockers = await retention.find_erasure_blockers(db, user.id)
+    if blockers:
+        raise ErasureBlocked(blockers)
+
+    uid = user.id
+    summary = ErasureSummary(
+        user_id=uid, erased_at=datetime.now(timezone.utc)
+    )
+
+    # --- delete on-disk files before their rows -------------------------
+    upload_paths = (
+        await db.execute(
+            select(AgentUpload.stored_path).where(AgentUpload.user_id == uid)
+        )
+    ).scalars().all()
+    for path in upload_paths:
+        if path and _remove_file(path):
+            summary.deleted_files += 1
+    if user.avatar_path and _remove_file(user.avatar_path):
+        summary.deleted_files += 1
+
+    # --- DELETE tables (pure PII, no retention basis) -------------------
+    # agent_messages reached via the subject's sessions; the session
+    # shells stay so the draft → payment chain is never cascade-deleted.
+    user_session_ids = select(AgentSession.id).where(
+        AgentSession.user_id == uid
+    )
+    summary.deleted_rows["agent_messages"] = await _delete_count(
+        db,
+        delete(AgentMessage).where(
+            AgentMessage.session_id.in_(user_session_ids)
+        ),
+    )
+    summary.deleted_rows["agent_uploads"] = await _delete_count(
+        db, delete(AgentUpload).where(AgentUpload.user_id == uid)
+    )
+    summary.deleted_rows["etorniegpt_chat_messages"] = await _delete_count(
+        db, delete(ChatMessage).where(ChatMessage.user_id == uid)
+    )
+    summary.deleted_rows["case_notes"] = await _delete_count(
+        db, delete(CaseNote).where(CaseNote.author_id == uid)
+    )
+    summary.deleted_rows["in_app_notifications"] = await _delete_count(
+        db,
+        delete(InAppNotification).where(
+            InAppNotification.recipient_id == uid
+        ),
+    )
+    summary.deleted_rows["notifications"] = await _delete_count(
+        db, delete(Notification).where(Notification.created_by == uid)
+    )
+    summary.deleted_rows["proposals"] = await _delete_count(
+        db, delete(Proposal).where(Proposal.created_by == uid)
+    )
+    summary.deleted_rows["braid_feedback_events"] = await _delete_count(
+        db,
+        delete(BraidCalibrationEvent).where(
+            BraidCalibrationEvent.feedback_user_id == uid
+        ),
+    )
+    summary.deleted_rows["organization_memberships"] = await _delete_count(
+        db,
+        delete(OrganizationMembership).where(
+            OrganizationMembership.user_id == uid
+        ),
+    )
+
+    # --- RETAIN with subject FKs nulled (invite history) ----------------
+    await db.execute(
+        update(OrganizationInvite)
+        .where(OrganizationInvite.invited_by_user_id == uid)
+        .values(invited_by_user_id=None)
+    )
+    await db.execute(
+        update(OrganizationInvite)
+        .where(OrganizationInvite.accepted_by_user_id == uid)
+        .values(accepted_by_user_id=None)
+    )
+
+    # --- ANONYMISE the subject row (tombstone) --------------------------
+    for column, value in retention.user_tombstone(uid).items():
+        setattr(user, column, value)
+    # Locked, unknowable password so the row stays authenticatable by the
+    # CHECK constraint yet can never be used to sign in.
+    user.hashed_password = hash_password(secrets.token_urlsafe(32))
+    user.erased_at = summary.erased_at
+    user.erasure_reason = reason
+    summary.anonymised = True
+
+    summary.retained_tables = [
+        p.name
+        for p in retention.policies_by_disposition(retention.Disposition.retain)
+    ]
+
+    await db.flush()
+    logger.info(
+        "GDPR erasure complete for user %s: deleted=%s files=%d",
+        uid,
+        summary.deleted_rows,
+        summary.deleted_files,
+    )
+    return summary

--- a/services/api/app/compliance/retention.py
+++ b/services/api/app/compliance/retention.py
@@ -1,0 +1,188 @@
+"""GDPR Article 17 data-retention & erasure policy.
+
+This module is the single, declarative source of truth for **what
+happens to each user-scoped table when a data subject is erased**. It is
+deliberately data, not logic, so a reviewing lawyer (this issue is
+``needs-lawyer``) can read the classification without reading the
+execution code in :mod:`app.compliance.erasure`.
+
+The inventory mirrors :mod:`app.compliance.data_export` (the Article-20
+export), which documents itself as "the one place to extend when a new
+user-scoped table is added". Every table exported there is classified
+here, so the two stay in lock-step.
+
+Three dispositions
+------------------
+* **DELETE** — pure personal data with no overriding retention basis;
+  rows are physically removed (and any backing files on disk deleted).
+* **ANONYMISE** — the subject's ``users`` row itself: identifying columns
+  are overwritten with a tombstone so every retained row that still
+  references the user id becomes pseudonymous.
+* **RETAIN** — rows kept under a GDPR Art. 17(3) exception (legal
+  obligation, or establishment/exercise/defence of legal claims). They
+  keep pointing at the now-anonymised user id, so no identifying data
+  survives in them.
+
+Erasure is **blocked** while the subject has a case in an active legal
+proceeding (Art. 17(3)(e)); see :data:`ERASURE_BLOCKING_STATUSES`.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cases.models import Case, CaseStatus
+
+
+class Disposition(str, Enum):
+    delete = "delete"
+    anonymise = "anonymise"
+    retain = "retain"
+
+
+@dataclass(frozen=True)
+class TablePolicy:
+    """How one user-scoped table is treated on erasure."""
+
+    name: str
+    disposition: Disposition
+    # Human-readable basis — surfaced in the retention doc & API summary.
+    reason: str
+
+
+# Cases in any of these statuses mean an active legal proceeding, so the
+# whole erasure request is refused under GDPR Art. 17(3)(e) until they
+# close. ``closed`` is the only non-blocking status.
+ERASURE_BLOCKING_STATUSES: frozenset[CaseStatus] = frozenset(
+    {CaseStatus.open, CaseStatus.in_progress, CaseStatus.under_review}
+)
+
+
+# Tombstone written over the ``users`` row. The synthetic email + a
+# locked (unknowable) password keep the ``ck_users_authenticatable``
+# CHECK satisfied while carrying no real personal data — the local-part
+# is just the internal UUID, which is the primary key, not PII. The
+# account is also deactivated, so it can never authenticate regardless.
+#
+# ``avatar_data`` (deferred LargeBinary) is set to None too; assigning
+# does not trigger a lazy load.
+def user_tombstone(user_id: uuid.UUID) -> dict[str, object]:
+    return {
+        "email": f"erased-{user_id}@deleted.etornie.invalid",
+        "full_name": "Erased user",
+        "phone": None,
+        "wallet_address": None,
+        "public_handle": None,
+        "notification_email": None,
+        "email_notifications_enabled": False,
+        "avatar_path": None,
+        "avatar_mime": None,
+        "avatar_data": None,
+        "default_organization_id": None,
+        "is_active": False,
+    }
+
+
+# Full classification of every user-scoped table from the Art-20 export.
+# Keyed by the export's collection name so the mapping is auditable
+# side-by-side with data_export.build_user_export.
+TABLE_POLICIES: tuple[TablePolicy, ...] = (
+    TablePolicy("profile", Disposition.anonymise, "Subject row — tombstoned"),
+    # --- deleted: conversational / notification / ancillary PII --------
+    TablePolicy(
+        "etorniegpt_chat_messages", Disposition.delete,
+        "Conversational personal data; no retention basis",
+    ),
+    TablePolicy(
+        "agent_messages", Disposition.delete,
+        "AI assistant conversation content; no retention basis",
+    ),
+    TablePolicy(
+        "agent_uploads", Disposition.delete,
+        "User-uploaded working files (+ on-disk bytes); no retention basis",
+    ),
+    TablePolicy(
+        "case_notes", Disposition.delete,
+        "Free-text notes authored by the subject; no retention basis",
+    ),
+    TablePolicy(
+        "in_app_notifications", Disposition.delete,
+        "Delivered notifications addressed to the subject",
+    ),
+    TablePolicy(
+        "notifications", Disposition.delete,
+        "Notifications created by the subject",
+    ),
+    TablePolicy(
+        "proposals", Disposition.delete,
+        "Proposals authored by the subject; no retention basis",
+    ),
+    TablePolicy(
+        "braid_feedback_events", Disposition.delete,
+        "Model-calibration feedback tied to the subject",
+    ),
+    TablePolicy(
+        "organization_memberships", Disposition.delete,
+        "Severs the subject's organisation links",
+    ),
+    # --- retained: legal-claim / financial / on-chain / audit basis ----
+    TablePolicy(
+        "organization_invites", Disposition.retain,
+        "Invite history retained; subject FKs nulled (SET NULL)",
+    ),
+    TablePolicy(
+        "cases", Disposition.retain,
+        "IP legal records, often on-chain attested (Art. 17(3)(b)/(e))",
+    ),
+    TablePolicy(
+        "case_events", Disposition.retain,
+        "Immutable case audit trail tied to retained cases",
+    ),
+    TablePolicy(
+        "agent_sessions", Disposition.retain,
+        "Session shells retained (messages deleted) to preserve the "
+        "draft → payment chain; no identifying data remains",
+    ),
+    TablePolicy(
+        "case_drafts", Disposition.retain,
+        "Filing drafts backing financial/filing records",
+    ),
+    TablePolicy(
+        "filing_attempts", Disposition.retain,
+        "Official IP-office filing record",
+    ),
+    TablePolicy(
+        "payment_intents", Disposition.retain,
+        "Financial record — statutory retention (CH CO 958f / EU VAT, ~10y)",
+    ),
+    TablePolicy(
+        "documents", Disposition.retain,
+        "Evidence attached to retained IP cases (Art. 17(3)(e))",
+    ),
+    TablePolicy(
+        "audit_logs", Disposition.retain,
+        "Security/compliance audit trail — legal obligation",
+    ),
+)
+
+
+def policies_by_disposition(disposition: Disposition) -> list[TablePolicy]:
+    return [p for p in TABLE_POLICIES if p.disposition is disposition]
+
+
+async def find_erasure_blockers(
+    db: AsyncSession, user_id: uuid.UUID
+) -> list[Case]:
+    """Return the subject's cases that block erasure (active proceedings)."""
+
+    rows = await db.execute(
+        select(Case).where(
+            Case.client_id == user_id,
+            Case.status.in_(ERASURE_BLOCKING_STATUSES),
+        )
+    )
+    return list(rows.scalars().all())

--- a/services/api/app/users/models.py
+++ b/services/api/app/users/models.py
@@ -125,6 +125,15 @@ class User(Base):
         nullable=False,
     )
 
+    # GDPR Article 17 erasure tombstone. When ``erased_at`` is set, the
+    # identifying columns above have been overwritten (see
+    # app/compliance/retention.user_tombstone) and the account is
+    # deactivated; ``erasure_reason`` records who/why for the audit trail.
+    erased_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    erasure_reason: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
     # Relationships
     client_cases: Mapped[list["Case"]] = relationship(  # noqa: F821
         back_populates="client",

--- a/services/api/app/users/router.py
+++ b/services/api/app/users/router.py
@@ -16,14 +16,24 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.dependencies import get_current_user, require_role
+from app.auth.utils import verify_password
 from app.cases.models import Case
 from app.compliance.data_export import build_user_export
+from app.compliance.erasure import ErasureBlocked, erase_user
 from app.config import settings
 from app.database import get_db
 from app.security.virus_scan import scan_upload
 from app.services.ukipo.models import UKIPOSubmission
 from app.users.models import User, UserRole
-from app.users.schemas import UserListResponse, UserResponse, UserUpdate
+from app.users.schemas import (
+    AdminErasureRequest,
+    ErasureBlockingCase,
+    ErasureRequest,
+    ErasureSummaryResponse,
+    UserListResponse,
+    UserResponse,
+    UserUpdate,
+)
 from app.users.service import get_user, list_users, soft_delete_user, update_user
 
 router = APIRouter(prefix="/users", tags=["users"])
@@ -297,6 +307,55 @@ async def export_my_data(
     )
 
 
+def _erasure_blocked_http(exc: ErasureBlocked) -> HTTPException:
+    """Build a 409 carrying the active cases that block erasure."""
+
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "message": (
+                "Erasure is blocked while you have cases in active legal "
+                "proceedings (GDPR Art. 17(3)(e)). They must be closed first."
+            ),
+            "blocking_cases": [
+                ErasureBlockingCase.model_validate(c).model_dump(mode="json")
+                for c in exc.blockers
+            ],
+        },
+    )
+
+
+@router.post("/me/erase", response_model=ErasureSummaryResponse)
+async def erase_my_data(
+    data: ErasureRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ErasureSummaryResponse:
+    """Erase the authenticated user's personal data (GDPR Art. 17).
+
+    Irreversible. Accounts with a password must re-authenticate; the
+    request is refused with 409 + the blocking cases if the subject has
+    an active legal proceeding.
+    """
+    if current_user.hashed_password:
+        if not data.password or not verify_password(
+            data.password, current_user.hashed_password
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Password confirmation is required to erase your data.",
+            )
+
+    try:
+        summary = await erase_user(
+            db, current_user, reason="self-service erasure request"
+        )
+    except ErasureBlocked as exc:
+        raise _erasure_blocked_http(exc)
+
+    return ErasureSummaryResponse(**vars(summary))
+
+
 @router.get("", response_model=UserListResponse)
 async def list_users_endpoint(
     skip: int = Query(0, ge=0),
@@ -389,3 +448,32 @@ async def delete_user_endpoint(
 
     user = await soft_delete_user(db, user)
     return user
+
+
+@router.post("/{user_id}/erase", response_model=ErasureSummaryResponse)
+async def erase_user_endpoint(
+    user_id: uuid.UUID,
+    data: AdminErasureRequest,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_role(UserRole.admin)),
+) -> ErasureSummaryResponse:
+    """Erase a user's personal data on their behalf (admin, GDPR Art. 17).
+
+    Refused with 409 + the blocking cases if the subject has an active
+    legal proceeding.
+    """
+    user = await get_user(db, user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    try:
+        summary = await erase_user(
+            db, user, reason=f"admin erasure: {data.reason}"
+        )
+    except ErasureBlocked as exc:
+        raise _erasure_blocked_http(exc)
+
+    return ErasureSummaryResponse(**vars(summary))

--- a/services/api/app/users/schemas.py
+++ b/services/api/app/users/schemas.py
@@ -53,3 +53,36 @@ class UserUpdate(BaseModel):
 class UserListResponse(BaseModel):
     users: list[UserResponse]
     total: int
+
+
+class ErasureRequest(BaseModel):
+    """Self-service GDPR erasure confirmation.
+
+    The frontend gates this behind a typed confirmation; ``password`` is
+    required for accounts that have one (re-authentication for an
+    irreversible action) and ignored for wallet-only accounts.
+    """
+
+    password: str | None = None
+
+
+class AdminErasureRequest(BaseModel):
+    reason: str = Field(min_length=1, max_length=255)
+
+
+class ErasureBlockingCase(BaseModel):
+    id: uuid.UUID
+    case_number: str | None = None
+    title: str | None = None
+    status: str
+
+    model_config = {"from_attributes": True}
+
+
+class ErasureSummaryResponse(BaseModel):
+    user_id: uuid.UUID
+    erased_at: datetime
+    anonymised: bool
+    deleted_rows: dict[str, int]
+    deleted_files: int
+    retained_tables: list[str]


### PR DESCRIPTION
## Summary

Implements the **GDPR Article 17 right to erasure** with a documented
retention policy (Closes #61). A data subject (self-service) or an admin
can erase a user's personal data; the implementation balances Article 17
against the **Art. 17(3) retention exceptions** (legal claims, legal
obligations, immutable on-chain records).

This issue is `needs-lawyer` — the policy is declarative and documented
in `docs/compliance/data-retention-and-erasure.md` for review.

## Mechanism — anonymise + selective delete

**Blocked while a legal proceeding is active (Art. 17(3)(e)).** If the
subject has a case in `open` / `in_progress` / `under_review`, erasure
is refused with **HTTP 409** and the list of blocking cases. Only
`closed` is non-blocking.

**Deleted** (pure PII, physical removal incl. on-disk files): EtornieGPT
chat, AI agent messages, agent uploads, case notes, in-app + outbound
notifications, proposals, BRAID feedback, organisation memberships, and
the avatar.

**Anonymised** — the `users` row is tombstoned: `email`, `full_name`,
`phone`, `wallet_address`, `public_handle`, `notification_email` and
avatar fields scrubbed; password replaced with an unknowable random
hash; `is_active=false`; `erased_at` / `erasure_reason` stamped. A
synthetic `erased-<uuid>@deleted.etornie.invalid` email keeps the
`ck_users_authenticatable` CHECK satisfied without storing PII. Every
retained row keeps pointing at this anonymised id, so no identifying
data survives.

**Retained** under Art. 17(3): payment intents (financial — statutory
~10y), case drafts / filing attempts, cases + events (often on-chain
attested), documents (case evidence), audit logs. Solana attestations /
NFT mints are immutable and remain on-chain by design; only the
off-chain link to the human is erased.

The `AgentSession → CaseDraft → PaymentIntent` cascade chain is
preserved by deleting only `AgentMessage` rows (the conversation
content), never the session shells.

## Backend (`services/api`)

- `app/compliance/retention.py` — declarative policy: blocking statuses,
  per-table disposition kept in lock-step with the Art-20 export
  inventory, the tombstone map, `find_erasure_blockers`.
- `app/compliance/erasure.py` — `erase_user` execution + summary.
- `User.erased_at` + `erasure_reason`; migration `e7b2d4f1a9c3`.
- `POST /users/me/erase` (password re-auth for password accounts) and
  `POST /users/{id}/erase` (admin, with reason); both return a summary
  or 409 + `blocking_cases`.
- `docs/compliance/data-retention-and-erasure.md`.

## Frontend (`dashboard`)

- `DataErasureSection` on the **Profile** page (danger zone, kept last):
  typed `DELETE MY DATA` confirmation + password, blocking-case display,
  post-erase summary then sign-out.

## Verification

Real Postgres + the running API, temp accounts cleaned up:

- **Service e2e** — deletes (chat / notes / agent messages) → 0;
  retained (cases / sessions / payments) survive; tombstone correct
  (email/name/phone/wallet/handle scrubbed, deactivated, `erased_at`
  set); idempotent re-erase is a no-op; active case raises the blocker. ✓
- **HTTP e2e** — wrong password → 401; active case → 409 with
  `blocking_cases`; closed case → 200 with retained tables incl.
  `payment_intents`; erased account → `/auth/me` 401 (deactivated). ✓
- `tsc --noEmit` clean.

## Screenshots

**Erasure blocked by active cases (Art. 17(3)(e))**

<img width="1400" height="816" alt="activeCases" src="https://github.com/user-attachments/assets/2e6a433a-7b7b-4996-b8f2-4d481b1d3b74" />

**Erase my data — danger zone confirmation**

<img width="1404" height="294" alt="delete" src="https://github.com/user-attachments/assets/900c0c89-aac6-4bc7-9284-c5798e99333a" />

## Notes

- Local DB sat on feature-branch migrations not yet in `main`
  (`98ee72c0f678`), so the `erased_at`/`erasure_reason` columns were
  applied with DDL identical to the migration's `upgrade()`. The
  migration chains cleanly off `main`'s head (`d4a5b6c7e8f9`) and runs on
  a clean/main DB.
- Open items flagged for legal review at the bottom of the retention doc
  (financial retention period/basis, documents on closed cases, the
  active-status set).
