### PR TITLE
feat(calendar): ICS subscription feed for case deadlines + renewals (#64)

### DIFF
--- a/dashboard/src/app/dashboard/profile/page.tsx
+++ b/dashboard/src/app/dashboard/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import api, { extractErrorMessage } from "@/lib/api";
+import CalendarSyncSection from "@/components/CalendarSyncSection";
 
 interface MeUser {
   id: string;
@@ -597,6 +598,9 @@ export default function ProfilePage() {
           )}
         </div>
       </section>
+
+      {/* Calendar (ICS) subscription feed */}
+      <CalendarSyncSection />
 
       {/* Filings timeline */}
       <section>

--- a/dashboard/src/components/CalendarSyncSection.tsx
+++ b/dashboard/src/components/CalendarSyncSection.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import api, { extractErrorMessage } from "@/lib/api";
+
+interface FeedStatus {
+  enabled: boolean;
+  url: string | null;
+}
+
+export default function CalendarSyncSection() {
+  const [status, setStatus] = useState<FeedStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await api.get<FeedStatus>("/calendar/feed");
+      setStatus(res.data);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Could not load calendar settings."));
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function enable() {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await api.post<FeedStatus>("/calendar/feed");
+      setStatus(res.data);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Could not enable the calendar feed."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function rotate() {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await api.post<FeedStatus>("/calendar/feed/rotate");
+      setStatus(res.data);
+      setCopied(false);
+    } catch (err) {
+      setError(extractErrorMessage(err, "Could not regenerate the link."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function disable() {
+    setError(null);
+    setBusy(true);
+    try {
+      await api.delete("/calendar/feed");
+      setStatus({ enabled: false, url: null });
+    } catch (err) {
+      setError(extractErrorMessage(err, "Could not disable the calendar feed."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copy() {
+    if (!status?.url) return;
+    try {
+      await navigator.clipboard.writeText(status.url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError("Could not copy. Select the link and copy it manually.");
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-[color:var(--color-stone)] bg-white p-6">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-semibold text-[color:var(--color-ink)]">
+            Calendar sync
+          </h3>
+          {status?.enabled ? (
+            <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-semibold text-green-800">
+              Enabled
+            </span>
+          ) : (
+            <span className="rounded-full bg-[color:var(--color-sand)] px-2.5 py-0.5 text-xs font-semibold text-[color:var(--color-muted)]">
+              Disabled
+            </span>
+          )}
+        </div>
+
+        <p className="text-sm text-[color:var(--color-muted)]">
+          Subscribe to a private calendar feed so your IP case deadlines and
+          renewal dates show up automatically in Google Calendar, Outlook, or
+          Apple Calendar. The link is read-only and private to you.
+        </p>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-800"
+          >
+            {error}
+          </div>
+        )}
+
+        {status?.enabled && status.url ? (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <input
+                readOnly
+                value={status.url}
+                onFocus={(e) => e.currentTarget.select()}
+                className="rwa-input w-full font-mono text-xs"
+                aria-label="Calendar feed URL"
+              />
+              <button
+                type="button"
+                onClick={copy}
+                className="shrink-0 rounded-lg border border-[color:var(--color-stone)] px-3 py-2 text-sm font-semibold text-[color:var(--color-ink)] hover:bg-[color:var(--color-sand)]"
+              >
+                {copied ? "Copied" : "Copy"}
+              </button>
+            </div>
+
+            <details className="rounded-lg border border-[color:var(--color-stone)] bg-[color:var(--color-elevated)] p-3 text-sm text-[color:var(--color-ink)]">
+              <summary className="cursor-pointer font-medium text-[color:var(--color-muted)]">
+                How to subscribe
+              </summary>
+              <ul className="mt-2 list-disc space-y-1 pl-5 text-[color:var(--color-muted)]">
+                <li>
+                  <strong>Google Calendar:</strong> Other calendars → From URL →
+                  paste the link.
+                </li>
+                <li>
+                  <strong>Outlook:</strong> Add calendar → Subscribe from web →
+                  paste the link.
+                </li>
+                <li>
+                  <strong>Apple Calendar:</strong> File → New Calendar
+                  Subscription → paste the link.
+                </li>
+              </ul>
+              <p className="mt-2 text-xs text-[color:var(--color-muted)]">
+                Calendar apps refresh subscribed feeds periodically (often
+                hourly), so new deadlines may take a little while to appear.
+              </p>
+            </details>
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={busy}
+                onClick={rotate}
+                className="rounded-lg border border-[color:var(--color-stone)] px-4 py-2 text-sm font-semibold text-[color:var(--color-ink)] hover:bg-[color:var(--color-sand)] disabled:opacity-50"
+              >
+                {busy ? "Working…" : "Regenerate link"}
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={disable}
+                className="rounded-lg border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 disabled:opacity-50"
+              >
+                Disable
+              </button>
+            </div>
+            <p className="text-xs text-[color:var(--color-muted)]">
+              Regenerating revokes the old link; update your calendar
+              subscription with the new one.
+            </p>
+          </div>
+        ) : (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={enable}
+            className="rwa-btn-primary"
+          >
+            {busy ? "Enabling…" : "Enable calendar feed"}
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/services/api/alembic/versions/f2c8a1d6b3e9_add_user_calendar_feed_token.py
+++ b/services/api/alembic/versions/f2c8a1d6b3e9_add_user_calendar_feed_token.py
@@ -5,7 +5,7 @@ feed of a user's case deadlines and renewals
 (GET /calendar/feed/<token>.ics). Null until the user enables the feed.
 
 Revision ID: f2c8a1d6b3e9
-Revises: d4a5b6c7e8f9
+Revises: 914ad2096e71
 Create Date: 2026-06-06
 """
 from alembic import op
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "f2c8a1d6b3e9"
-down_revision = "e7b2d4f1a9c3"
+down_revision = "914ad2096e71"
 branch_labels = None
 depends_on = None
 

--- a/services/api/alembic/versions/f2c8a1d6b3e9_add_user_calendar_feed_token.py
+++ b/services/api/alembic/versions/f2c8a1d6b3e9_add_user_calendar_feed_token.py
@@ -1,0 +1,36 @@
+"""add users.calendar_feed_token for ICS calendar subscription feed
+
+Stores the unguessable token that authorises the read-only iCalendar
+feed of a user's case deadlines and renewals
+(GET /calendar/feed/<token>.ics). Null until the user enables the feed.
+
+Revision ID: f2c8a1d6b3e9
+Revises: d4a5b6c7e8f9
+Create Date: 2026-06-06
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f2c8a1d6b3e9"
+down_revision = "d4a5b6c7e8f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("calendar_feed_token", sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        "ix_users_calendar_feed_token",
+        "users",
+        ["calendar_feed_token"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_calendar_feed_token", table_name="users")
+    op.drop_column("users", "calendar_feed_token")

--- a/services/api/alembic/versions/f2c8a1d6b3e9_add_user_calendar_feed_token.py
+++ b/services/api/alembic/versions/f2c8a1d6b3e9_add_user_calendar_feed_token.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "f2c8a1d6b3e9"
-down_revision = "d4a5b6c7e8f9"
+down_revision = "e7b2d4f1a9c3"
 branch_labels = None
 depends_on = None
 

--- a/services/api/app/calendar/__init__.py
+++ b/services/api/app/calendar/__init__.py
@@ -1,0 +1,8 @@
+"""Read-only iCalendar (ICS) subscription feed of a user's IP deadlines.
+
+A per-user, unguessable token authorises an unauthenticated feed
+(GET /calendar/feed/<token>.ics) that Google Calendar, Outlook and Apple
+Calendar can subscribe to. The feed surfaces case deadlines and renewal
+due dates as VEVENTs with VALARM reminders, so the IP Agent's reminders
+also appear in counsel's external calendar.
+"""

--- a/services/api/app/calendar/router.py
+++ b/services/api/app/calendar/router.py
@@ -1,0 +1,94 @@
+"""Calendar subscription endpoints.
+
+The feed itself is public but token-gated (calendar apps cannot send a
+bearer token); the management endpoints are authenticated.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_user
+from app.calendar import service
+from app.database import get_db
+from app.users.models import User
+
+router = APIRouter(prefix="/calendar", tags=["calendar"])
+
+
+class FeedStatus(BaseModel):
+    enabled: bool
+    url: str | None = None
+
+
+@router.get("/feed/{token}.ics")
+async def get_calendar_feed(
+    token: str,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Public, token-gated iCalendar feed of the user's IP deadlines.
+
+    Unauthenticated by design — the unguessable token identifies the
+    subject so calendar clients (Google/Outlook/Apple) can subscribe.
+    """
+    user = await service.get_user_by_feed_token(db, token)
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Calendar feed not found.",
+        )
+
+    body = await service.build_feed(db, user)
+    return Response(
+        content=body,
+        media_type="text/calendar; charset=utf-8",
+        headers={
+            "Content-Disposition": 'inline; filename="etornie-deadlines.ics"',
+            "Cache-Control": "private, max-age=3600",
+        },
+    )
+
+
+@router.get("/feed", response_model=FeedStatus)
+async def get_feed_status(
+    current_user: User = Depends(get_current_user),
+) -> FeedStatus:
+    token = current_user.calendar_feed_token
+    return FeedStatus(
+        enabled=bool(token),
+        url=service.feed_url(token) if token else None,
+    )
+
+
+@router.post("/feed", response_model=FeedStatus)
+async def enable_feed(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> FeedStatus:
+    """Enable the feed (create a token on first use) and return its URL."""
+
+    token = await service.ensure_token(db, current_user)
+    return FeedStatus(enabled=True, url=service.feed_url(token))
+
+
+@router.post("/feed/rotate", response_model=FeedStatus)
+async def rotate_feed(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> FeedStatus:
+    """Issue a fresh feed URL, revoking the previous one."""
+
+    token = await service.rotate_token(db, current_user)
+    return FeedStatus(enabled=True, url=service.feed_url(token))
+
+
+@router.delete("/feed", status_code=status.HTTP_204_NO_CONTENT)
+async def disable_feed(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    """Disable the feed and revoke the URL."""
+
+    await service.disable_feed(db, current_user)

--- a/services/api/app/calendar/service.py
+++ b/services/api/app/calendar/service.py
@@ -1,0 +1,174 @@
+"""Build the iCalendar feed and manage the per-user feed token."""
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from icalendar import Alarm, Calendar, Event
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cases.models import Case, CaseStatus
+from app.config import settings
+from app.users.models import User
+
+_PRODID = "-//Etornie//IP Deadlines//EN"
+_CALENDAR_NAME = "Etornie IP Deadlines"
+
+# Reminders fired ahead of each deadline, mirroring the renewal
+# dispatcher's intent that counsel gets advance warning.
+_ALARM_OFFSETS: tuple[timedelta, ...] = (
+    timedelta(days=-7),
+    timedelta(days=-1),
+)
+
+
+def generate_token() -> str:
+    """A URL-safe, unguessable feed token (fits the 64-char column)."""
+
+    return secrets.token_urlsafe(32)
+
+
+async def get_user_by_feed_token(
+    db: AsyncSession, token: str
+) -> User | None:
+    if not token:
+        return None
+    return (
+        await db.execute(
+            select(User).where(User.calendar_feed_token == token)
+        )
+    ).scalar_one_or_none()
+
+
+async def ensure_token(db: AsyncSession, user: User) -> str:
+    """Return the user's feed token, creating one on first use."""
+
+    if not user.calendar_feed_token:
+        user.calendar_feed_token = generate_token()
+        await db.flush()
+    return user.calendar_feed_token
+
+
+async def rotate_token(db: AsyncSession, user: User) -> str:
+    """Issue a fresh token, revoking the previous feed URL."""
+
+    user.calendar_feed_token = generate_token()
+    await db.flush()
+    return user.calendar_feed_token
+
+
+async def disable_feed(db: AsyncSession, user: User) -> None:
+    user.calendar_feed_token = None
+    await db.flush()
+
+
+def feed_url(token: str) -> str:
+    base = settings.api_public_url.rstrip("/")
+    return f"{base}/calendar/feed/{token}.ics"
+
+
+async def _cases_for(db: AsyncSession, user: User) -> list[Case]:
+    """Cases the user is involved in (as client or assigned counsel)."""
+
+    stmt = select(Case).where(
+        or_(Case.client_id == user.id, Case.assigned_lawyer_id == user.id)
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+def _with_alarms(event: Event, summary: str) -> None:
+    for offset in _ALARM_OFFSETS:
+        alarm = Alarm()
+        alarm.add("action", "DISPLAY")
+        alarm.add("description", summary)
+        alarm.add("trigger", offset)
+        event.add_component(alarm)
+
+
+def _build_event(
+    *,
+    uid: str,
+    summary: str,
+    start,
+    all_day: bool,
+    description: str,
+    last_modified: datetime | None,
+    stamp: datetime,
+) -> Event:
+    event = Event()
+    event.add("uid", uid)
+    event.add("summary", summary)
+    event.add("dtstart", start)
+    # A bounded end keeps every client happy: all-day events span one day,
+    # timed events one hour.
+    event.add("dtend", start + timedelta(days=1 if all_day else 0, hours=0 if all_day else 1))
+    event.add("dtstamp", stamp)
+    if last_modified is not None:
+        event.add("last-modified", last_modified)
+    event.add("description", description)
+    event.add("transp", "TRANSPARENT")
+    _with_alarms(event, summary)
+    return event
+
+
+async def build_feed(db: AsyncSession, user: User) -> bytes:
+    """Render the user's deadlines + renewals as an iCalendar document."""
+
+    cal = Calendar()
+    cal.add("prodid", _PRODID)
+    cal.add("version", "2.0")
+    cal.add("calscale", "GREGORIAN")
+    cal.add("method", "PUBLISH")
+    cal.add("x-wr-calname", _CALENDAR_NAME)
+    # Hint subscribed clients to refresh roughly hourly.
+    cal.add("x-published-ttl", "PT1H")
+    cal.add("refresh-interval;value=duration", "PT1H")
+
+    stamp = datetime.now(timezone.utc)
+
+    for case in await _cases_for(db, user):
+        label = f"{case.title} ({case.case_number})"
+        jurisdiction = case.jurisdiction or "n/a"
+
+        if case.deadline is not None:
+            if case.deadline_time is not None:
+                start = datetime.combine(
+                    case.deadline, case.deadline_time, tzinfo=timezone.utc
+                )
+                all_day = False
+            else:
+                start = case.deadline  # date -> all-day VEVENT
+                all_day = True
+            cal.add_component(
+                _build_event(
+                    uid=f"{case.id}-deadline@etornie",
+                    summary=f"IP deadline: {label}",
+                    start=start,
+                    all_day=all_day,
+                    description=(
+                        f"Deadline for IP case {case.case_number}. "
+                        f"Jurisdiction: {jurisdiction}."
+                    ),
+                    last_modified=case.updated_at,
+                    stamp=stamp,
+                )
+            )
+
+        if case.renewal_due_at is not None and case.status != CaseStatus.closed:
+            cal.add_component(
+                _build_event(
+                    uid=f"{case.id}-renewal@etornie",
+                    summary=f"Renewal due: {label}",
+                    start=case.renewal_due_at,
+                    all_day=False,
+                    description=(
+                        f"Renewal due for IP case {case.case_number}. "
+                        f"Jurisdiction: {jurisdiction}."
+                    ),
+                    last_modified=case.updated_at,
+                    stamp=stamp,
+                )
+            )
+
+    return cal.to_ical()

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -13,6 +13,7 @@ from app.auth.router import router as auth_router
 from app.auth.wallet_router import router as wallet_auth_router
 from app.braid.admin_router import router as braid_admin_router
 from app.braid.router import router as braid_router
+from app.calendar.router import router as calendar_router
 from app.cases.metadata_router import router as case_metadata_router
 from app.cases.router import router as cases_router
 from app.config import settings
@@ -111,6 +112,7 @@ async def _user_facing_error_handler(
 app.include_router(auth_router)
 app.include_router(wallet_auth_router)
 app.include_router(users_router)
+app.include_router(calendar_router)
 app.include_router(cases_router)
 app.include_router(case_metadata_router)
 app.include_router(documents_router)

--- a/services/api/app/users/models.py
+++ b/services/api/app/users/models.py
@@ -113,6 +113,16 @@ class User(Base):
         LargeBinary, nullable=True, deferred=True
     )
 
+    # Calendar (ICS) subscription feed. When set, this unguessable token
+    # authorises an unauthenticated read-only iCalendar feed of the
+    # user's case deadlines and renewals at
+    # GET /calendar/feed/<token>.ics, which Google/Outlook/Apple can
+    # subscribe to. Null until the user enables the feed; rotating the
+    # token revokes the previous URL.
+    calendar_feed_token: Mapped[str | None] = mapped_column(
+        String(64), unique=True, index=True, nullable=True
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "python-docx>=1.1.0",
     "openpyxl>=3.1.0",
     "stripe>=11.0.0",
+    "icalendar>=5.0.0",
     "sentry-sdk[fastapi]>=2.0.0",
     "opentelemetry-sdk>=1.27.0",
     "opentelemetry-exporter-otlp-proto-http>=1.27.0",


### PR DESCRIPTION
Closes #64.

Per-user, token-gated read-only **iCalendar feed** so case deadlines and renewal dates appear in Google Calendar, Outlook, and Apple Calendar.

## Changes
- `app/calendar/service.py` — RFC 5545 VEVENTs (all-day vs timed deadlines; renewal dates; closed-case renewals skipped) + VALARM reminders at 7 days and 1 day before; token generate/rotate/lookup.
- `app/calendar/router.py` — public `GET /calendar/feed/{token}.ics`; authenticated `GET/POST /calendar/feed`, `POST /calendar/feed/rotate`, `DELETE /calendar/feed`.
- `User.calendar_feed_token` + migration `f2c8a1d6b3e9`; `icalendar` dependency.
- Frontend `CalendarSyncSection` on the profile page: feed URL + copy, subscribe instructions, regenerate, disable.

## Verification
- Service e2e: feed builds and parses, correct VEVENTs/VALARMs, closed-case renewal skipped, all-day DATE value.
- HTTP e2e: enable → public `.ics` (no auth, 200 `text/calendar`) → rotate (old URL 404) → bogus token 404 → disable (revoked).
- `tsc --noEmit` clean.

## Screenshots
<img width="1374" height="322" alt="dasboard" src="https://github.com/user-attachments/assets/4ec29ed6-ffcf-43d3-9bac-2a4b87f0f53d" />
<img width="996" height="748" alt="calendar" src="https://github.com/user-attachments/assets/a2a1d534-0452-456c-ae6a-2720b3a9e5d7" />
