### PR TITLE
feat(cases): bulk import cases from CSV / XML (#67) — merged with main

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,6 +17,13 @@ paths = [
   '''tests/zk_fixtures/.*''',
   '''.*\.example$''',
   '''.*\.env\.example$''',
+  # Public Groth16 verifying keys — cryptographic *public* data, not secrets.
+  # The generic-api-key / high-entropy rules trip on their long byte arrays.
+  # The vk_*.rs glob covers vk_compliance.rs + vk_file_ownership.rs (and any
+  # future verifying-key module).
+  '''programs/etornie-zk-verifier/src/groth16_vk\.rs''',
+  '''programs/etornie-zk-verifier/src/vk_.*\.rs''',
+  '''scripts/extract_vk\.js''',
 ]
 
 # Literal strings that appear in tests and docs but are not real secrets.

--- a/dashboard/src/app/dashboard/cases/page.tsx
+++ b/dashboard/src/app/dashboard/cases/page.tsx
@@ -72,6 +72,21 @@ interface CaseListResponse {
   total: number;
 }
 
+interface BulkImportRow {
+  row: number;
+  status: string;
+  case_id: string | null;
+  case_number: string | null;
+  error: string | null;
+}
+
+interface BulkImportReport {
+  total: number;
+  created: number;
+  failed: number;
+  results: BulkImportRow[];
+}
+
 const CASE_TYPES = ["trademark", "patent", "design", "copyright"];
 
 const NICE_CLASSES: ReadonlyArray<{ class_number: number; category: string; description: string }> = [
@@ -296,7 +311,32 @@ export default function CasesPage() {
   const [createLoading, setCreateLoading] = useState(false);
   const [createError, setCreateError] = useState("");
   const [createSuccess, setCreateSuccess] = useState("");
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [bulkError, setBulkError] = useState("");
+  const [bulkReport, setBulkReport] = useState<BulkImportReport | null>(null);
+  const [bulkDefaultType, setBulkDefaultType] = useState("");
+  const bulkFileRef = useRef<HTMLInputElement | null>(null);
   const { publicKey: walletPubkey, signTransaction } = useWallet();
+
+  async function handleBulkImport(file: File) {
+    setBulkBusy(true);
+    setBulkError("");
+    setBulkReport(null);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      if (bulkDefaultType) fd.append("default_case_type", bulkDefaultType);
+      const res = await api.post<BulkImportReport>("/cases/bulk-import", fd, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      setBulkReport(res.data);
+      if (res.data.created > 0) await fetchCases();
+    } catch (err) {
+      setBulkError(extractErrorMessage(err, "Bulk import failed."));
+    } finally {
+      setBulkBusy(false);
+    }
+  }
 
   async function fetchCases() {
     setLoading(true);
@@ -479,13 +519,85 @@ export default function CasesPage() {
         <h1 className="text-2xl font-bold text-gray-800">
           Cases ({total})
         </h1>
-        <button
-          onClick={() => setShowCreate(!showCreate)}
-          className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-        >
-          {showCreate ? "Cancel" : "New Case"}
-        </button>
+        <div className="flex items-center gap-2">
+          <input
+            ref={bulkFileRef}
+            type="file"
+            accept=".csv,.xml"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              e.target.value = "";
+              if (f) handleBulkImport(f);
+            }}
+          />
+          <select
+            value={bulkDefaultType}
+            onChange={(e) => setBulkDefaultType(e.target.value)}
+            title="Default type for rows whose file has no type column"
+            className="rounded border border-gray-300 bg-white px-2 py-2 text-sm text-gray-700"
+          >
+            <option value="">Type from file</option>
+            <option value="trademark">Default: Trademark</option>
+            <option value="patent">Default: Patent</option>
+            <option value="design">Default: Design</option>
+            <option value="copyright">Default: Copyright</option>
+          </select>
+          <button
+            onClick={() => bulkFileRef.current?.click()}
+            disabled={bulkBusy}
+            title="Bulk import cases from a CSV or XML file"
+            className="rounded border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {bulkBusy ? "Importing…" : "Bulk import"}
+          </button>
+          <button
+            onClick={() => setShowCreate(!showCreate)}
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            {showCreate ? "Cancel" : "New Case"}
+          </button>
+        </div>
       </div>
+
+      {bulkError && (
+        <div className="mb-4 rounded bg-red-50 p-3 text-sm text-red-700 border border-red-200">
+          {bulkError}
+        </div>
+      )}
+
+      {bulkReport && (
+        <div className="mb-4 rounded-lg border border-gray-200 bg-white p-4 text-sm shadow-sm">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="font-semibold text-gray-800">
+              Bulk import: {bulkReport.created} created, {bulkReport.failed}{" "}
+              failed (of {bulkReport.total})
+            </span>
+            <button
+              onClick={() => setBulkReport(null)}
+              className="text-xs text-gray-500 hover:text-gray-700"
+            >
+              Dismiss
+            </button>
+          </div>
+          <p className="mb-2 text-xs text-gray-500">
+            Columns: title*, case_type* (trademark/patent/design/copyright),
+            jurisdiction, nice_classes, filing_date, deadline, description,
+            client_email, client_name, client_wallet.
+          </p>
+          {bulkReport.failed > 0 && (
+            <ul className="space-y-0.5 text-xs text-red-700">
+              {bulkReport.results
+                .filter((r) => r.status === "failed")
+                .map((r) => (
+                  <li key={r.row}>
+                    Row {r.row}: {r.error}
+                  </li>
+                ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       {createSuccess && (
         <div className="mb-4 rounded bg-green-50 p-3 text-sm text-green-700 border border-green-200">

--- a/services/api/app/cases/bulk_import.py
+++ b/services/api/app/cases/bulk_import.py
@@ -1,0 +1,295 @@
+"""Bulk case import from CSV / XML (issue #67).
+
+Enterprise prospects arrive with hundreds of existing matters; this turns
+a CSV or XML export into cases in one upload. Parsing is tolerant
+(case-insensitive headers, BOM-safe) and XXE-safe (defusedxml). Each row
+is validated and created inside its own savepoint, so one bad row never
+sinks the rest — every row comes back in the report as created or failed
+with a reason.
+
+Recognised columns (CSV headers / XML <case> child tags or attributes):
+    title*          case title
+    case_type*      trademark | patent | design | copyright
+    jurisdiction    free text (e.g. "DE", "European Union")
+    nice_classes    comma-separated, e.g. "25,35"
+    filing_date     ISO date (YYYY-MM-DD)
+    deadline        ISO date (YYYY-MM-DD)
+    description     free text
+    client_email    links to a registered user; otherwise used as guest email
+    client_name     guest client name (when client_email is unregistered)
+    client_wallet   Solana pubkey to bind as the on-chain client
+(* required)
+"""
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.service import get_user_by_email
+from app.cases.models import CaseType
+from app.cases.service import create_case
+
+_VALID_CASE_TYPES = {t.value for t in CaseType}
+
+# Map many real-world column headers onto our canonical fields. Keys are
+# header names after lower-casing and collapsing ``_``/``-``/space to a
+# single space, so "Mark Text", "mark_text" and "mark-text" all match.
+# The canonical names map to themselves (e.g. "case type" -> case_type).
+_HEADER_ALIASES: dict[str, str] = {
+    # title
+    "title": "title", "name": "title", "mark": "title",
+    "mark text": "title", "mark name": "title", "trademark": "title",
+    "trade mark": "title", "trademark name": "title", "brand": "title",
+    "matter": "title", "matter name": "title", "case title": "title",
+    "case name": "title", "ip name": "title",
+    # case_type
+    "case type": "case_type", "type": "case_type", "ip type": "case_type",
+    "matter type": "case_type", "category": "case_type",
+    "rights type": "case_type", "right type": "case_type", "kind": "case_type",
+    # jurisdiction
+    "jurisdiction": "jurisdiction", "country": "jurisdiction",
+    "territory": "jurisdiction", "region": "jurisdiction",
+    "office": "jurisdiction", "country code": "jurisdiction",
+    "ipo": "jurisdiction",
+    # nice_classes
+    "nice classes": "nice_classes", "nice": "nice_classes",
+    "classes": "nice_classes", "class": "nice_classes",
+    "nice class": "nice_classes", "classification": "nice_classes",
+    # filing_date
+    "filing date": "filing_date", "filed": "filing_date",
+    "filing": "filing_date", "application date": "filing_date",
+    "date filed": "filing_date", "filed date": "filing_date",
+    # deadline
+    "deadline": "deadline", "due": "deadline", "due date": "deadline",
+    "renewal date": "deadline", "renewal": "deadline", "expiry": "deadline",
+    "expiration": "deadline", "next deadline": "deadline",
+    # description
+    "description": "description", "notes": "description", "note": "description",
+    "remarks": "description", "details": "description", "comment": "description",
+    "comments": "description",
+    # client_email
+    "client email": "client_email", "email": "client_email",
+    "owner email": "client_email", "applicant email": "client_email",
+    "contact email": "client_email", "e mail": "client_email",
+    # client_name
+    "client name": "client_name", "client": "client_name",
+    "owner": "client_name", "applicant": "client_name", "holder": "client_name",
+    "proprietor": "client_name", "owner name": "client_name",
+    "applicant name": "client_name", "company": "client_name",
+    # client_wallet
+    "client wallet": "client_wallet", "wallet": "client_wallet",
+    "wallet address": "client_wallet", "pubkey": "client_wallet",
+    "solana wallet": "client_wallet",
+}
+
+# Common case_type values seen in exports -> our enum value.
+_CASE_TYPE_ALIASES: dict[str, str] = {
+    "tm": "trademark", "trade mark": "trademark", "trademark": "trademark",
+    "mark": "trademark", "word mark": "trademark", "wordmark": "trademark",
+    "pat": "patent", "patent": "patent", "utility patent": "patent",
+    "design": "design", "registered design": "design", "design patent": "design",
+    "copyright": "copyright", "©": "copyright",
+}
+
+
+def _canon_header(key: Any) -> str | None:
+    k = str(key).strip().lower().replace("_", " ").replace("-", " ")
+    k = " ".join(k.split())
+    return _HEADER_ALIASES.get(k)
+
+
+class BulkImportParseError(ValueError):
+    """The uploaded file could not be parsed into rows."""
+
+
+@dataclass
+class RowResult:
+    row: int
+    status: str  # "created" | "failed"
+    case_id: str | None = None
+    case_number: str | None = None
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def _normalise(row: dict[str, Any]) -> dict[str, str]:
+    """Map known headers (incl. aliases) to canonical fields, strip
+    values, and drop unknown/empty columns."""
+    out: dict[str, str] = {}
+    for key, value in row.items():
+        if key is None:
+            continue
+        canon = _canon_header(key)
+        if canon is None:
+            continue
+        v = "" if value is None else str(value).strip()
+        if v and canon not in out:
+            out[canon] = v
+    return out
+
+
+def parse_csv(content: bytes) -> list[dict[str, str]]:
+    try:
+        text = content.decode("utf-8-sig")  # tolerate a BOM
+    except UnicodeDecodeError as exc:
+        raise BulkImportParseError(
+            "CSV is not valid UTF-8 text."
+        ) from exc
+    # Auto-detect the delimiter so European exports (semicolon) and
+    # tab/pipe-separated files parse without manual conversion.
+    try:
+        dialect = csv.Sniffer().sniff(text[:4096], delimiters=",;\t|")
+        delimiter = dialect.delimiter
+    except csv.Error:
+        delimiter = ","
+    reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+    if reader.fieldnames is None:
+        raise BulkImportParseError("CSV has no header row.")
+    return [_normalise(row) for row in reader]
+
+
+def parse_xml(content: bytes) -> list[dict[str, str]]:
+    from defusedxml.ElementTree import fromstring
+
+    try:
+        root = fromstring(content)
+    except Exception as exc:  # noqa: BLE001 — any parse failure is user error
+        raise BulkImportParseError(f"Invalid XML: {exc}") from exc
+
+    rows: list[dict[str, str]] = []
+    # Accept either a single <case> root, <case> elements anywhere under
+    # the root, or (as a fallback) the root's direct children.
+    if root.tag.lower() == "case":
+        elements = [root]
+    else:
+        elements = root.findall(".//case") or list(root)
+    for case_el in elements:
+        raw: dict[str, Any] = {}
+        for child in case_el:
+            raw[child.tag] = (child.text or "")
+        for attr_key, attr_val in case_el.attrib.items():
+            raw.setdefault(attr_key, attr_val)
+        rows.append(_normalise(raw))
+    return rows
+
+
+def parse_upload(filename: str, content: bytes) -> list[dict[str, str]]:
+    name = (filename or "").lower()
+    if name.endswith(".csv"):
+        return parse_csv(content)
+    if name.endswith(".xml"):
+        return parse_xml(content)
+    raise BulkImportParseError(
+        "Unsupported file type — upload a .csv or .xml file."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Row -> case
+# ---------------------------------------------------------------------------
+
+
+def _parse_date(value: str, field: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{field} '{value}' is not a valid ISO date (YYYY-MM-DD)."
+        ) from exc
+
+
+async def _row_to_kwargs(
+    db: AsyncSession,
+    row: dict[str, str],
+    default_case_type: str | None = None,
+) -> dict[str, Any]:
+    """Validate one row and build create_case kwargs (raises ValueError).
+
+    ``default_case_type`` applies to rows whose file carries no type
+    column (e.g. a trademark-only portfolio export).
+    """
+    title = row.get("title")
+    if not title:
+        raise ValueError("title is required.")
+
+    raw_type = (row.get("case_type") or default_case_type or "").strip().lower()
+    case_type = _CASE_TYPE_ALIASES.get(raw_type, raw_type)
+    if case_type not in _VALID_CASE_TYPES:
+        raise ValueError(
+            f"case_type must be one of {sorted(_VALID_CASE_TYPES)}; "
+            f"got '{row.get('case_type', '')}'. Tip: set a default type "
+            "for the whole file if it has no type column."
+        )
+
+    kwargs: dict[str, Any] = {
+        "title": title,
+        "case_type": CaseType(case_type),
+        "description": row.get("description"),
+        "jurisdiction": row.get("jurisdiction"),
+        "nice_classes": row.get("nice_classes"),
+    }
+    if "filing_date" in row:
+        kwargs["filing_date"] = _parse_date(row["filing_date"], "filing_date")
+    if "deadline" in row:
+        kwargs["deadline"] = _parse_date(row["deadline"], "deadline")
+
+    # Client resolution: a registered email links the case to that user;
+    # an unregistered email becomes a guest contact; a wallet binds the
+    # on-chain client. All optional — an unassigned imported matter is
+    # valid and can be assigned later.
+    client_email = row.get("client_email")
+    if client_email:
+        user = await get_user_by_email(db, client_email)
+        if user is not None:
+            kwargs["client_id"] = user.id
+        else:
+            kwargs["guest_client_email"] = client_email
+            kwargs["guest_client_name"] = row.get("client_name") or client_email
+    elif row.get("client_name"):
+        kwargs["guest_client_name"] = row["client_name"]
+    if row.get("client_wallet"):
+        kwargs["client_wallet"] = row["client_wallet"]
+
+    return kwargs
+
+
+async def import_cases(
+    db: AsyncSession,
+    rows: list[dict[str, str]],
+    default_case_type: str | None = None,
+) -> list[RowResult]:
+    """Create a case per row inside a savepoint; report each outcome.
+
+    Row numbering is 1-based and counts data rows (the CSV header is not
+    a row). A failing row is rolled back to its savepoint and recorded;
+    successful rows persist when the caller commits. ``default_case_type``
+    fills in rows whose file has no type column.
+    """
+    results: list[RowResult] = []
+    for index, row in enumerate(rows, start=1):
+        try:
+            kwargs = await _row_to_kwargs(db, row, default_case_type)
+            async with db.begin_nested():
+                case = await create_case(db, **kwargs)
+            results.append(
+                RowResult(
+                    row=index,
+                    status="created",
+                    case_id=str(case.id),
+                    case_number=case.case_number,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — per-row isolation
+            results.append(
+                RowResult(row=index, status="failed", error=str(exc))
+            )
+    return results

--- a/services/api/app/cases/router.py
+++ b/services/api/app/cases/router.py
@@ -2,7 +2,15 @@ import base64
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import (
+    APIRouter,
+    Depends,
+    Form,
+    HTTPException,
+    Query,
+    UploadFile,
+    status,
+)
 from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,6 +24,8 @@ from app.cases.schemas import (
     CaseCreateResponse,
     CaseEventResponse,
     CaseListResponse,
+    BulkImportResponse,
+    BulkImportRowResult,
     CaseNoteCreate,
     CaseNoteResponse,
     CaseResponse,
@@ -201,6 +211,79 @@ async def create_case_endpoint(
     return CaseCreateResponse(
         case=CaseResponse.model_validate(case),
         attestation=attestation_payload,
+    )
+
+
+_BULK_IMPORT_MAX_ROWS = 1000
+
+
+@router.post(
+    "/bulk-import",
+    response_model=BulkImportResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def bulk_import_cases_endpoint(
+    file: UploadFile,
+    default_case_type: str | None = Form(default=None),
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_role(UserRole.admin)),
+) -> BulkImportResponse:
+    """Bulk-create cases from an uploaded CSV or XML file (admin only).
+
+    Each data row is validated and created in its own savepoint, so a
+    bad row is reported without aborting the import. ``default_case_type``
+    is applied to rows whose file has no type column. Returns a per-row
+    report.
+    """
+    from app.cases.bulk_import import (
+        BulkImportParseError,
+        import_cases,
+        parse_upload,
+    )
+
+    content = await file.read()
+    if not content:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Empty file."
+        )
+    try:
+        rows = parse_upload(file.filename or "", content)
+    except BulkImportParseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        )
+    if not rows:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No data rows found in the file.",
+        )
+    if len(rows) > _BULK_IMPORT_MAX_ROWS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Too many rows ({len(rows)}); the limit is "
+                f"{_BULK_IMPORT_MAX_ROWS} per import."
+            ),
+        )
+
+    results = await import_cases(
+        db, rows, default_case_type=default_case_type or None
+    )
+    created = sum(1 for r in results if r.status == "created")
+    return BulkImportResponse(
+        total=len(results),
+        created=created,
+        failed=len(results) - created,
+        results=[
+            BulkImportRowResult(
+                row=r.row,
+                status=r.status,
+                case_id=r.case_id,
+                case_number=r.case_number,
+                error=r.error,
+            )
+            for r in results
+        ],
     )
 
 

--- a/services/api/app/cases/schemas.py
+++ b/services/api/app/cases/schemas.py
@@ -43,6 +43,21 @@ class CaseCreate(BaseModel):
         raise ValueError(msg)
 
 
+class BulkImportRowResult(BaseModel):
+    row: int = Field(..., description="1-based data-row number.")
+    status: str = Field(..., description="'created' or 'failed'.")
+    case_id: uuid.UUID | None = None
+    case_number: str | None = None
+    error: str | None = None
+
+
+class BulkImportResponse(BaseModel):
+    total: int
+    created: int
+    failed: int
+    results: list[BulkImportRowResult]
+
+
 class CaseUpdate(BaseModel):
     title: str | None = Field(default=None, min_length=1, max_length=500)
     description: str | None = None

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "openpyxl>=3.1.0",
     "stripe>=11.0.0",
     "sentry-sdk[fastapi]>=2.0.0",
+    # XXE-safe XML parsing for bulk case import — issue #67.
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/services/api/tests/test_bulk_import.py
+++ b/services/api/tests/test_bulk_import.py
@@ -1,0 +1,246 @@
+"""Tests for bulk case import from CSV / XML (issue #67).
+
+Real DB, no mocks: rows are parsed from real CSV/XML bytes and created
+through the real create_case pipeline; per-row failures are asserted on
+actual report output.
+"""
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cases.bulk_import import (
+    BulkImportParseError,
+    import_cases,
+    parse_csv,
+    parse_xml,
+    parse_upload,
+)
+from app.cases.models import Case
+from app.users.models import User
+from tests.conftest import auth_headers
+
+
+class TestParsing:
+    def test_csv_headers_normalised_and_bom_safe(self) -> None:
+        content = "﻿title,Case_Type,jurisdiction\nMy Mark,trademark,DE\n"
+        rows = parse_csv(content.encode("utf-8"))
+        assert rows == [
+            {"title": "My Mark", "case_type": "trademark", "jurisdiction": "DE"}
+        ]
+
+    def test_csv_drops_empty_and_unknown_columns(self) -> None:
+        rows = parse_csv(b"title,case_type,bogus\nA,patent,\n")
+        assert rows == [{"title": "A", "case_type": "patent"}]
+
+    def test_xml_child_tags_and_attributes(self) -> None:
+        xml = (
+            b"<cases>"
+            b"<case><title>X</title><case_type>patent</case_type></case>"
+            b'<case title="Y" case_type="design"/>'
+            b"</cases>"
+        )
+        rows = parse_xml(xml)
+        assert {"title": "X", "case_type": "patent"} in rows
+        assert {"title": "Y", "case_type": "design"} in rows
+
+    def test_xml_rejects_xxe(self) -> None:
+        # External-entity (XXE) payload must be refused, not resolved.
+        xxe = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]>'
+            b"<cases><case><title>&x;</title>"
+            b"<case_type>patent</case_type></case></cases>"
+        )
+        with pytest.raises(BulkImportParseError):
+            parse_xml(xxe)
+
+    def test_parse_upload_rejects_unknown_extension(self) -> None:
+        with pytest.raises(BulkImportParseError):
+            parse_upload("portfolio.txt", b"whatever")
+
+    def test_header_aliases_map_to_canonical(self) -> None:
+        # Real-world headers: Mark/Type/Country/Classes/Owner.
+        rows = parse_csv(
+            b"Mark,Type,Country,Classes,Owner\n"
+            b"Acme,Trade Mark,DE,25,Acme GmbH\n"
+        )
+        assert rows == [
+            {
+                "title": "Acme",
+                "case_type": "Trade Mark",
+                "jurisdiction": "DE",
+                "nice_classes": "25",
+                "client_name": "Acme GmbH",
+            }
+        ]
+
+    def test_semicolon_with_aliases(self) -> None:
+        rows = parse_csv(
+            "Trademark Name;Matter Type;Territory\nBrand;TM;FR\n".encode()
+        )
+        assert rows == [
+            {"title": "Brand", "case_type": "TM", "jurisdiction": "FR"}
+        ]
+
+
+class TestImportCases:
+    async def test_creates_good_rows_and_reports_bad(
+        self, db_session: AsyncSession
+    ) -> None:
+        rows = parse_csv(
+            b"title,case_type,jurisdiction\n"
+            b"Alpha Mark,trademark,DE\n"
+            b"Beta Patent,patent,EU\n"
+            b"Broken,notatype,EU\n"          # invalid case_type
+            b",trademark,EU\n"               # missing title
+        )
+        results = await import_cases(db_session, rows)
+        assert [r.status for r in results] == [
+            "created",
+            "created",
+            "failed",
+            "failed",
+        ]
+        assert results[0].case_number
+        assert "case_type" in (results[2].error or "")
+        assert "title" in (results[3].error or "")
+
+        # The two good cases really exist.
+        created_ids = [
+            uuid.UUID(r.case_id) for r in results if r.status == "created"
+        ]
+        found = (
+            await db_session.execute(
+                select(Case).where(Case.id.in_(created_ids))
+            )
+        ).scalars().all()
+        assert len(found) == 2
+
+    async def test_client_email_links_registered_user(
+        self, db_session: AsyncSession, client_user: User
+    ) -> None:
+        rows = parse_csv(
+            (
+                "title,case_type,client_email\n"
+                f"Linked,trademark,{client_user.email}\n"
+                "Guesty,patent,nobody@nowhere.test\n"
+            ).encode("utf-8")
+        )
+        results = await import_cases(db_session, rows)
+        assert all(r.status == "created" for r in results)
+
+        linked = (
+            await db_session.execute(
+                select(Case).where(Case.id == uuid.UUID(results[0].case_id))
+            )
+        ).scalar_one()
+        assert linked.client_id == client_user.id
+
+        guest = (
+            await db_session.execute(
+                select(Case).where(Case.id == uuid.UUID(results[1].case_id))
+            )
+        ).scalar_one()
+        assert guest.client_id is None
+        assert guest.guest_client_email == "nobody@nowhere.test"
+
+    async def test_aliased_headers_and_case_type_values_import(
+        self, db_session: AsyncSession
+    ) -> None:
+        # Headers and case_type values both use real-world variants.
+        rows = parse_csv(
+            b"Mark,Type,Country\n"
+            b"Aliased Mark,Trade Mark,DE\n"
+            b"Aliased Pat,pat,EU\n"
+        )
+        results = await import_cases(db_session, rows)
+        assert [r.status for r in results] == ["created", "created"]
+
+    async def test_default_case_type_for_files_without_a_type_column(
+        self, db_session: AsyncSession
+    ) -> None:
+        # A trademark-portfolio export with no type column: default fills.
+        rows = parse_csv(b"Mark,Country\nAcme Brand,DE\nBeta Brand,FR\n")
+        results = await import_cases(
+            db_session, rows, default_case_type="trademark"
+        )
+        assert [r.status for r in results] == ["created", "created"]
+
+    async def test_no_type_and_no_default_fails(
+        self, db_session: AsyncSession
+    ) -> None:
+        rows = parse_csv(b"Mark,Country\nAcme Brand,DE\n")
+        results = await import_cases(db_session, rows)
+        assert results[0].status == "failed"
+        assert "case_type" in (results[0].error or "")
+
+    async def test_bad_row_does_not_block_following_rows(
+        self, db_session: AsyncSession
+    ) -> None:
+        rows = parse_csv(
+            b"title,case_type\nBad,bogus\nGood,design\n"
+        )
+        results = await import_cases(db_session, rows)
+        assert results[0].status == "failed"
+        assert results[1].status == "created"
+
+
+class TestBulkImportEndpoint:
+    async def test_requires_admin(
+        self, client: AsyncClient, client_user: User
+    ) -> None:
+        resp = await client.post(
+            "/cases/bulk-import",
+            files={"file": ("p.csv", b"title,case_type\nA,trademark\n", "text/csv")},
+            headers=auth_headers(client_user),
+        )
+        assert resp.status_code == 403
+
+    async def test_requires_auth(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/cases/bulk-import",
+            files={"file": ("p.csv", b"title,case_type\nA,trademark\n", "text/csv")},
+        )
+        assert resp.status_code == 401
+
+    async def test_csv_import_report(
+        self, client: AsyncClient, admin_user: User
+    ) -> None:
+        csv_bytes = (
+            b"title,case_type,jurisdiction\n"
+            b"Endpoint Mark,trademark,DE\n"
+            b"Nope,invalidtype,EU\n"
+        )
+        resp = await client.post(
+            "/cases/bulk-import",
+            files={"file": ("portfolio.csv", csv_bytes, "text/csv")},
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total"] == 2
+        assert body["created"] == 1
+        assert body["failed"] == 1
+
+    async def test_empty_file_rejected(
+        self, client: AsyncClient, admin_user: User
+    ) -> None:
+        resp = await client.post(
+            "/cases/bulk-import",
+            files={"file": ("p.csv", b"", "text/csv")},
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 400
+
+    async def test_unsupported_type_rejected(
+        self, client: AsyncClient, admin_user: User
+    ) -> None:
+        resp = await client.post(
+            "/cases/bulk-import",
+            files={"file": ("p.txt", b"title,case_type\nA,trademark\n", "text/plain")},
+            headers=auth_headers(admin_user),
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
Supersedes #130 — same bulk-import feature, with the now-stale `main` conflicts resolved so it merges cleanly.

#130's branch had diverged from `main` (case templates #65 touched the same `cases/page.tsx` regions; the dependency list and the lint config moved). Because the feature branch can't be pushed to from this environment, this PR carries #130's work merged onto current `main` from the session branch.

## What's included (unchanged from #130)
- `POST /cases/bulk-import` — admin CSV/XML importer (XXE-safe `defusedxml`, delimiter sniffing, header aliases, per-row savepoint isolation, 1000-row cap).
- Cases page: **Bulk import** button + default-type dropdown + per-row result panel.

## Conflict resolution
- `cases/page.tsx`: kept the #65 `CaseTemplateOption` interface + template state/`useEffect` byte-identical to `main`; the bulk-import interfaces, state and handler were relocated to distinct anchors so nothing is lost from either side.
- `pyproject.toml`: kept `main`'s deps (icalendar/web3/py-solc-x/eth-account) and re-homed `defusedxml`.
- Backend `router.py` / `schemas.py` auto-merged.

Once green, #130 can be closed in favour of this PR.

https://claude.ai/code/session_01RDwY6JpJSKRwDQD8u89oSC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDwY6JpJSKRwDQD8u89oSC)_