### PR TITLE
feat(api): partner Q&A API + EtornieGPT answer-quality fixes

### DIFF
--- a/services/api/alembic/versions/d7f3a9c1e4b2_add_api_keys_table.py
+++ b/services/api/alembic/versions/d7f3a9c1e4b2_add_api_keys_table.py
@@ -1,0 +1,57 @@
+"""add api_keys table for the public partner Q&A API
+
+Stores partner API keys (SHA-256 hash only) for the answer-only public
+chat endpoint. No plaintext is persisted.
+
+Revision ID: d7f3a9c1e4b2
+Revises: a1f4e8c0b2d6
+Create Date: 2026-06-09
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "d7f3a9c1e4b2"
+down_revision = "a1f4e8c0b2d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("key_hash", sa.String(length=64), nullable=False),
+        sa.Column("label", sa.String(length=255), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "rate_limit_per_minute",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("60"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_api_keys")),
+    )
+    op.create_index(
+        op.f("ix_api_keys_key_hash"),
+        "api_keys",
+        ["key_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_api_keys_key_hash"), table_name="api_keys")
+    op.drop_table("api_keys")

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -81,6 +81,11 @@ class Settings(BaseSettings):
     # Auxiliary model for cheap one-shot tasks like session title
     # generation. Non-reasoning, serverless on Together.
     together_title_model: str = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+    # EtornieGPT Q&A assistant (the country-aware IP-law chat + the public
+    # partner /api/v1/chat). Moved off openai/gpt-oss-20b, which intermittently
+    # returned empty content and leaks harmony scratchpad text on Together's
+    # serving; Llama-3.3-70B-Turbo matches the agent and answers reliably.
+    together_etorniegpt_model: str = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
 
     # WhatsApp Business API
     whatsapp_api_token: str = ""

--- a/services/api/app/etorniegpt/service.py
+++ b/services/api/app/etorniegpt/service.py
@@ -1,48 +1,79 @@
 """EtornieGPT service: country-aware IP law assistant powered by Together AI."""
 
+import logging
 import re
 
 from together import Together
 
 from app.config import settings
+from app.errors import ErrorCategory, UserFacingError
 from app.etorniegpt.countries import (
     detect_country_from_question,
     format_country_context,
     _normalize,
     _ALIASES,
+    _IGNORE_TERMS,
 )
 
 SYSTEM_PROMPT = (
-    "You are EtornieGPT, an AI assistant for an IP (intellectual property) management "
-    "platform. You only provide expert support on trademark registration, patents, "
-    "design registration, copyright, country-specific application processes, and Nice "
-    "classification. You do not answer questions outside these areas. Provide short and "
-    "clear answers, do not use emojis, do not fabricate information, and respond in the "
-    "same language the question is asked in. If you do not have the information, say "
-    "'I do not have this information', never fabricate."
+    "You are EtornieGPT, the AI assistant of Etornie - a platform that "
+    "classifies, prepares, files and tracks intellectual-property rights "
+    "(trademarks, patents, designs, copyright) for its users.\n\n"
+    "Scope: only answer IP topics - registration/filing, copyright, Nice "
+    "classification, country-specific procedures, and how Etornie's own "
+    "process works. Politely decline anything outside IP.\n\n"
+    "Etornie does the work for the user - guide the user through Etornie, "
+    "not national offices:\n"
+    "- Etornie's AI agent prepares and submits the application to the "
+    "relevant IP office (e.g. EUIPO) on the user's behalf; the user does not "
+    "file at the national office themselves.\n"
+    "- Help pick the correct Nice class(es) and goods/services, list the "
+    "required documents, and explain each step of the Etornie flow: open a "
+    "case, classify, prepare the application, pay inside Etornie (by card via "
+    "Stripe, or with crypto via Solana), the agent files it, track the "
+    "status, and get on-chain proof of the filing on Solana.\n"
+    "- When asked 'how do I register/file', explain the process and direct "
+    "the user to do it through Etornie; do not present going to the national "
+    "office directly as the primary route.\n\n"
+    "Accuracy: never fabricate. For exact fees, timelines or amounts, do not "
+    "invent numbers - say they are shown in the user's Etornie case or "
+    "checkout. If you do not have the information, say 'I do not have this "
+    "information'.\n\n"
+    "Style: clear and concise, no emojis, and always reply in the same "
+    "language the question is asked in."
 )
 
-MODEL = "openai/gpt-oss-20b"
+logger = logging.getLogger(__name__)
 
-# Known country name patterns to detect "country mentioned but not in DB"
-_COUNTRY_INDICATORS = [
-    " in ", " of ",
-    " about ", " regarding ",
-    "country", "jurisdiction",
-]
+MODEL = settings.together_etorniegpt_model
+
+# A locative preposition immediately followed by a capitalised proper noun
+# ("in Turkey", "of Brazil", "about Chile") is the signal that the user is
+# asking about a specific place. Matched on word boundaries against the
+# original (case-bearing) text.
+_PLACE_CONTEXT_RE = re.compile(
+    r"\b(?:[Ii]n|[Oo]f|[Aa]bout|[Rr]egarding)\s+(?:the\s+)?([A-Z][A-Za-z]+)"
+)
 
 
 def _question_mentions_unknown_country(question: str) -> bool:
-    """Check if question likely asks about a specific country not in our DB."""
-    normalized = _normalize(question)
+    """True when the question targets a specific named place we cannot resolve.
 
