### PR TITLE
feat(sdk): public TypeScript and Python SDKs (#71)

### DIFF
--- a/dashboard/src/app/docs/page.tsx
+++ b/dashboard/src/app/docs/page.tsx
@@ -23,6 +23,7 @@ const SECTIONS: readonly Section[] = [
   { id: "notifications", label: "Notifications" },
   { id: "ip-agent", label: "IP Agent" },
   { id: "api", label: "API Reference" },
+  { id: "sdk", label: "SDKs" },
   { id: "stack", label: "Tech Stack" },
   { id: "roadmap", label: "Roadmap" },
   { id: "faq", label: "FAQ" },
@@ -393,6 +394,54 @@ export default function DocsPage() {
                   ["POST", "/agents/ip/configure", "Configure intervals"],
                 ]}
               />
+            </Article>
+
+            <Article
+              id="sdk"
+              title="Developers: SDKs"
+              intro="Official client libraries for integrating against the Etornie API from your own apps and scripts. Hand-written and typed, covering auth, cases, documents, renewals, calendar, and data export."
+            >
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="rwa-card p-5">
+                  <SubHeading>TypeScript / JavaScript</SubHeading>
+                  <pre className="mt-2 overflow-x-auto rounded-lg bg-[color:var(--color-espresso)] p-3 text-xs text-[color:var(--color-cream)]">
+                    <code>{`npm install @etornie/sdk
+
+import { EtornieClient } from "@etornie/sdk";
+
+const etornie = new EtornieClient({
+  baseUrl: "https://api.etornie.com",
+});
+await etornie.auth.login(email, password);
+const { cases } = await etornie.cases.list({ status: "open" });`}</code>
+                  </pre>
+                </div>
+                <div className="rwa-card p-5">
+                  <SubHeading>Python</SubHeading>
+                  <pre className="mt-2 overflow-x-auto rounded-lg bg-[color:var(--color-espresso)] p-3 text-xs text-[color:var(--color-cream)]">
+                    <code>{`pip install etornie
+
+from etornie import EtornieClient
+
+with EtornieClient("https://api.etornie.com") as etornie:
+    etornie.auth.login(email, password)
+    cases, total = etornie.cases.list(status="open")`}</code>
+                  </pre>
+                </div>
+              </div>
+              <p className="text-sm text-[color:var(--color-muted)]">
+                Authentication uses bearer tokens (email + password login, or
+                pass a token you already hold). Source and full method reference
+                live in the repository under{" "}
+                <code className="rounded bg-[color:var(--color-linen)] px-1.5 py-0.5 text-xs">
+                  packages/sdk-typescript
+                </code>{" "}
+                and{" "}
+                <code className="rounded bg-[color:var(--color-linen)] px-1.5 py-0.5 text-xs">
+                  packages/sdk-python
+                </code>
+                .
+              </p>
             </Article>
 
             <Article

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,0 +1,51 @@
+# Etornie SDKs
+
+Official client libraries for integrating against the Etornie IP platform API.
+
+| Language | Package | Source | Install |
+|----------|---------|--------|---------|
+| TypeScript / JavaScript | `@etornie/sdk` | [`packages/sdk-typescript`](../../packages/sdk-typescript) | `npm install @etornie/sdk` |
+| Python | `etornie` | [`packages/sdk-python`](../../packages/sdk-python) | `pip install etornie` |
+
+Both SDKs are hand-written, typed, and cover the core public resources:
+
+- **auth** — `login`, `me`
+- **cases** — list, get, create *(admin)*, update *(admin)*
+- **documents** — list, download
+- **renewals** — status
+- **calendar** — feed enable / rotate / disable / status
+- **data export** — GDPR Article 20 export download
+
+## Authentication
+
+The API uses bearer tokens. Authenticate with email + password (the client
+stores the access token), or construct the client with a token you already
+hold.
+
+```ts
+// TypeScript
+import { EtornieClient } from "@etornie/sdk";
+const etornie = new EtornieClient({ baseUrl: "https://api.etornie.com" });
+await etornie.auth.login("you@example.com", "password");
+const { cases } = await etornie.cases.list({ status: "open" });
+```
+
+```python
+# Python
+from etornie import EtornieClient
+with EtornieClient("https://api.etornie.com") as etornie:
+    etornie.auth.login("you@example.com", "password")
+    cases, total = etornie.cases.list(status="open")
+```
+
+See each package's README for the full method reference and error handling.
+
+## Tests
+
+Both packages ship unit tests plus credential-gated integration tests that
+run against a live API when these environment variables are set (otherwise
+they are skipped, never mocked):
+
+```
+ETORNIE_API_URL, ETORNIE_TEST_EMAIL, ETORNIE_TEST_PASSWORD
+```

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -1,0 +1,63 @@
+# etornie
+
+Official Python SDK for the [Etornie](https://etornie.com) intellectual-property platform API.
+
+## Install
+
+```bash
+pip install etornie
+```
+
+Requires Python 3.10+.
+
+## Quick start
+
+```python
+from etornie import EtornieClient
+
+with EtornieClient("https://api.etornie.com") as etornie:
+    # Authenticate (stores the access token on the client)
+    etornie.auth.login("you@example.com", "your-password")
+    # ...or: EtornieClient("https://api.etornie.com", token="...")
+
+    me = etornie.auth.me()
+
+    cases, total = etornie.cases.list(status="open", limit=20)
+    detail = etornie.cases.get(cases[0].id)
+
+    renewal = etornie.renewals.status(detail.id)
+    docs, _ = etornie.documents.list(detail.id)
+```
+
+## Resources
+
+| Namespace | Methods |
+|-----------|---------|
+| `auth` | `login(email, password)`, `me()` |
+| `cases` | `list(skip=, limit=, status=)`, `get(id)`, `create(**fields)` *(admin)*, `update(id, **fields)` *(admin)* |
+| `documents` | `list(case_id)` → `(docs, total)`, `download(id)` → `bytes` |
+| `renewals` | `status(case_id)` |
+| `calendar` | `status()`, `enable()`, `rotate()`, `disable()` |
+| `data_export` | `download(fmt)` → `bytes` (`json` \| `pdf` \| `docx` \| `xlsx`) |
+
+## Errors
+
+Non-2xx responses raise `EtornieApiError` (`.status_code`, `.detail`).
+Calling an authenticated method without a token raises `EtornieAuthError`.
+
+```python
+from etornie import EtornieApiError
+
+try:
+    etornie.cases.get("missing")
+except EtornieApiError as err:
+    print(err.status_code, err.detail)
+```
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest            # integration tests run only when ETORNIE_API_URL,
+                  # ETORNIE_TEST_EMAIL and ETORNIE_TEST_PASSWORD are set
+```

--- a/packages/sdk-python/etornie/__init__.py
+++ b/packages/sdk-python/etornie/__init__.py
@@ -1,0 +1,28 @@
+"""Official Python SDK for the Etornie IP platform API."""
+from __future__ import annotations
+
+from .client import EtornieClient
+from .errors import EtornieApiError, EtornieAuthError, EtornieError
+from .models import (
+    CalendarFeedStatus,
+    Case,
+    CaseDocument,
+    RenewalStatus,
+    TokenResponse,
+    User,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "EtornieClient",
+    "EtornieError",
+    "EtornieApiError",
+    "EtornieAuthError",
+    "TokenResponse",
+    "User",
+    "Case",
+    "CaseDocument",
+    "RenewalStatus",
+    "CalendarFeedStatus",
+]

--- a/packages/sdk-python/etornie/client.py
+++ b/packages/sdk-python/etornie/client.py
@@ -1,0 +1,218 @@
+"""Synchronous client for the Etornie API."""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import httpx
+
+from .errors import EtornieApiError, EtornieAuthError
+from .models import (
+    CalendarFeedStatus,
+    Case,
+    CaseDocument,
+    RenewalStatus,
+    TokenResponse,
+    User,
+)
+
+DataExportFormat = Literal["json", "pdf", "docx", "xlsx"]
+CaseStatus = Literal["open", "in_progress", "under_review", "closed"]
+
+
+class EtornieClient:
+    """Typed client for the Etornie API.
+
+    >>> etornie = EtornieClient("https://api.etornie.com")
+    >>> etornie.auth.login("you@example.com", "password")
+    >>> cases = etornie.cases.list(status="open")
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: str | None = None,
+        timeout: float = 30.0,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url is required")
+        self.base_url = base_url.rstrip("/")
+        self._token = token
+        self._http = http_client or httpx.Client(timeout=timeout)
+
+        self.auth = AuthResource(self)
+        self.cases = CasesResource(self)
+        self.documents = DocumentsResource(self)
+        self.renewals = RenewalsResource(self)
+        self.calendar = CalendarResource(self)
+        self.data_export = DataExportResource(self)
+
+    # -- token -----------------------------------------------------------
+    def set_token(self, token: str | None) -> None:
+        self._token = token
+
+    @property
+    def token(self) -> str | None:
+        return self._token
+
+    # -- context manager -------------------------------------------------
+    def __enter__(self) -> "EtornieClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._http.close()
+
+    # -- low-level request ----------------------------------------------
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: Any = None,
+        auth: bool = True,
+        raw: bool = False,
+    ) -> Any:
+        headers = {"Accept": "application/json"}
+        if auth:
+            if not self._token:
+                raise EtornieAuthError()
+            headers["Authorization"] = f"Bearer {self._token}"
+
+        clean_params = (
+            {k: v for k, v in params.items() if v is not None}
+            if params
+            else None
+        )
+
+        resp = self._http.request(
+            method,
+            self.base_url + path,
+            params=clean_params,
+            json=json,
+            headers=headers,
+        )
+
+        if resp.status_code >= 400:
+            try:
+                detail = resp.json().get("detail")
+            except Exception:  # noqa: BLE001 - non-JSON error body
+                detail = resp.text
+            raise EtornieApiError(resp.status_code, detail)
+
+        if raw:
+            return resp.content
+        if resp.status_code == 204 or not resp.content:
+            return None
+        return resp.json()
+
+
+class AuthResource:
+    def __init__(self, client: EtornieClient) -> None:
+        self._c = client
+
+    def login(self, email: str, password: str) -> TokenResponse:
+        """Exchange email + password for tokens; stores the access token."""
+        data = self._c.request(
+            "POST", "/auth/login", json={"email": email, "password": password}, auth=False
+        )
+        tokens = TokenResponse.from_dict(data)
+        self._c.set_token(tokens.access_token)
+        return tokens
+
+    def me(self) -> User:
+        return User.from_dict(self._c.request("GET", "/auth/me"))
+
+
+class CasesResource:
+    def __init__(self, client: EtornieClient) -> None:
+        self._c = client
+
+    def list(
+        self,
+        *,
+        skip: int | None = None,
+        limit: int | None = None,
+        status: CaseStatus | None = None,
+    ) -> tuple[list[Case], int]:
+        """Return (cases, total)."""
+        data = self._c.request(
+            "GET", "/cases", params={"skip": skip, "limit": limit, "status": status}
+        )
+        return [Case.from_dict(c) for c in data["cases"]], int(data["total"])
+
+    def get(self, case_id: str) -> Case:
+        return Case.from_dict(self._c.request("GET", f"/cases/{case_id}"))
+
+    def create(self, **fields: Any) -> Case:
+        """Create a case (requires an admin token)."""
+        data = self._c.request("POST", "/cases", json=fields)
+        return Case.from_dict(data["case"])
+
+    def update(self, case_id: str, **fields: Any) -> Case:
+        return Case.from_dict(
+            self._c.request("PATCH", f"/cases/{case_id}", json=fields)
+        )
+
+
+class DocumentsResource:
+    def __init__(self, client: EtornieClient) -> None:
+        self._c = client
+
+    def list(self, case_id: str) -> tuple[list[CaseDocument], int]:
+        data = self._c.request("GET", f"/cases/{case_id}/documents")
+        return (
+            [CaseDocument.from_dict(d) for d in data["documents"]],
+            int(data["total"]),
+        )
+
+    def download(self, document_id: str) -> bytes:
+        return self._c.request(
+            "GET", f"/documents/{document_id}/download", raw=True
+        )
+
+
+class RenewalsResource:
+    def __init__(self, client: EtornieClient) -> None:
+        self._c = client
+
+    def status(self, case_id: str) -> RenewalStatus:
+        return RenewalStatus.from_dict(
+            self._c.request("GET", f"/cases/{case_id}/renewal-status")
+        )
+
+
+class CalendarResource:
+    def __init__(self, client: EtornieClient) -> None:
+        self._c = client
+
+    def status(self) -> CalendarFeedStatus:
+        return CalendarFeedStatus.from_dict(self._c.request("GET", "/calendar/feed"))
+
+    def enable(self) -> CalendarFeedStatus:
+        return CalendarFeedStatus.from_dict(
+            self._c.request("POST", "/calendar/feed")
+        )
+
+    def rotate(self) -> CalendarFeedStatus:
+        return CalendarFeedStatus.from_dict(
+            self._c.request("POST", "/calendar/feed/rotate")
+        )
+
+    def disable(self) -> None:
+        self._c.request("DELETE", "/calendar/feed")
+
+
+class DataExportResource:
+    def __init__(self, client: EtornieClient) -> None:
+        self._c = client
+
+    def download(self, fmt: DataExportFormat = "json") -> bytes:
+        """Download the authenticated user's GDPR data export (Article 20)."""
+        return self._c.request(
+            "GET", "/users/me/export", params={"format": fmt}, raw=True
+        )

--- a/packages/sdk-python/etornie/errors.py
+++ b/packages/sdk-python/etornie/errors.py
@@ -1,0 +1,27 @@
+"""Exceptions raised by the Etornie SDK."""
+from __future__ import annotations
+
+from typing import Any
+
+
+class EtornieError(Exception):
+    """Base class for all SDK errors."""
+
+
+class EtornieAuthError(EtornieError):
+    """Raised when an authenticated call is made without a token."""
+
+    def __init__(
+        self,
+        message: str = "No access token set. Call auth.login() or pass a token.",
+    ) -> None:
+        super().__init__(message)
+
+
+class EtornieApiError(EtornieError):
+    """Raised when the Etornie API returns a non-2xx response."""
+
+    def __init__(self, status_code: int, detail: Any) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"Etornie API error {status_code}: {detail!r}")

--- a/packages/sdk-python/etornie/models.py
+++ b/packages/sdk-python/etornie/models.py
@@ -1,0 +1,94 @@
+"""Typed models mirroring the Etornie API response shapes.
+
+Each model is a frozen dataclass with a ``from_dict`` constructor that
+ignores unknown keys, so the SDK keeps working when the API adds fields.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, TypeVar
+
+T = TypeVar("T", bound="_Base")
+
+
+@dataclass(frozen=True)
+class _Base:
+    @classmethod
+    def from_dict(cls: type[T], data: dict[str, Any]) -> T:
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+@dataclass(frozen=True)
+class TokenResponse(_Base):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+@dataclass(frozen=True)
+class User(_Base):
+    id: str
+    full_name: str
+    role: str
+    is_active: bool
+    auth_method: str
+    created_at: str
+    updated_at: str
+    email: str | None = None
+    phone: str | None = None
+    wallet_address: str | None = None
+    public_handle: str | None = None
+
+
+@dataclass(frozen=True)
+class Case(_Base):
+    id: str
+    title: str
+    case_number: str
+    case_type: str
+    status: str
+    created_at: str
+    updated_at: str
+    description: str | None = None
+    client_id: str | None = None
+    assigned_lawyer_id: str | None = None
+    jurisdiction: str | None = None
+    nice_classes: str | None = None
+    filing_date: str | None = None
+    deadline: str | None = None
+    deadline_time: str | None = None
+    attestation_tx: str | None = None
+    attestation_pda: str | None = None
+    client_wallet: str | None = None
+    nft_mint: str | None = None
+    nft_state: str = "none"
+
+
+@dataclass(frozen=True)
+class CaseDocument(_Base):
+    id: str
+    case_id: str
+    uploaded_by: str
+    filename: str
+    status: str
+    created_at: str
+    file_type: str | None = None
+    file_size: int | None = None
+    document_type: str | None = None
+
+
+@dataclass(frozen=True)
+class RenewalStatus(_Base):
+    case_id: str
+    renewal_due_at: str | None = None
+    days_remaining: int | None = None
+    is_overdue: bool = False
+    open_window: int | None = None
+    reminders: list[dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True)
+class CalendarFeedStatus(_Base):
+    enabled: bool
+    url: str | None = None

--- a/packages/sdk-python/examples/demo.py
+++ b/packages/sdk-python/examples/demo.py
@@ -1,0 +1,32 @@
+"""Live demo: PYTHONPATH=. python examples/demo.py
+Env: ETORNIE_API_URL, ETORNIE_TEST_EMAIL, ETORNIE_TEST_PASSWORD
+"""
+from __future__ import annotations
+
+import os
+
+from etornie import EtornieApiError, EtornieClient
+
+base_url = os.environ["ETORNIE_API_URL"]
+email = os.environ["ETORNIE_TEST_EMAIL"]
+password = os.environ["ETORNIE_TEST_PASSWORD"]
+
+with EtornieClient(base_url) as etornie:
+    tokens = etornie.auth.login(email, password)
+    print("login ok, token len:", len(tokens.access_token))
+
+    me = etornie.auth.me()
+    print(f"me: {me.email} | role: {me.role} | id: {me.id[:8]}…")
+
+    cases, total = etornie.cases.list(limit=5)
+    print("cases.list -> total:", total, "| returned:", len(cases))
+
+    export_bytes = etornie.data_export.download("json")
+    print("data_export(json) -> bytes:", len(export_bytes))
+
+    try:
+        etornie.cases.get("00000000-0000-0000-0000-000000000000")
+    except EtornieApiError as err:
+        print("error handling ok -> EtornieApiError status:", err.status_code)
+
+print("PYTHON SDK DEMO OK")

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "etornie"
+version = "0.1.0"
+description = "Official Python SDK for the Etornie IP platform API"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+keywords = ["etornie", "intellectual-property", "sdk", "api-client"]
+dependencies = [
+    "httpx>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["etornie"]

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -1,0 +1,74 @@
+"""SDK tests.
+
+Integration tests run against a real, running Etornie API and are
+credential-gated via environment variables. Without credentials they are
+skipped (never mocked), so the suite stays green where the API is
+unreachable.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from etornie import EtornieApiError, EtornieAuthError, EtornieClient
+
+API_URL = os.environ.get("ETORNIE_API_URL")
+EMAIL = os.environ.get("ETORNIE_TEST_EMAIL")
+PASSWORD = os.environ.get("ETORNIE_TEST_PASSWORD")
+_LIVE = bool(API_URL and EMAIL and PASSWORD)
+_requires_api = pytest.mark.skipif(
+    not _LIVE,
+    reason="set ETORNIE_API_URL, ETORNIE_TEST_EMAIL, ETORNIE_TEST_PASSWORD",
+)
+
+
+def test_base_url_required() -> None:
+    with pytest.raises(ValueError):
+        EtornieClient("")
+
+
+def test_base_url_trailing_slash_stripped() -> None:
+    assert EtornieClient("https://api.etornie.com/").base_url == (
+        "https://api.etornie.com"
+    )
+
+
+def test_authed_call_without_token_raises() -> None:
+    client = EtornieClient("https://example.invalid")
+    with pytest.raises(EtornieAuthError):
+        client.auth.me()
+
+
+@_requires_api
+def test_login_and_me() -> None:
+    with EtornieClient(API_URL) as client:
+        client.auth.login(EMAIL, PASSWORD)
+        me = client.auth.me()
+        assert me.email == EMAIL
+        assert me.id
+
+
+@_requires_api
+def test_list_cases() -> None:
+    with EtornieClient(API_URL) as client:
+        client.auth.login(EMAIL, PASSWORD)
+        cases, total = client.cases.list(limit=5)
+        assert isinstance(cases, list)
+        assert isinstance(total, int)
+
+
+@_requires_api
+def test_calendar_feed_lifecycle() -> None:
+    with EtornieClient(API_URL) as client:
+        client.auth.login(EMAIL, PASSWORD)
+        try:
+            enabled = client.calendar.enable()
+        except EtornieApiError as exc:
+            if exc.status_code == 404:
+                pytest.skip("calendar feature not available on target API")
+            raise
+        assert enabled.enabled is True
+        assert enabled.url and "/calendar/feed/" in enabled.url
+        client.calendar.disable()
+        assert client.calendar.status().enabled is False

--- a/packages/sdk-typescript/README.md
+++ b/packages/sdk-typescript/README.md
@@ -1,0 +1,71 @@
+# @etornie/sdk
+
+Official TypeScript SDK for the [Etornie](https://etornie.com) intellectual-property platform API.
+
+## Install
+
+```bash
+npm install @etornie/sdk
+```
+
+Requires Node.js 18+ (uses the global `fetch`). Works in the browser and in modern runtimes too.
+
+## Quick start
+
+```ts
+import { EtornieClient } from "@etornie/sdk";
+
+const etornie = new EtornieClient({ baseUrl: "https://api.etornie.com" });
+
+// Authenticate (stores the access token on the client)
+await etornie.auth.login("you@example.com", "your-password");
+
+// ...or pass a token you already have
+// const etornie = new EtornieClient({ baseUrl, token });
+
+const me = await etornie.auth.me();
+
+const { cases, total } = await etornie.cases.list({ status: "open", limit: 20 });
+const detail = await etornie.cases.get(cases[0].id);
+
+const renewal = await etornie.renewals.status(detail.id);
+const docs = await etornie.documents.list(detail.id);
+```
+
+## Resources
+
+| Namespace | Methods |
+|-----------|---------|
+| `auth` | `login(email, password)`, `me()` |
+| `cases` | `list(params?)`, `get(id)`, `create(input)` *(admin)*, `update(id, input)` *(admin)* |
+| `documents` | `list(caseId)`, `download(id)` → `ArrayBuffer` |
+| `renewals` | `status(caseId)` |
+| `calendar` | `status()`, `enable()`, `rotate()`, `disable()` |
+| `dataExport` | `download(format)` → `ArrayBuffer` (`json` \| `pdf` \| `docx` \| `xlsx`) |
+
+## Errors
+
+Non-2xx responses throw `EtornieApiError` (`.status`, `.detail`). Calling an
+authenticated method without a token throws `EtornieAuthError`.
+
+```ts
+import { EtornieApiError } from "@etornie/sdk";
+
+try {
+  await etornie.cases.get("missing");
+} catch (err) {
+  if (err instanceof EtornieApiError) {
+    console.error(err.status, err.detail);
+  }
+}
+```
+
+## Development
+
+```bash
+npm install
+npm run typecheck
+npm run build
+npm test            # integration tests run only when ETORNIE_API_URL,
+                    # ETORNIE_TEST_EMAIL and ETORNIE_TEST_PASSWORD are set
+```

--- a/packages/sdk-typescript/examples/demo.ts
+++ b/packages/sdk-typescript/examples/demo.ts
@@ -1,0 +1,31 @@
+// Live demo: run with `npx tsx examples/demo.ts`
+// Env: ETORNIE_API_URL, ETORNIE_TEST_EMAIL, ETORNIE_TEST_PASSWORD
+import { EtornieClient, EtornieApiError } from "../src/index.js";
+
+const baseUrl = process.env.ETORNIE_API_URL!;
+const email = process.env.ETORNIE_TEST_EMAIL!;
+const password = process.env.ETORNIE_TEST_PASSWORD!;
+
+const etornie = new EtornieClient({ baseUrl });
+
+const tokens = await etornie.auth.login(email, password);
+console.log("login ok, token len:", tokens.access_token.length);
+
+const me = await etornie.auth.me();
+console.log("me:", me.email, "| role:", me.role, "| id:", me.id.slice(0, 8) + "…");
+
+const { cases, total } = await etornie.cases.list({ limit: 5 });
+console.log("cases.list -> total:", total, "| returned:", cases.length);
+
+const exportBytes = await etornie.dataExport.download("json");
+console.log("dataExport(json) -> bytes:", exportBytes.byteLength);
+
+try {
+  await etornie.cases.get("00000000-0000-0000-0000-000000000000");
+} catch (err) {
+  if (err instanceof EtornieApiError) {
+    console.log("error handling ok -> EtornieApiError status:", err.status);
+  }
+}
+
+console.log("TS SDK DEMO OK");

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@etornie/sdk",
+  "version": "0.1.0",
+  "description": "Official TypeScript SDK for the Etornie IP platform API",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "etornie",
+    "intellectual-property",
+    "sdk",
+    "api-client"
+  ],
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -1,0 +1,236 @@
+import { EtornieApiError, EtornieAuthError } from "./errors.js";
+import type {
+  Case,
+  CaseListResponse,
+  CalendarFeedStatus,
+  CreateCaseInput,
+  DataExportFormat,
+  DocumentListResponse,
+  ListCasesParams,
+  RenewalStatus,
+  TokenResponse,
+  UpdateCaseInput,
+  User,
+} from "./types.js";
+
+export interface EtornieClientOptions {
+  /** Base URL of the Etornie API, e.g. https://api.etornie.com */
+  baseUrl: string;
+  /** Optional bearer access token (or set later via auth.login). */
+  token?: string;
+  /** Custom fetch implementation (defaults to global fetch). */
+  fetch?: typeof fetch;
+}
+
+type RequestOptions = {
+  method?: string;
+  query?: Record<string, string | number | undefined>;
+  body?: unknown;
+  auth?: boolean;
+  raw?: boolean;
+};
+
+/**
+ * Typed client for the Etornie API.
+ *
+ * ```ts
+ * const etornie = new EtornieClient({ baseUrl: "https://api.etornie.com" });
+ * await etornie.auth.login("you@example.com", "password");
+ * const { cases } = await etornie.cases.list({ status: "open" });
+ * ```
+ */
+export class EtornieClient {
+  readonly baseUrl: string;
+  private token?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  readonly auth: AuthResource;
+  readonly cases: CasesResource;
+  readonly documents: DocumentsResource;
+  readonly renewals: RenewalsResource;
+  readonly calendar: CalendarResource;
+  readonly dataExport: DataExportResource;
+
+  constructor(options: EtornieClientOptions) {
+    if (!options.baseUrl) throw new Error("baseUrl is required");
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.token = options.token;
+    const f = options.fetch ?? globalThis.fetch;
+    if (!f) {
+      throw new Error(
+        "No fetch implementation available. Pass options.fetch (Node < 18)."
+      );
+    }
+    this.fetchImpl = f;
+
+    this.auth = new AuthResource(this);
+    this.cases = new CasesResource(this);
+    this.documents = new DocumentsResource(this);
+    this.renewals = new RenewalsResource(this);
+    this.calendar = new CalendarResource(this);
+    this.dataExport = new DataExportResource(this);
+  }
+
+  /** Set or replace the bearer access token. */
+  setToken(token: string | undefined): void {
+    this.token = token;
+  }
+
+  /** The current access token, if any. */
+  getToken(): string | undefined {
+    return this.token;
+  }
+
+  /** Low-level request helper. Most callers use the resource methods. */
+  async request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    const { method = "GET", query, body, auth = true, raw = false } = options;
+
+    const url = new URL(this.baseUrl + path);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined) url.searchParams.set(key, String(value));
+      }
+    }
+
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (auth) {
+      if (!this.token) throw new EtornieAuthError();
+      headers.Authorization = `Bearer ${this.token}`;
+    }
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+
+    const res = await this.fetchImpl(url.toString(), {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      let detail: unknown = undefined;
+      try {
+        detail = (await res.json())?.detail;
+      } catch {
+        detail = await res.text().catch(() => undefined);
+      }
+      throw new EtornieApiError(res.status, detail);
+    }
+
+    if (raw) return (await res.arrayBuffer()) as unknown as T;
+    if (res.status === 204) return undefined as T;
+    return (await res.json()) as T;
+  }
+
+  /** Request returning the raw response bytes (downloads). */
+  async requestBytes(
+    path: string,
+    options: RequestOptions = {}
+  ): Promise<ArrayBuffer> {
+    return this.request<ArrayBuffer>(path, { ...options, raw: true });
+  }
+}
+
+class AuthResource {
+  constructor(private readonly client: EtornieClient) {}
+
+  /** Exchange email + password for tokens and store the access token. */
+  async login(email: string, password: string): Promise<TokenResponse> {
+    const tokens = await this.client.request<TokenResponse>("/auth/login", {
+      method: "POST",
+      auth: false,
+      body: { email, password },
+    });
+    this.client.setToken(tokens.access_token);
+    return tokens;
+  }
+
+  /** The authenticated user. */
+  async me(): Promise<User> {
+    return this.client.request<User>("/auth/me");
+  }
+}
+
+class CasesResource {
+  constructor(private readonly client: EtornieClient) {}
+
+  list(params: ListCasesParams = {}): Promise<CaseListResponse> {
+    return this.client.request<CaseListResponse>("/cases", {
+      query: { skip: params.skip, limit: params.limit, status: params.status },
+    });
+  }
+
+  get(caseId: string): Promise<Case> {
+    return this.client.request<Case>(`/cases/${caseId}`);
+  }
+
+  /** Create a case (requires an admin token). */
+  async create(input: CreateCaseInput): Promise<Case> {
+    const res = await this.client.request<{ case: Case }>("/cases", {
+      method: "POST",
+      body: input,
+    });
+    return res.case;
+  }
+
+  update(caseId: string, input: UpdateCaseInput): Promise<Case> {
+    return this.client.request<Case>(`/cases/${caseId}`, {
+      method: "PATCH",
+      body: input,
+    });
+  }
+}
+
+class DocumentsResource {
+  constructor(private readonly client: EtornieClient) {}
+
+  list(caseId: string): Promise<DocumentListResponse> {
+    return this.client.request<DocumentListResponse>(
+      `/cases/${caseId}/documents`
+    );
+  }
+
+  /** Download a document's bytes. */
+  download(documentId: string): Promise<ArrayBuffer> {
+    return this.client.requestBytes(`/documents/${documentId}/download`);
+  }
+}
+
+class RenewalsResource {
+  constructor(private readonly client: EtornieClient) {}
+
+  status(caseId: string): Promise<RenewalStatus> {
+    return this.client.request<RenewalStatus>(`/cases/${caseId}/renewal-status`);
+  }
+}
+
+class CalendarResource {
+  constructor(private readonly client: EtornieClient) {}
+
+  status(): Promise<CalendarFeedStatus> {
+    return this.client.request<CalendarFeedStatus>("/calendar/feed");
+  }
+
+  enable(): Promise<CalendarFeedStatus> {
+    return this.client.request<CalendarFeedStatus>("/calendar/feed", {
+      method: "POST",
+    });
+  }
+
+  rotate(): Promise<CalendarFeedStatus> {
+    return this.client.request<CalendarFeedStatus>("/calendar/feed/rotate", {
+      method: "POST",
+    });
+  }
+
+  async disable(): Promise<void> {
+    await this.client.request<void>("/calendar/feed", { method: "DELETE" });
+  }
+}
+
+class DataExportResource {
+  constructor(private readonly client: EtornieClient) {}
+
+  /** Download the authenticated user's GDPR data export (Article 20). */
+  download(format: DataExportFormat = "json"): Promise<ArrayBuffer> {
+    return this.client.requestBytes("/users/me/export", { query: { format } });
+  }
+}

--- a/packages/sdk-typescript/src/errors.ts
+++ b/packages/sdk-typescript/src/errors.ts
@@ -1,0 +1,20 @@
+/** Error thrown when the Etornie API returns a non-2xx response. */
+export class EtornieApiError extends Error {
+  readonly status: number;
+  readonly detail: unknown;
+
+  constructor(status: number, detail: unknown, message?: string) {
+    super(message ?? `Etornie API error ${status}`);
+    this.name = "EtornieApiError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+/** Error thrown when a request is made without authentication. */
+export class EtornieAuthError extends Error {
+  constructor(message = "No access token set. Call auth.login() or pass a token.") {
+    super(message);
+    this.name = "EtornieAuthError";
+  }
+}

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -1,0 +1,4 @@
+export { EtornieClient } from "./client.js";
+export type { EtornieClientOptions } from "./client.js";
+export { EtornieApiError, EtornieAuthError } from "./errors.js";
+export type * from "./types.js";

--- a/packages/sdk-typescript/src/types.ts
+++ b/packages/sdk-typescript/src/types.ts
@@ -1,0 +1,133 @@
+// Domain types mirroring the Etornie API response shapes for the core
+// resources the SDK covers. Optional fields use `| null` to match the
+// API's JSON (nullable columns serialise to null).
+
+export type CaseType = "trademark" | "patent" | "design" | "copyright";
+export type CaseStatus = "open" | "in_progress" | "under_review" | "closed";
+export type CaseNftState = "none" | "pending_claim" | "minted" | "burned";
+export type DocumentStatus = string;
+export type UserRole = "admin" | "client";
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+}
+
+export interface User {
+  id: string;
+  email: string | null;
+  full_name: string;
+  phone: string | null;
+  role: UserRole;
+  is_active: boolean;
+  wallet_address: string | null;
+  public_handle: string | null;
+  auth_method: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Case {
+  id: string;
+  title: string;
+  description: string | null;
+  case_number: string;
+  case_type: CaseType;
+  status: CaseStatus;
+  client_id: string | null;
+  assigned_lawyer_id: string | null;
+  jurisdiction: string | null;
+  nice_classes: string | null;
+  filing_date: string | null;
+  deadline: string | null;
+  deadline_time: string | null;
+  created_at: string;
+  updated_at: string;
+  attestation_tx: string | null;
+  attestation_pda: string | null;
+  client_wallet: string | null;
+  nft_mint: string | null;
+  nft_state: CaseNftState;
+}
+
+export interface CaseListResponse {
+  cases: Case[];
+  total: number;
+}
+
+export interface CreateCaseInput {
+  title: string;
+  case_type: CaseType;
+  description?: string | null;
+  client_id?: string | null;
+  client_wallet?: string | null;
+  guest_client_name?: string | null;
+  guest_client_email?: string | null;
+  guest_client_phone?: string | null;
+  assigned_lawyer_id?: string | null;
+  jurisdiction?: string | null;
+  nice_classes?: string | null;
+  filing_date?: string | null;
+  deadline?: string | null;
+  deadline_time?: string | null;
+}
+
+export interface UpdateCaseInput {
+  title?: string;
+  description?: string | null;
+  case_type?: CaseType;
+  status?: CaseStatus;
+  assigned_lawyer_id?: string | null;
+  jurisdiction?: string | null;
+  nice_classes?: string | null;
+  filing_date?: string | null;
+  deadline?: string | null;
+  deadline_time?: string | null;
+}
+
+export interface CaseDocument {
+  id: string;
+  case_id: string;
+  uploaded_by: string;
+  filename: string;
+  file_type: string | null;
+  file_size: number | null;
+  status: DocumentStatus;
+  document_type: string | null;
+  created_at: string;
+}
+
+export interface DocumentListResponse {
+  documents: CaseDocument[];
+  total: number;
+}
+
+export interface RenewalReminderRow {
+  window_days: number;
+  target_due_at: string;
+  sent_at: string;
+  channels: string[];
+}
+
+export interface RenewalStatus {
+  case_id: string;
+  renewal_due_at: string | null;
+  days_remaining: number | null;
+  is_overdue: boolean;
+  open_window: number | null;
+  reminders: RenewalReminderRow[];
+}
+
+export interface CalendarFeedStatus {
+  enabled: boolean;
+  url: string | null;
+}
+
+export type DataExportFormat = "json" | "pdf" | "docx" | "xlsx";
+
+export interface ListCasesParams {
+  skip?: number;
+  limit?: number;
+  status?: CaseStatus;
+}

--- a/packages/sdk-typescript/test/client.test.ts
+++ b/packages/sdk-typescript/test/client.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { EtornieClient, EtornieApiError, EtornieAuthError } from "../src/index.js";
+
+// Integration tests run against a real, running Etornie API. They are
+// credential-gated: set the env vars below to enable them. Without
+// credentials they are skipped (never mocked) so the suite stays green
+// in environments that cannot reach the API.
+const API_URL = process.env.ETORNIE_API_URL;
+const EMAIL = process.env.ETORNIE_TEST_EMAIL;
+const PASSWORD = process.env.ETORNIE_TEST_PASSWORD;
+const live = Boolean(API_URL && EMAIL && PASSWORD);
+
+describe("EtornieClient (unit)", () => {
+  it("requires a baseUrl", () => {
+    expect(() => new EtornieClient({ baseUrl: "" })).toThrow();
+  });
+
+  it("throws EtornieAuthError when calling an authed endpoint without a token", async () => {
+    const client = new EtornieClient({ baseUrl: "https://example.invalid" });
+    await expect(client.auth.me()).rejects.toBeInstanceOf(EtornieAuthError);
+  });
+
+  it("strips a trailing slash from baseUrl", () => {
+    const client = new EtornieClient({ baseUrl: "https://api.etornie.com/" });
+    expect(client.baseUrl).toBe("https://api.etornie.com");
+  });
+});
+
+describe.skipIf(!live)("EtornieClient (integration)", () => {
+  let client: EtornieClient;
+
+  beforeAll(async () => {
+    client = new EtornieClient({ baseUrl: API_URL! });
+    await client.auth.login(EMAIL!, PASSWORD!);
+  });
+
+  it("logs in and returns the current user", async () => {
+    const me = await client.auth.me();
+    expect(me.email).toBe(EMAIL);
+    expect(me.id).toBeTruthy();
+  });
+
+  it("lists cases", async () => {
+    const res = await client.cases.list({ limit: 5 });
+    expect(Array.isArray(res.cases)).toBe(true);
+    expect(typeof res.total).toBe("number");
+  });
+
+  it("manages the calendar feed", async (ctx) => {
+    let enabled;
+    try {
+      enabled = await client.calendar.enable();
+    } catch (err) {
+      if (err instanceof EtornieApiError && err.status === 404) {
+        ctx.skip(); // calendar feature not available on target API
+        return;
+      }
+      throw err;
+    }
+    expect(enabled.enabled).toBe(true);
+    expect(enabled.url).toContain("/calendar/feed/");
+    await client.calendar.disable();
+    const status = await client.calendar.status();
+    expect(status.enabled).toBe(false);
+  });
+});

--- a/packages/sdk-typescript/tsconfig.json
+++ b/packages/sdk-typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
Closes #71.

Hand-written, typed client libraries (grant deliverable) covering the core public resources: **auth, cases, documents, renewals, calendar, data export**. Bearer-token auth (login helper or pass a token).

## Changes
- `packages/sdk-typescript` (`@etornie/sdk`) — zero runtime deps (global `fetch`), `EtornieClient` with resource namespaces, typed models, `EtornieApiError`/`EtornieAuthError`, README, vitest tests, `examples/demo.ts`.
- `packages/sdk-python` (`etornie`) — `httpx`-based `EtornieClient`, frozen dataclass models, README, pytest tests, `examples/demo.py`.
- `docs/sdk/` index + **Developers: SDKs** section on the dashboard `/docs` page (install + quick-start for both).

## Verification
- Live against the running API for both SDKs: `login → me → cases.list → dataExport(json) → 404 error handling`.
- Python: `5 passed, 1 skipped` (calendar skipped where the feature isn't deployed). TS source `tsc --noEmit` clean.
- Tests credential-gated (`ETORNIE_API_URL/EMAIL/PASSWORD`); skipped, never mocked, when unset.

## Out of scope
- npm / PyPI publishing (package scaffolding ready; no publish performed).