### PR TITLE
feat(signer): add Vault-backed KMS signer, gate local backend by env, audit logging (#21)

### DIFF
--- a/services/api/app/security/signer_backends.py
+++ b/services/api/app/security/signer_backends.py
@@ -1,0 +1,126 @@
+"""Vault-backed operator signer (Transit secrets engine).
+
+Keeps the raw ed25519 private key inside Vault; every signature is
+requested over Vault's HTTP API instead of being computed from key
+bytes held in this process's memory. Configuration (all read at call
+time, so tests can monkeypatch env vars freely):
+
+  VAULT_ADDR              e.g. https://vault.internal:8200
+  VAULT_TOKEN             Vault auth token with sign+read on the
+                          configured Transit key
+  VAULT_TRANSIT_KEY_NAME  Transit key name, default "etornie-operator"
+
+The Vault Transit key must be created with ``type=ed25519``:
+
+    vault secrets enable transit   # once per Vault
+    vault write -f transit/keys/etornie-operator type=ed25519
+"""
+from __future__ import annotations
+
+import base64
+import os
+from dataclasses import dataclass
+
+import httpx
+from solders.pubkey import Pubkey
+
+from app.security.operator_key import log_operator_access
+
+
+class VaultSignerError(RuntimeError):
+    """Raised when Vault Transit config or a Vault API call is invalid."""
+
+
+def _vault_config() -> tuple[str, str, str]:
+    addr = os.environ.get("VAULT_ADDR", "").strip().rstrip("/")
+    token = os.environ.get("VAULT_TOKEN", "").strip()
+    key_name = os.environ.get(
+        "VAULT_TRANSIT_KEY_NAME", "etornie-operator"
+    ).strip()
+    if not addr or not token:
+        raise VaultSignerError(
+            "SIGNER_BACKEND=vault requires VAULT_ADDR and VAULT_TOKEN "
+            "to be set"
+        )
+    return addr, token, key_name
+
+
+@dataclass(frozen=True)
+class VaultOperatorSigner:
+    """Drop-in replacement for solders.Keypair, backed by Vault Transit.
+
+    Only implements the two methods client.py actually calls on the
+    operator object: ``pubkey()`` and ``sign_message(bytes)``.
+    """
+
+    _addr: str
+    _token: str
+    _key_name: str
+    _pubkey: Pubkey
+
+    def pubkey(self) -> Pubkey:
+        return self._pubkey
+
+    def sign_message(self, message: bytes) -> bytes:
+        url = f"{self._addr}/v1/transit/sign/{self._key_name}"
+        body = {"input": base64.b64encode(message).decode("ascii")}
+        resp = httpx.post(
+            url,
+            json=body,
+            headers={"X-Vault-Token": self._token},
+            timeout=10.0,
+        )
+        if resp.status_code != 200:
+            raise VaultSignerError(
+                f"vault sign failed ({resp.status_code}): "
+                f"{resp.text[:300]}"
+            )
+        signature_field = resp.json()["data"]["signature"]
+        # Format: "vault:v1:<base64 sig>"
+        b64_sig = signature_field.split(":", 2)[-1]
+        return base64.b64decode(b64_sig)
+
+
+def _fetch_vault_pubkey(addr: str, token: str, key_name: str) -> Pubkey:
+    url = f"{addr}/v1/transit/keys/{key_name}"
+    resp = httpx.get(url, headers={"X-Vault-Token": token}, timeout=10.0)
+    if resp.status_code != 200:
+        raise VaultSignerError(
+            f"vault key lookup failed ({resp.status_code}): "
+            f"{resp.text[:300]}"
+        )
+    data = resp.json()["data"]
+    latest_version = str(data["latest_version"])
+    raw_b64 = data["keys"][latest_version]["public_key"]
+    raw = base64.b64decode(raw_b64)
+    # Vault returns the raw 32-byte ed25519 public key for this key
+    # type; if a future Vault version wraps it (DER/SPKI), the actual
+    # key material is always the last 32 bytes.
+    raw = raw[-32:]
+    return Pubkey.from_bytes(raw)
+
+
+def load_vault_operator(
+    *, caller_context: str = "unknown", op_kind: str = "sign"
+) -> VaultOperatorSigner:
+    """Build a VaultOperatorSigner, auditing the access like the file backend."""
+    try:
+        addr, token, key_name = _vault_config()
+        pubkey = _fetch_vault_pubkey(addr, token, key_name)
+    except VaultSignerError as exc:
+        log_operator_access(
+            caller_context=caller_context,
+            op_kind=op_kind,
+            success=False,
+            note=str(exc)[:480],
+        )
+        raise
+    log_operator_access(
+        caller_context=caller_context,
+        op_kind=op_kind,
+        success=True,
+        note=f"vault:{key_name}",
+    )
+    return VaultOperatorSigner(
+        _addr=addr, _token=token, _key_name=key_name, _pubkey=pubkey
+    )

--- a/services/api/app/security/signer_backends.py
+++ b/services/api/app/security/signer_backends.py
@@ -20,11 +20,27 @@ from __future__ import annotations
 import base64
 import os
 from dataclasses import dataclass
+from typing import Protocol
 
 import httpx
 from solders.pubkey import Pubkey
 
 from app.security.operator_key import log_operator_access
+
+
+class OperatorSigner(Protocol):
+    """Structural type shared by every operator signer backend.
+
+    Both ``solders.Keypair`` (the local-file backend) and
+    ``VaultOperatorSigner`` below satisfy this shape without needing to
+    inherit from anything — Python's structural typing (Protocol) just
+    checks that ``.pubkey()`` and ``.sign_message(bytes)`` exist with
+    matching signatures.
+    """
+
+    def pubkey(self) -> Pubkey: ...
+
+    def sign_message(self, message: bytes) -> bytes: ...
 
 
 class VaultSignerError(RuntimeError):

--- a/services/api/app/solana/client.py
+++ b/services/api/app/solana/client.py
@@ -37,6 +37,7 @@ from solders.system_program import ID as SYSTEM_PROGRAM_ID
 from solders.transaction import VersionedTransaction
 
 from app.config import settings
+from app.security.signer_backends import OperatorSigner
 
 logger = logging.getLogger(__name__)
 
@@ -378,7 +379,10 @@ def _load_local_file_operator(
     return keypair
 
 
-def _load_operator(caller_context: str = "unknown", op_kind: str = "sign"):
+def _load_operator(
+    caller_context: str = "unknown", op_kind: str = "sign"
+) -> OperatorSigner:
+  
     """Load the operator signer.
 
     Backend is chosen via the ``SIGNER_BACKEND`` env var:

--- a/services/api/app/solana/client.py
+++ b/services/api/app/solana/client.py
@@ -21,6 +21,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import os
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -313,8 +314,10 @@ def _resolve_operator_path() -> Path:
     return Path.cwd() / configured
 
 
-def _load_operator(caller_context: str = "unknown", op_kind: str = "sign") -> Keypair:
-    """Load the operator keypair.
+def _load_local_file_operator(
+    caller_context: str = "unknown", op_kind: str = "sign"
+) -> Keypair:
+    """Load the operator keypair from the local encrypted key file.
 
     Adds two security improvements over reading the file straight:
     1. The on-disk content is passed through
@@ -324,6 +327,8 @@ def _load_operator(caller_context: str = "unknown", op_kind: str = "sign") -> Ke
     2. Every load attempt — success or failure — writes one row to
        ``operator_key_access_log`` so an operator can audit who/what
        reached for the key after the fact.
+
+    Only usable when ETORNIE_ENV != "production" — see _load_operator.
     """
     from app.security.operator_key import (
         OperatorKeyError,
@@ -371,6 +376,49 @@ def _load_operator(caller_context: str = "unknown", op_kind: str = "sign") -> Ke
         success=True,
     )
     return keypair
+
+
+def _load_operator(caller_context: str = "unknown", op_kind: str = "sign"):
+    """Load the operator signer.
+
+    Backend is chosen via the ``SIGNER_BACKEND`` env var:
+
+    - ``"file"`` (default): read the local, optionally Fernet-encrypted
+      key file. Disabled outside development — see the ETORNIE_ENV
+      check below — because a filesystem-resident private key is not
+      acceptable for a production/mainnet deployment.
+    - ``"vault"``: sign remotely via HashiCorp Vault's Transit secrets
+      engine (see app.security.signer_backends). The raw private key
+      material never enters this process.
+
+    Both paths return an object exposing ``.pubkey()`` and
+    ``.sign_message(bytes)`` — the only two methods the rest of this
+    module calls on the operator — and both write an audit row via
+    ``log_operator_access`` before returning.
+    """
+    backend = os.environ.get("SIGNER_BACKEND", "file").strip().lower()
+
+    if backend == "vault":
+        from app.security.signer_backends import load_vault_operator
+
+        return load_vault_operator(
+            caller_context=caller_context, op_kind=op_kind
+        )
+
+    if backend != "file":
+        raise SolanaClientError(f"unknown SIGNER_BACKEND: {backend!r}")
+
+    env = os.environ.get("ETORNIE_ENV", "development").strip().lower()
+    if env == "production":
+        raise SolanaClientError(
+            "SIGNER_BACKEND=file is disabled when ETORNIE_ENV=production. "
+            "Set SIGNER_BACKEND=vault (or another managed backend) "
+            "before deploying to mainnet."
+        )
+
+    return _load_local_file_operator(
+        caller_context=caller_context, op_kind=op_kind
+    )
 
 
 def derive_attestation_pda(case_id: bytes) -> tuple[Pubkey, int]:

--- a/services/api/app/solana/client.py
+++ b/services/api/app/solana/client.py
@@ -528,7 +528,10 @@ async def finalize_sponsored_attestation_tx(
     replace slot 0 with our operator signature, and splice the sig
     array back in front of the untouched message bytes.
     """
-    operator = _load_operator()
+    operator = _load_operator(
+        caller_context="solana.finalize_sponsored_attestation_tx",
+        op_kind="sign",
+    )
 
     num_sigs, sigs_start = _read_compact_u16(signed_tx_bytes, 0)
     if num_sigs == 0:
@@ -914,7 +917,10 @@ async def finalize_mint_claim_tx(signed_tx_bytes: bytes) -> str:
     to avoid any re-serialization that could break the client's
     signature. Returns the confirmed signature.
     """
-    operator = _load_operator()
+    operator = _load_operator(
+        caller_context="solana.finalize_mint_claim_tx",
+        op_kind="sign",
+    )
 
     num_sigs, sigs_start = _read_compact_u16(signed_tx_bytes, 0)
     if num_sigs == 0:
@@ -1087,7 +1093,10 @@ async def finalize_sponsored_verify_tx(signed_tx_bytes: bytes) -> str:
 
     Returns the confirmed tx signature.
     """
-    operator = _load_operator()
+    operator = _load_operator(
+        caller_context="solana.finalize_sponsored_verify_tx",
+        op_kind="sign",
+    )
 
     num_sigs, sigs_start = _read_compact_u16(signed_tx_bytes, 0)
     if num_sigs == 0:
@@ -1471,7 +1480,10 @@ async def submit_compliance_proof_tx(
     from solders.message import MessageV0
 
     program_id = Pubkey.from_string(settings.solana_zk_verifier_program_id)
-    operator = _load_operator()
+    operator = _load_operator(
+        caller_context="solana.submit_compliance_proof_tx",
+        op_kind="sign",
+    )
     pda, _bump = derive_compliance_record_pda(user, query_hash)
 
     ix_data = (


### PR DESCRIPTION
## Why
`_load_operator()` in services/api/app/solana/client.py always read the
operator keypair from the local filesystem (optionally Fernet-encrypted).
This is not secure enough for mainnet.

## What changed
- `app/security/signer_backends.py`: added `VaultOperatorSigner`, which
  signs remotely via HashiCorp Vault's Transit secrets engine. The raw
  private key never enters this process's memory.
- Defined an `OperatorSigner` Protocol — both `solders.Keypair` and
  `VaultOperatorSigner` satisfy this shape (`.pubkey()`, `.sign_message()`),
  so no existing call sites in `client.py` needed to change.
- `_load_operator()` was refactored into a backend switch driven by the
  `SIGNER_BACKEND` env var (`file` | `vault`).
- When `SIGNER_BACKEND=file` and `ETORNIE_ENV=production`, the function now
  raises — the local file backend can no longer be used on mainnet.
- The 4 functions that actually sign a transaction
  (`finalize_sponsored_attestation_tx`, `finalize_mint_claim_tx`,
  `finalize_sponsored_verify_tx`, `submit_compliance_proof_tx`) now pass a
  meaningful `caller_context` to the audit log (previously all logged as
  "unknown").

## Acceptance criteria
- [x] Solana signer abstraction supports at least one of KMS/Vault/Fireblocks
      (Vault Transit implementation added)
- [x] Local file backend only works when ETORNIE_ENV != production
- [x] Audit log entry on every signature (already existed; now carries a
      meaningful caller_context)

## Proof
<img width="1047" height="636" alt="image" src="https://github.com/user-attachments/assets/8f78621c-5558-4905-8df1-098232dd0a83" />

## Notes
- The Vault Transit key must be created with `type=ed25519` (see the
  docstring in signer_backends.py).
- `httpx` was already a runtime dependency in pyproject.toml, no new
  dependency was needed.

Closes #21