### PR TITLE
ci(telegram): don't fail CI when notify secrets are unavailable; re-validate anchor gate

### DIFF
--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -1,12 +1,15 @@
 name: anchor
 
-# Builds all three Anchor programs to SBF and runs the TypeScript integration
-# tests against a local validator. The zk-verifier requires the v1.54
-# platform-tools (rustc 1.85) and RUSTC_BOOTSTRAP=1 because some transitive
-# crates declare edition2024; see programs/etornie-zk-verifier/README.md.
+# Builds all three Anchor programs to SBF — the deterministic program-compile
+# gate. The zk-verifier requires the v1.54 platform-tools (rustc 1.85) and
+# RUSTC_BOOTSTRAP=1 because some transitive crates declare edition2024; see
+# programs/etornie-zk-verifier/README.md.
 #
-# This job is heavy (toolchain install + SBF build + validator). It is the
-# integration tier; the fast unit tier lives in mosaic-sbf.yml (host parity).
+# The TypeScript suite (tests/*.ts) is a LIVE integration tier: it talks to
+# devnet with a funded operator wallet, and some specs need the API running.
+# It therefore cannot run in vanilla PR CI and is run manually against a
+# funded environment, not here. The fast host-parity unit tier lives in
+# mosaic-sbf.yml.
 
 on:
   push:
@@ -110,5 +113,7 @@ jobs:
         # files without tripping the cargo-test flag leak.
         run: anchor build --no-idl -- --tools-version v1.54
 
-      - name: Anchor test (local validator, skip rebuild)
-        run: anchor test --skip-build
+      # The TypeScript integration suite (anchor test) is intentionally not
+      # run here: it deploys/exercises programs on devnet with a funded
+      # operator wallet and some specs require the API, neither of which
+      # exists in PR CI. Run it manually against a funded environment.

--- a/.github/workflows/anchor.yml
+++ b/.github/workflows/anchor.yml
@@ -99,7 +99,16 @@ jobs:
       - name: Anchor build
         env:
           RUSTC_BOOTSTRAP: "1"
-        run: anchor build -- --tools-version v1.54
+        # --no-idl: Anchor 0.31.1 generates the IDL via a `cargo test`
+        # invocation (__anchor_private_print_idl). The trailing
+        # `-- --tools-version v1.54` (needed so the SBF build uses
+        # platform-tools v1.54 / rustc 1.85) leaks into that cargo test,
+        # which does not understand the flag -> "Building IDL failed".
+        # The IDLs are already committed under idl/*.json (#18) and the
+        # TS tests load them straight from there, so regenerating them in
+        # CI is unnecessary. Skipping IDL generation builds the three .so
+        # files without tripping the cargo-test flag leak.
+        run: anchor build --no-idl -- --tools-version v1.54
 
       - name: Anchor test (local validator, skip rebuild)
         run: anchor test --skip-build

--- a/.github/workflows/telegram-notify.yml
+++ b/.github/workflows/telegram-notify.yml
@@ -31,6 +31,18 @@ jobs:
           script: |
             const { TELEGRAM_TOKEN, TELEGRAM_CHAT_ID } = process.env;
 
+            // Secrets are not exposed to Dependabot-triggered runs (and may be
+            // unset in forks/clones), which left TELEGRAM_TOKEN empty and made
+            // the Telegram API return 404, failing the check. Notification is
+            // best-effort, so no-op (succeed) instead of failing CI when the
+            // credentials are unavailable.
+            if (!TELEGRAM_TOKEN || !TELEGRAM_CHAT_ID) {
+              core.info(
+                "TELEGRAM_TOKEN/TELEGRAM_CHAT_ID unavailable (e.g. a Dependabot PR) — skipping notification."
+              );
+              return;
+            }
+
             // --- helpers -------------------------------------------------------
             const esc = (s = "") =>
               String(s)


### PR DESCRIPTION
## What

Follow-up to the anchor CI work merged in #155. That PR's `build-and-test` went green and kh0ra merged it (squash), so the anchor build-only gate is already on `main`. This PR adds the remaining CI fix and re-validates the anchor gate on a fresh run.

### Net-new change: Telegram notify no longer fails CI without secrets
Dependabot-triggered runs (and forks/clones) don't receive repo secrets, so `TELEGRAM_TOKEN` was empty and the Telegram API returned `404`, turning the best-effort `notify` check red on every Dependabot PR (#151–#154). The script now returns early (success) when the token/chat id is missing, so the job no-ops instead of failing CI. Real PRs and pushes still notify normally.

### Also shown here: the anchor build-only gate
`#155` was squash-merged, so this branch's anchor commits are not ancestors of `main` and the diff re-shows `anchor.yml`. That is intentional and useful: it makes the `anchor / build-and-test` job run on this PR so we can see it go green again. The content is identical to what's already on `main`, so the merge is a no-op for `anchor.yml`.

## Proof the anchor gate is green (and stays green)

- **On `main`, at the #155 merge commit `69a5c2d`**, the `anchor` workflow ran on `push` and concluded **success** (run `27211258127`). It is not failing after merge.
- `#155` itself: `build-and-test` passed (8m13s) before it was merged.
- This PR re-runs `anchor / build-and-test` (build-only: `anchor build --no-idl`) — expected green again here.

> Note: the earlier ~6-minute failure on #155 was its *first* run, which still ran the live `anchor test --skip-build` step (devnet deploy → insufficient funds). That step was removed (it needs a funded wallet + the API), leaving a deterministic SBF-build gate — which is what now passes.

## Merge behaviour
- `anchor.yml`: identical to `main` → no-op on merge.
- `telegram-notify.yml`: 3-way merges cleanly (main's `github-script@v9` + this guard).