-    # If detect_country found something, it's not unknown
-    # This function is only called when detect returns None
-    # Check if there are country-like patterns
-    for indicator in _COUNTRY_INDICATORS:
-        if indicator in question.lower() or _normalize(indicator) in normalized:
+    Only reached when ``detect_country_from_question`` already failed, so a
+    capitalised proper noun after a locative preposition is a country /
+    jurisdiction we have no verified data for (e.g. "...registration in
+    Turkey?").
+
+    Crucially this matches whole words: ordinary words like "international",
+    "software" or "single" never trigger it. The previous implementation
+    substring-matched the "in"/"of" *inside* those words and wrongly returned
+    the "no data" canned answer for almost every general question. Known IP
+    terms / organisations (Madrid, Nice, WIPO, ...) are excluded.
+    """
+    for match in _PLACE_CONTEXT_RE.finditer(question):
+        candidate = _normalize(match.group(1))
+        if candidate and candidate not in _IGNORE_TERMS:
             return True
-
     return False
 
 
@@ -98,14 +129,36 @@ async def ask_etorniegpt(question: str, language: str = "tr") -> dict:
 
     client = Together(api_key=settings.together_api_key)
 
-    response = client.chat.completions.create(
-        model=MODEL,
-        messages=messages,
-        max_tokens=1024,
-        temperature=0.3,
-    )
+    # Any upstream model failure (credit/rate limit, timeout, 5xx, bad
+    # config) is surfaced as a clean 502 via UserFacingError instead of a
+    # raw 500, so callers — the chat UI and the partner /api/v1/chat — get a
+    # friendly message they can show and retry on.
+    try:
+        response = client.chat.completions.create(
+            model=MODEL,
+            messages=messages,
+            max_tokens=1024,
+            temperature=0.3,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface every upstream failure cleanly
+        logger.error("EtornieGPT model call failed (model=%s): %s", MODEL, exc)
+        raise UserFacingError(
+            "The assistant is temporarily unavailable. Please try again in a moment.",
+            technical_detail=f"{type(exc).__name__}: {exc}",
+            category=ErrorCategory.unknown,
+            http_status=502,
+        ) from exc
 
-    answer = response.choices[0].message.content or ""
+    answer = (response.choices[0].message.content or "").strip()
+    if not answer:
+        logger.warning("EtornieGPT returned an empty completion (model=%s)", MODEL)
+        raise UserFacingError(
+            "The assistant could not generate an answer. Please rephrase your "
+            "question and try again.",
+            technical_detail="empty completion content",
+            category=ErrorCategory.unknown,
+            http_status=502,
+        )
 
     return {
         "answer": answer,

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -34,6 +34,7 @@ from app.notifications.router import router as notifications_router
 from app.organizations.router import router as organizations_router
 from app.payments.router import router as payments_router
 from app.proposals.router import router as proposals_router
+from app.public_api.router import router as public_api_router
 from app.renewals.router import router as renewals_router
 from app.required_documents.router import router as required_documents_router
 from app.services.euipo.router import router as euipo_router
@@ -134,6 +135,7 @@ app.include_router(braid_router)
 app.include_router(braid_admin_router)
 app.include_router(agent_router)
 app.include_router(payments_router)
+app.include_router(public_api_router)
 app.include_router(renewals_router)
 app.include_router(organizations_router)
 app.include_router(admin_router)

--- a/services/api/app/public_api/__init__.py
+++ b/services/api/app/public_api/__init__.py
@@ -1,0 +1,7 @@
+"""Public partner API — answer-only Q&A surface over EtornieGPT.
+
+A trusted external platform (same Etornie product family) reaches our more
+advanced EtornieGPT here, server-to-server, for question/answer only. There
+are no agent actions (no filings, attestations, payments) and no x402 — just
+ask a question, get an answer. Access is gated by an API key, not a user JWT.
+"""

--- a/services/api/app/public_api/models.py
+++ b/services/api/app/public_api/models.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class ApiKey(Base):
+    """A partner API key for the answer-only public Q&A endpoint.
+
+    Only the SHA-256 hash of the key is stored; the plaintext is shown once
+    at creation and never persisted. ``rate_limit_per_minute`` is enforced
+    per key (see app/public_api/security.py).
+    """
+
+    __tablename__ = "api_keys"
+
+    # ``id`` (uuid PK) comes from Base.
+
+    key_hash: Mapped[str] = mapped_column(
+        String(64), unique=True, index=True, nullable=False
+    )
+    label: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+    rate_limit_per_minute: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=60, server_default="60"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/services/api/app/public_api/router.py
+++ b/services/api/app/public_api/router.py
@@ -1,0 +1,104 @@
+"""Public partner Q&A API.
+
+``POST /api/v1/chat`` is answer-only: it forwards the question to
+EtornieGPT and returns the answer. No agent actions (filings, attestations,
+payments) are reachable here, and there is no x402 — it is a plain
+question/answer surface for trusted partner platforms, authenticated by an
+API key.
+
+Key lifecycle (mint / list / revoke) lives under ``/admin/api-keys`` and is
+restricted to admin users.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import require_role
+from app.database import get_db
+from app.etorniegpt.service import ask_etorniegpt
+from app.public_api.models import ApiKey
+from app.public_api.schemas import (
+    ApiKeyCreatedResponse,
+    ApiKeyInfo,
+    CreateApiKeyRequest,
+    PublicChatRequest,
+    PublicChatResponse,
+)
+from app.public_api.security import generate_api_key, require_api_key
+from app.users.models import User, UserRole
+
+router = APIRouter(tags=["public-api"])
+
+
+@router.post("/api/v1/chat", response_model=PublicChatResponse)
+async def public_chat(
+    data: PublicChatRequest,
+    api_key: ApiKey = Depends(require_api_key),
+) -> PublicChatResponse:
+    """Answer a question via EtornieGPT (answer-only, no actions, no payment)."""
+    result = await ask_etorniegpt(data.question, language=data.language)
+    return PublicChatResponse(
+        answer=result["answer"],
+        country_detected=result.get("country_detected"),
+        model=result["model"],
+    )
+
+
+@router.post(
+    "/admin/api-keys",
+    response_model=ApiKeyCreatedResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_api_key(
+    data: CreateApiKeyRequest,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.admin)),
+) -> ApiKeyCreatedResponse:
+    """Mint a partner API key. The plaintext is returned only in this response."""
+    raw_key, key_hash = generate_api_key()
+    api_key = ApiKey(
+        key_hash=key_hash,
+        label=data.label,
+        rate_limit_per_minute=data.rate_limit_per_minute,
+    )
+    db.add(api_key)
+    await db.flush()
+    await db.refresh(api_key)
+    return ApiKeyCreatedResponse(
+        id=api_key.id,
+        label=api_key.label,
+        api_key=raw_key,
+        rate_limit_per_minute=api_key.rate_limit_per_minute,
+    )
+
+
+@router.get("/admin/api-keys", response_model=list[ApiKeyInfo])
+async def list_api_keys(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.admin)),
+) -> list[ApiKey]:
+    """List all partner keys (never exposes the plaintext or the hash)."""
+    rows = await db.scalars(select(ApiKey).order_by(ApiKey.created_at.desc()))
+    return list(rows)
+
+
+@router.delete(
+    "/admin/api-keys/{key_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def revoke_api_key(
+    key_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_role(UserRole.admin)),
+) -> Response:
+    """Revoke a key (soft delete — sets is_active=false so it stops working)."""
+    api_key = await db.get(ApiKey, key_id)
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="API key not found"
+        )
+    api_key.is_active = False
+    await db.flush()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/services/api/app/public_api/schemas.py
+++ b/services/api/app/public_api/schemas.py
@@ -1,0 +1,41 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class PublicChatRequest(BaseModel):
+    question: str = Field(min_length=1, max_length=4000)
+    language: str = Field(default="tr", max_length=8)
+
+
+class PublicChatResponse(BaseModel):
+    answer: str
+    country_detected: str | None = None
+    model: str
+
+
+class CreateApiKeyRequest(BaseModel):
+    label: str = Field(min_length=1, max_length=255)
+    rate_limit_per_minute: int = Field(default=60, ge=1, le=10000)
+
+
+class ApiKeyCreatedResponse(BaseModel):
+    """Returned once at creation — ``api_key`` is the only time the plaintext
+    is exposed."""
+
+    id: uuid.UUID
+    label: str
+    api_key: str
+    rate_limit_per_minute: int
+
+
+class ApiKeyInfo(BaseModel):
+    id: uuid.UUID
+    label: str
+    is_active: bool
+    rate_limit_per_minute: int
+    created_at: datetime
+    last_used_at: datetime | None = None
+
+    model_config = {"from_attributes": True}

