### PR TITLE
chore(security): add external pentest scope document (#52)

### DIFF
--- a/docs/security/pentest-scope.md
+++ b/docs/security/pentest-scope.md
@@ -1,0 +1,63 @@
+# External Penetration Test — Scope Document
+
+## Purpose
+Define the scope for an external penetration test to be conducted before
+the platform goes to mainnet, so the engagement can be scoped and quoted
+accurately by the vendor.
+
+## In scope
+- **OWASP Top 10** — injection, broken authentication, sensitive data
+  exposure, broken access control, security misconfiguration, and the
+  remaining categories, applied to the public API surface
+  (`services/api/`).
+- **Authentication / authorization flow** — login, session handling,
+  token issuance and validation, TOTP 2FA, role-based access control
+  (admin vs. client).
+- **Wallet flow** — wallet connect, signature requests, sponsored
+  transaction construction/signing (see the operator signer work in
+  #21), and the treasury fee-payment checks in
+  `services/api/app/solana/client.py`.
+- **ZK-specific surface** — proof submission endpoints
+  (`verify_proof`, `verify_file_ownership_proof`,
+  `verify_compliance_proof`), replay protection, and PDA derivation
+  logic in `programs/`.
+
+## Out of scope
+- Third-party infrastructure providers (RPC providers, Vault/KMS
+  hosting, cloud provider security) — covered by their own compliance
+  attestations, not this engagement.
+- Denial-of-service / load testing.
+- Physical security.
+
+*(To be confirmed with the vendor and product owner before kickoff.)*
+
+## Test approach
+- **Type:** Gray-box (testers get read access to this repository and
+  API docs, but no production credentials).
+- **Environment:** Staging / devnet only — no testing against mainnet
+  or production data.
+
+## Timeline
+- Estimated engagement length: to be confirmed with the vendor
+  (issue #52 is labeled `effort/L`, i.e. 3–7 days of internal
+  coordination effort).
+- Target: complete before the `v1.0 Production Ready` milestone.
+
+## Deliverables
+- A findings report categorizing issues by severity (critical / high /
+  medium / low).
+- Remediation recommendations for each finding.
+- A re-test of critical/high findings after fixes are deployed.
+
+## Stakeholders
+- **Product decision owner:** TBD — this scope requires sign-off
+  before a vendor is engaged (see the `needs-product-decision` label
+  on #52).
+- **Technical point of contact:** TBD.
+
+## Open questions
+- Which vendor(s) will be approached for quotes?
+- Does the ZK circuit code itself (`circuits/`) need a specialized
+  cryptography review in addition to the application-level pentest?
+
+Closes #52

--- a/docs/security/pentest-scope.md
+++ b/docs/security/pentest-scope.md
@@ -1,5 +1,13 @@
 # External Penetration Test — Scope Document
 
+> **Status:** DRAFT — awaiting product sign-off (see the
+> `needs-product-decision` label on #52).
+> **Last updated:** 2026-09-07 · **Owner:** TBD
+>
+> This document defines the scope only. The penetration test itself is
+> still outstanding; #52 stays open until the engagement is completed
+> and the findings are triaged.
+
 ## Purpose
 Define the scope for an external penetration test to be conducted before
 the platform goes to mainnet, so the engagement can be scoped and quoted
@@ -59,5 +67,3 @@ accurately by the vendor.
 - Which vendor(s) will be approached for quotes?
 - Does the ZK circuit code itself (`circuits/`) need a specialized
   cryptography review in addition to the application-level pentest?
-
-Closes #52


### PR DESCRIPTION
## Why
Issue #52 requires an external penetration test before mainnet, but the
scope (which systems, which flows) needed to be defined first so the
engagement can be accurately quoted and approved.

## What changed
Added `docs/security/pentest-scope.md`, covering:
- In-scope areas: OWASP Top 10, auth/authorization flow, wallet flow,
  ZK-specific surface
- Out-of-scope items
- Test approach (gray-box, staging/devnet only)
- Timeline, deliverables, and open stakeholder questions

## Note
This issue is labeled `needs-product-decision` — the scope in this
document should be reviewed and confirmed by the product owner before
a vendor is engaged.

## Review follow-up
- Dropped the stray `Closes #52` line from the document body (it was a
  PR-description artifact that would have lived in the repo forever).
- Added a `Status: DRAFT` banner so the document does not read as
  approved before product sign-off.
- Changed the issue link from `Closes` to `Refs`: this PR defines the
  scope, it does not perform the penetration test. #52 must stay open
  until the engagement is completed and the findings are triaged.

Refs #52