--- a/services/api/app/public_api/security.py
+++ b/services/api/app/public_api/security.py
@@ -1,0 +1,113 @@
+"""API-key authentication + per-key rate limiting for the public Q&A API.
+
+Keys are random tokens prefixed ``etk_``; only their SHA-256 hash is stored.
+Rate limiting is a fixed 60-second window counter in Redis, keyed by the
+key's id. The limiter fails open (allows the request) if Redis is
+unreachable — a notification/quota control must not take the API down.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timezone
+
+import redis
+from fastapi import Depends, HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import get_db
+from app.public_api.models import ApiKey
+
+logger = logging.getLogger(__name__)
+
+API_KEY_PREFIX = "etk_"
+_API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+_redis: redis.Redis | None = None
+
+
+def _get_redis() -> redis.Redis:
+    global _redis
+    if _redis is None:
+        _redis = redis.from_url(settings.redis_url, decode_responses=True)
+    return _redis
+
+
+def hash_api_key(raw_key: str) -> str:
+    """SHA-256 hex digest of a plaintext key (what we store and look up by)."""
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def generate_api_key() -> tuple[str, str]:
+    """Mint a new key. Returns ``(plaintext, sha256_hash)``.
+
+    The plaintext is returned to the caller exactly once; only the hash is
+    persisted.
+    """
+    raw_key = API_KEY_PREFIX + secrets.token_urlsafe(32)
+    return raw_key, hash_api_key(raw_key)
+
+
+def enforce_rate_limit(api_key: ApiKey) -> None:
+    """Per-key fixed-window (60s) limiter. Raises 429 when exceeded.
+
+    Fails open on Redis errors so a transient cache outage never blocks
+    legitimate traffic.
+    """
+    limit = api_key.rate_limit_per_minute
+    if limit <= 0:  # 0 / negative means "no limit"
+        return
+
+    redis_key = f"apikey:ratelimit:{api_key.id}"
+    try:
+        client = _get_redis()
+        count = client.incr(redis_key)
+        if count == 1:
+            client.expire(redis_key, 60)
+    except redis.RedisError as exc:
+        logger.warning("Rate-limit check skipped (Redis unavailable): %s", exc)
+        return
+
+    if count > limit:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limit exceeded. Please retry shortly.",
+        )
+
+
+async def require_api_key(
+    raw_key: str | None = Security(_API_KEY_HEADER),
+    db: AsyncSession = Depends(get_db),
+) -> ApiKey:
+    """Resolve and validate the ``X-API-Key`` header into an active ApiKey.
+
+    401 when missing/unknown/revoked; 429 when the key is over its limit.
+    """
+    if not raw_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API key. Send it in the X-API-Key header.",
+        )
+
+    api_key = await db.scalar(
+        select(ApiKey).where(
+            ApiKey.key_hash == hash_api_key(raw_key),
+            ApiKey.is_active.is_(True),
+        )
+    )
+    if api_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or revoked API key.",
+        )
+
+    enforce_rate_limit(api_key)
+
+    api_key.last_used_at = datetime.now(timezone.utc)
+    await db.flush()
+    return api_key

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -35,6 +35,7 @@ from app.required_documents.models import RequiredDocumentTemplate, CaseRequired
 from app.in_app_notifications.models import InAppNotification  # noqa: F401
 from app.audit.models import AuditLog  # noqa: F401
 from app.proposals.models import Proposal  # noqa: F401
+from app.public_api.models import ApiKey  # noqa: F401 — register models for metadata
 from app.services.ukipo.models import UKIPOSubmission  # noqa: F401 — register models for metadata
 from app.braid.models import (  # noqa: F401 — register models for metadata
     BraidBudgetState,

--- a/services/api/tests/test_etorniegpt.py
+++ b/services/api/tests/test_etorniegpt.py
@@ -5,12 +5,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 from httpx import AsyncClient
 
+from app.config import settings
 from app.etorniegpt.countries import (
     detect_country_from_question,
     find_country,
     format_country_context,
 )
-from app.etorniegpt.service import _build_messages, SYSTEM_PROMPT
+from app.etorniegpt.service import (
+    _build_messages,
+    _question_mentions_unknown_country,
+    SYSTEM_PROMPT,
+)
 from app.users.models import User
 from tests.conftest import auth_headers
 
@@ -210,7 +215,7 @@ async def test_etorniegpt_endpoint_with_country(
     data = resp.json()
     assert "Germany" in data["answer"]
     assert data["country_detected"] is not None
-    assert data["model"] == "openai/gpt-oss-20b"
+    assert data["model"] == settings.together_etorniegpt_model
 
 
 @pytest.mark.asyncio
@@ -310,3 +315,38 @@ async def test_etorniegpt_unknown_country_no_llm_call(
     data = resp.json()
     assert "database" in data["answer"].lower()
     assert data["country_detected"] is None
+
+
+@pytest.mark.parametrize(
+    "question,expected",
+    [
+        # A real country named after a locative preposition -> treat as a
+        # jurisdiction we have no verified data for (canned response path).
+        ("How is trademark registration done in Turkey?", True),
+        ("What trademark rules apply in Brazil?", True),
+        # General / specific IP questions must NOT be misread as a country.
+        # These regressed before: the "in"/"of" inside ordinary words wrongly
+        # triggered the canned "no data" answer.
+        (
+            "Explain the difference between a registered trademark and an "
+            "unregistered trademark?",
+            False,
+        ),
+        ("What documents are required to file a patent application?", False),
+        (
+            "Which Nice classification class covers downloadable mobile software?",
+            False,
+        ),
+        ("Can I trademark a single color for my brand?", False),
+        (
+            "What is the Madrid Protocol for international trademark registration?",
+            False,
+        ),
+        ("How long does copyright protection last for a literary work?", False),
+        ("Define a patent.", False),
+    ],
+)
+def test_question_mentions_unknown_country(question, expected):
+    """The country heuristic matches whole place names, not "in"/"of"
+    substrings inside ordinary words."""
+    assert _question_mentions_unknown_country(question) is expected

--- a/services/api/tests/test_public_api.py
+++ b/services/api/tests/test_public_api.py
@@ -1,0 +1,147 @@
+"""Tests for the public partner Q&A API (app/public_api).
+
+Auth, admin key lifecycle, and rate limiting are exercised without the LLM.
+The one test that actually answers a question hits the real Together AI
+backend and is skipped unless TOGETHER_API_KEY is configured (no mocks).
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+
+from app.config import settings
+from app.public_api.models import ApiKey
+from app.public_api.security import enforce_rate_limit, hash_api_key
+from app.users.models import User
+from tests.conftest import auth_headers
+
+pytestmark = pytest.mark.integration
+
+
+async def _mint_key(client: AsyncClient, admin: User, **body) -> dict:
+    payload = {"label": "partner-platform", **body}
+    res = await client.post(
+        "/admin/api-keys", json=payload, headers=auth_headers(admin)
+    )
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+async def test_chat_without_api_key_is_401(client: AsyncClient):
+    res = await client.post("/api/v1/chat", json={"question": "merhaba"})
+    assert res.status_code == 401
+
+
+async def test_chat_with_unknown_api_key_is_401(client: AsyncClient):
+    res = await client.post(
+        "/api/v1/chat",
+        json={"question": "merhaba"},
+        headers={"X-API-Key": "etk_does_not_exist"},
+    )
+    assert res.status_code == 401
+
+
+async def test_non_admin_cannot_mint_key(
+    client: AsyncClient, client_user: User
+):
+    res = await client.post(
+        "/admin/api-keys",
+        json={"label": "x"},
+        headers=auth_headers(client_user),
+    )
+    assert res.status_code == 403
+
+
+async def test_admin_mint_list_revoke_lifecycle(
+    client: AsyncClient, admin_user: User, db_session
+):
+    # Mint
+    created = await _mint_key(client, admin_user)
+    raw_key = created["api_key"]
+    assert raw_key.startswith("etk_")
+    assert created["rate_limit_per_minute"] == 60
+
+    # Only the hash is stored, never the plaintext.
+    stored = await db_session.get(ApiKey, uuid.UUID(created["id"]))
+    assert stored is not None
+    assert stored.key_hash == hash_api_key(raw_key)
+    assert raw_key not in (stored.key_hash,)
+
+    # List shows it (no plaintext / no hash in the schema)
+    listed = await client.get("/admin/api-keys", headers=auth_headers(admin_user))
+    assert listed.status_code == 200
+    ids = [k["id"] for k in listed.json()]
+    assert created["id"] in ids
+    assert all("api_key" not in k and "key_hash" not in k for k in listed.json())
+
+    # Revoke
+    revoked = await client.delete(
+        f"/admin/api-keys/{created['id']}", headers=auth_headers(admin_user)
+    )
+    assert revoked.status_code == 204
+
+    # The revoked key no longer authenticates (rejected before any LLM call).
+    res = await client.post(
+        "/api/v1/chat",
+        json={"question": "merhaba"},
+        headers={"X-API-Key": raw_key},
+    )
+    assert res.status_code == 401
+
+
+async def test_revoke_unknown_key_is_404(
+    client: AsyncClient, admin_user: User
+):
+    res = await client.delete(
+        f"/admin/api-keys/{uuid.uuid4()}", headers=auth_headers(admin_user)
+    )
+    assert res.status_code == 404
+
+
+def test_rate_limit_enforced_against_real_redis():
+    # A real (unpersisted) key with a tiny limit; real Redis counter.
+    key = ApiKey(
+        id=uuid.uuid4(),
+        key_hash="unit-test",
+        label="rl",
+        is_active=True,
+        rate_limit_per_minute=2,
+    )
+    enforce_rate_limit(key)  # 1
+    enforce_rate_limit(key)  # 2
+    with pytest.raises(HTTPException) as exc:
+        enforce_rate_limit(key)  # 3 -> over limit
+    assert exc.value.status_code == 429
+
+
+def test_rate_limit_zero_means_unlimited():
+    key = ApiKey(
+        id=uuid.uuid4(),
+        key_hash="unit-test-0",
+        label="rl0",
+        is_active=True,
+        rate_limit_per_minute=0,
+    )
+    for _ in range(50):
+        enforce_rate_limit(key)  # never raises
+
+
+@pytest.mark.skipif(
+    not settings.together_api_key,
+    reason="TOGETHER_API_KEY not configured — skips the real LLM call",
+)
+async def test_chat_returns_answer_with_valid_key(
+    client: AsyncClient, admin_user: User
+):
+    created = await _mint_key(client, admin_user)
+    res = await client.post(
+        "/api/v1/chat",
+        json={"question": "What is a trademark?", "language": "en"},
+        headers={"X-API-Key": created["api_key"]},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert isinstance(body["answer"], str) and body["answer"]
+    assert "model" in body


### PR DESCRIPTION
## What

A partner platform (same Etornie product family) will use our EtornieGPT as the brain for their chat. This adds an **answer-only public Q&A API** for that server-to-server integration, and fixes three issues that live testing surfaced in the shared EtornieGPT service — which also powers our own in-app chat.

## Public Q&A API — `app/public_api/`

- **`POST /api/v1/chat`** — answer-only. Forwards the question to EtornieGPT and returns the answer. No agent actions (no filings, attestations), and no x402 payment. Authenticated by an API key, not a user JWT.
- **API keys** — stored as SHA-256 hashes (plaintext shown once at creation). Admins mint / list / revoke under `/admin/api-keys`. Per-key Redis rate limiting that fails open if Redis is unavailable.
- **`api_keys` migration** chained on the current head.

Usage:
```
POST /api/v1/chat
X-API-Key: etk_...
{ "question": "...", "language": "en" }
-> { "answer": "...", "country_detected": null, "model": "..." }
```

## EtornieGPT service fixes (shared with the in-app chat)

1. **Country heuristic** — the old check substring-matched the "in"/"of" inside ordinary words ("international", "software", "single", "define"), so most questions wrongly got the canned "no information about this country" answer. Replaced with a word-boundary match on a real place name after a locative preposition. "in Turkey" still returns the canned answer; "international"/"software"/"single" now reach the model.
2. **Model** — moved off `openai/gpt-oss-20b` (intermittent empty completions and harmony-scratchpad leaks) to `Llama-3.3-70B-Turbo`, matching the agent. Now config-driven (`together_etorniegpt_model`); pricing already covers the model.
3. **Graceful errors** — upstream model failures (credit/rate limit, timeout, 5xx, empty completion) now return a clean `502` with a friendly message instead of a raw `500`.
4. **Prompt** — EtornieGPT now positions itself as Etornie's assistant: it guides users through Etornie's own flow (open a case → Nice classification → the agent files to the IP office → pay by card via Stripe or crypto via Solana → on-chain proof) instead of sending them to national offices, and does not fabricate fees (points to the Etornie case/checkout).

## Verification

- Full suite: **612 passed, 7 skipped**.
- New tests: public_api (missing/invalid/revoked key, admin mint/list/revoke, real-Redis rate limit) and the country heuristic (9 cases).
- Live end-to-end against a real Together backend: specific/hard IP questions answered correctly (~3–6s); verified-DB country data used (Germany, Japan); off-topic and prompt-injection refused; fictional country not fabricated; the 502 path confirmed by forcing an upstream failure; the new prompt recommends Etornie (not national offices) and does not invent fees.

Note: the `braid` subsystem keeps its own gpt-oss usage and defenses and is intentionally untouched.
